### PR TITLE
Snap 584

### DIFF
--- a/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/DRDAConnThread.java
+++ b/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/DRDAConnThread.java
@@ -4183,7 +4183,7 @@ class DRDAConnThread extends Thread {
              if (!Misc.getMemStore().isSnappyStore()) {
                database.queryHDFS = true;
              }
-             else if (!Misc.getMemStore().isRowStoreOnly()) {
+             else {
                database.routeQuery = true;
              }
           }

--- a/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/DRDAConnThread.java
+++ b/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/DRDAConnThread.java
@@ -4183,7 +4183,7 @@ class DRDAConnThread extends Thread {
              if (!Misc.getMemStore().isSnappyStore()) {
                database.queryHDFS = true;
              }
-             else {
+             else if (!Misc.getMemStore().isRowStoreOnly()) {
                database.routeQuery = true;
              }
           }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
@@ -480,7 +480,8 @@ public interface GfxdConstants {
           Attribute.SKIP_CONSTRAINT_CHECKS,
           Attribute.ROUTE_QUERY,
           Attribute.AUTHZ_FULL_ACCESS_USERS,
-          Attribute.AUTHZ_READ_ONLY_ACCESS_USERS
+          Attribute.AUTHZ_READ_ONLY_ACCESS_USERS,
+          Attribute.SNAPPY_ROW_STORE_ONLY
         }));
 
   // --------------------- Flags for SanityManager debug trace below

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -321,6 +321,8 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
   
   private String dbLocaleStr;
 
+  private boolean isRowStoreOnly;
+
   private volatile LocalRegion identityRegion;
 
   // Embedded GFXD loner instance which will be 
@@ -978,7 +980,10 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
               "Exception occurred while starting GemFireXD JXM Agent", ade);
         }
       }
-      
+
+      this.isRowStoreOnly = Boolean.parseBoolean(
+          getBootProperty(Attribute.SNAPPY_ROW_STORE_ONLY));
+
       // persistingDD needs to be initialized here since we are dependent on it
       // in GfxdDistributionAdvisor
       String persistDD = getBootProperty(Attribute.GFXD_PERSIST_DD);
@@ -2282,6 +2287,10 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
 
   public boolean isSnappyStore() {
     return this.snappyStore;
+  }
+
+  public boolean isRowStoreOnly() {
+    return this.isRowStoreOnly;
   }
 
   public String getDatabaseName() {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -63,6 +63,7 @@ import com.gemstone.gemfire.internal.cache.wan.GatewaySenderEventCallbackArgumen
 import com.gemstone.gnu.trove.THashMap;
 import com.pivotal.gemfirexd.Attribute;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
+import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.access.GemFireTransaction;
 import com.pivotal.gemfirexd.internal.engine.access.MemConglomerate;
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
@@ -4956,8 +4957,10 @@ public final class GenericLanguageConnectionContext
 
 	@Override
 	public void setQueryRouting(boolean routeQuery) {
-		this.gfxdFlags = GemFireXDUtils.set(this.gfxdFlags, ROUTE_QUERY,
-				routeQuery);
+		if (!Misc.getMemStore().isRowStoreOnly()) {
+			this.gfxdFlags = GemFireXDUtils.set(this.gfxdFlags, ROUTE_QUERY,
+					routeQuery);
+		}
 	}
 
 	@Override

--- a/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/Attribute.java
+++ b/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/Attribute.java
@@ -246,6 +246,9 @@ public interface Attribute {
   /** property name for enabling persistence of data dictionary */
   String GFXD_PERSIST_DD = "persist-dd";
 
+  /** property to indicate that this server is booted in only row store mode **/
+  String SNAPPY_ROW_STORE_ONLY = "row-store";
+
   /**
    * Read timeout for the connection, in seconds. Only for thin client
    * connections.


### PR DESCRIPTION
Added a new boot property "row-store" to indicate that Snappy servers are started in row store only mode (that is lead node is not started). Query routing will not be enabled when row-store is set to true.

Snappy start up scripts will be started with "-row-store=true" . (opening a separate PR those since those are in different repo)

@sumwale @kneeraj please review.
