### PR TITLE
Converting synchronized block to RW lock.

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionManager.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionManager.java
@@ -3073,17 +3073,18 @@ public final class DistributionManager
     if (ch != null) {
       MembershipManager mgr = ch.getMembershipManager();
       if (mgr != null) {
-        synchronized (mgr.getViewLock()) {
-          this.membersLock.readLock().lock();
-          try {
-            // Don't let the members come and go while we are adding this
-            // listener.  This ensures that the listener (probably a
-            // ReplyProcessor) gets a consistent view of the members.
-            addAllMembershipListener(l);
-            return this.membersAndAdmin;
-          } finally {
-            this.membersLock.readLock().unlock();
-          }
+        ReentrantReadWriteLock viewLock = mgr.getViewLock();
+        viewLock.writeLock().lock();
+        this.membersLock.readLock().lock();
+        try {
+          // Don't let the members come and go while we are adding this
+          // listener.  This ensures that the listener (probably a
+          // ReplyProcessor) gets a consistent view of the members.
+          addAllMembershipListener(l);
+          return this.membersAndAdmin;
+        } finally {
+          this.membersLock.readLock().unlock();
+          viewLock.writeLock().unlock();
         }
       }
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/membership/MembershipManager.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/membership/MembershipManager.java
@@ -21,6 +21,7 @@ import java.net.DatagramSocket;
 import java.util.Set;
 import java.util.HashMap;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import com.gemstone.gemfire.SystemFailure;
 import com.gemstone.gemfire.distributed.DistributedMember;
@@ -58,7 +59,7 @@ public interface MembershipManager {
    * While this lock is held the view can't change.
    * @since 5.7
    */
-  public Object getViewLock();
+  public ReentrantReadWriteLock getViewLock();
 
   /**
    * Return a {@link InternalDistributedMember} representing the current system


### PR DESCRIPTION
@sumwale @kneeraj @suranjan please review the following snippet specifically. We can discuss about the race condition getting introduced with this change. IMO, this is negligible.

``` java
  protected void processMessage(DistributionMessage msg) {
    boolean isNew = false;
    InternalDistributedMember m = msg.getSender();
    boolean shunned = false;

    // First grab the lock: check the sender against our stabilized view.
    latestViewLock.readLock().lock();
    try {
      if (isShunnedNoSync(m)) {
        if (msg instanceof StartupMessage) {
          endShun(m);
        }
        else {
          // fix for bug 41538 - sick alert listener causes deadlock
          // due to view lock being held during messaging
          shunned = true;
        }
      } // isShunned

      if (!shunned) {
        isNew = !latestView.contains(m) && !surpriseMembers.containsKey(m);

        // If it's a new sender, wait our turn, generate the event
        if (isNew) {
>>>>>>>>> unlocking the readLock so that addSurpriseMember can acquire writeLock >>>>>>>>>>>>>
          latestViewLock.readLock().unlock(); // synchronized
          shunned = !addSurpriseMember(m, getStubForMember(m));
>>>>>>>>>>>>>>>>>>>>>>
        } // isNew
      }

      // Latch the view before we unlock
    } finally {
>>>>>>>>>> avoiding extra readLock.unlock if (isNew == true) >>>>>>>>>>>>
      if (!isNew) { // note: if(isNew) then we release read and acquire writeLock inside addSurpriseMember.
        latestViewLock.readLock().unlock(); // synchronized
      }
>>>>>>>>>>>>>>>>>>>>>>
    }

    if (shunned) { // bug #41538 - shun notification must be outside synchronization to avoid hanging
      warnShun(m);
      if (VERBOSE_VIEWS || logger.fineEnabled()) {
        logger.info(LocalizedStrings.DEBUG, "Membership: Ignoring message from shunned member <"
            + m +">:" + msg);
      }
      throw new MemberShunnedException(getStubForMember(m));
    }


```
