### PR TITLE
SNAP-321: read conf/log4j.properties explicitly

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/InternalDistributedSystem.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/InternalDistributedSystem.java
@@ -832,7 +832,7 @@ public final class InternalDistributedSystem
   {
     LogWriterImpl logger = null;
     File logFile = config.getLogFile();
-    String logFileName = null;
+    String logFilePath = null;
     PrintStream out = null;
     String firstMsg = null;
     boolean firstMsgWarning = false;
@@ -862,7 +862,7 @@ public final class InternalDistributedSystem
         }
         }
       }
-      logFileName = logFile.getName();
+      logFilePath = logFile.getPath();
       if (!useSLF4JBridge) {
         FileOutputStream fos = null;
         try {
@@ -898,10 +898,10 @@ public final class InternalDistributedSystem
 
     if (useSLF4JBridge) {
       if (isSecurityLog) {
-        logger = new GFToSlf4jBridge(config.getName(), logFileName,
+        logger = new GFToSlf4jBridge(config.getName(), logFilePath,
             config.getSecurityLogLevel());
       } else {
-        logger = new GFToSlf4jBridge(config.getName(), logFileName,
+        logger = new GFToSlf4jBridge(config.getName(), logFilePath,
             config.getLogLevel());
       }
       if (logger.infoEnabled()

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/ClientSharedUtils.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/ClientSharedUtils.java
@@ -17,6 +17,8 @@
 
 package com.gemstone.gemfire.internal.shared;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
@@ -1094,7 +1096,7 @@ public abstract class ClientSharedUtils {
     if (logFile != null) {
       props.setProperty("log4j.appender.file.file", logFile);
     }
-    // lastly override with any user provided properties file
+    // override with any user provided properties file
     in = ClientSharedUtils.class.getResourceAsStream("/log4j.properties");
     if (in != null) {
       Properties setProps = new Properties();
@@ -1104,6 +1106,21 @@ public abstract class ClientSharedUtils {
         in.close();
       }
       props.putAll(setProps);
+    }
+    // lastly override with user provided properties file in "conf/"
+    String snappyDir = NativeCalls.getInstance().getEnvironment("SNAPPY_HOME");
+    if (snappyDir != null) {
+      File confFile = new File(snappyDir + "/conf", "log4j.properties");
+      if (confFile.canRead()) {
+        Properties setProps = new Properties();
+        in = new FileInputStream(confFile);
+        try {
+          setProps.load(in);
+        } finally {
+          in.close();
+        }
+        props.putAll(setProps);
+      }
     }
     LogManager.resetConfiguration();
     PropertyConfigurator.configure(props);


### PR DESCRIPTION
- since product does not use default log4j configuration load (to override it with "log-file", "log-level" properties),
  so need to explicitly load conf/log4j.properties
- also fixed the log-file passed to initLog4j to use path and not just the name
