### PR TITLE
Fixes-SNAP-333 Rename metadata column name

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/ResultSetNode.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/ResultSetNode.java
@@ -53,6 +53,7 @@ package	com.pivotal.gemfirexd.internal.impl.sql.compile;
 
 
 
+import com.gemstone.gemfire.internal.lang.StringUtils;
 import com.pivotal.gemfirexd.internal.catalog.types.DefaultInfoImpl;
 import com.pivotal.gemfirexd.internal.engine.sql.compile.DistributionDefinitionNode;
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
@@ -1090,8 +1091,13 @@ public abstract class ResultSetNode extends QueryTreeNode
 		for (int i=0; i<resultColumns.size(); i++)
 		{
 			ResultColumn rc = (ResultColumn) resultColumns.elementAt(i);
-			if (rc.isNameGenerated())
-				rc.setName(Integer.toString(i+1));
+			if (rc.isNameGenerated()) {
+				if (!StringUtils.isBlank(System.getenv("SNAPPY_HOME"))) {
+					rc.setName("_c" + Integer.toString(i));
+				} else {
+					rc.setName(Integer.toString(i + 1));
+				}
+			}
 		}
 	}
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/ResultSetNode.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/ResultSetNode.java
@@ -55,6 +55,7 @@ package	com.pivotal.gemfirexd.internal.impl.sql.compile;
 
 import com.gemstone.gemfire.internal.lang.StringUtils;
 import com.pivotal.gemfirexd.internal.catalog.types.DefaultInfoImpl;
+import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.sql.compile.DistributionDefinitionNode;
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
 import com.pivotal.gemfirexd.internal.iapi.reference.ClassName;
@@ -1092,7 +1093,7 @@ public abstract class ResultSetNode extends QueryTreeNode
 		{
 			ResultColumn rc = (ResultColumn) resultColumns.elementAt(i);
 			if (rc.isNameGenerated()) {
-				if (!StringUtils.isBlank(System.getenv("SNAPPY_HOME"))) {
+				if (Misc.getMemStore().isSnappyStore()) {
 					rc.setName("_c" + Integer.toString(i));
 				} else {
 					rc.setName(Integer.toString(i + 1));


### PR DESCRIPTION
ResultsetMetdata Column Name should be formatted as _c{index}
in snappy to match spark column name formatting
