### PR TITLE
Changes to address SNAP-607

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -688,5 +688,7 @@ task checkAll {
   mustRunAfter buildAll
 }
 task precheckin {
-  dependsOn cleanAll, buildAll, checkAll
+  if (project.hasProperty('gfxd')) {
+    dependsOn cleanAll, buildAll, checkAll
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -563,7 +563,6 @@ def includeJar(def jarFile) {
 task product(dependsOn: [ subprojectBase + 'gemfirexd-client:jar',
     subprojectBase + 'gemfirexd-core:shadowJar',
     subprojectBase + 'gemfirexd-tools:jar',
-    subprojectBase + 'gemfirexd-tests:jar',
     subprojectBase + 'gemfirexd-shared:javadoc',
     subprojectBase + 'gemfirexd-core:javadoc' ]) << {
 

--- a/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/am/CrossConverters.java
+++ b/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/am/CrossConverters.java
@@ -716,14 +716,14 @@ public final class CrossConverters implements Converter {
             default:
             throw new SqlException(agent_.logWriter_, 
                 new ClientMessageId (SQLState.LANG_DATA_TYPE_SET_MISMATCH),
-                "String", Types.getTypeString(targetDriverType), (String)null);
+                "String", Types.getTypeString(targetDriverType), columnName);
             }
         } catch (java.lang.NumberFormatException e) {
             throw new SqlException(agent_.logWriter_, 
                     new ClientMessageId 
                     (SQLState.LANG_FORMAT_EXCEPTION), 
                     Types.getTypeString(targetDriverType),
-                    e);                    
+                    columnName, e);
         }
     }
 
@@ -767,7 +767,7 @@ public final class CrossConverters implements Converter {
         default:
             throw new SqlException(agent_.logWriter_, 
                 new ClientMessageId (SQLState.LANG_DATA_TYPE_SET_MISMATCH),
-                "byte[]", Types.getTypeString(targetType), (String)null);
+                "byte[]", Types.getTypeString(targetType), columnName);
         }
     }
 
@@ -847,7 +847,7 @@ public final class CrossConverters implements Converter {
         default:
             throw new SqlException(agent_.logWriter_, 
                 new ClientMessageId (SQLState.LANG_DATA_TYPE_SET_MISMATCH),
-                "java.io.InputStream", Types.getTypeString(targetType), (String)null);
+                "java.io.InputStream", Types.getTypeString(targetType), columnName);
         }
     }
 
@@ -919,7 +919,7 @@ public final class CrossConverters implements Converter {
         default:
             throw new SqlException(agent_.logWriter_, 
                 new ClientMessageId (SQLState.LANG_DATA_TYPE_SET_MISMATCH),
-                "java.io.InputStream", Types.getTypeString(targetType), (String)null);
+                "java.io.InputStream", Types.getTypeString(targetType), columnName);
         }
     }
 
@@ -1010,7 +1010,7 @@ public final class CrossConverters implements Converter {
         } else {
             throw new SqlException(agent_.logWriter_, 
                 new ClientMessageId (SQLState.LANG_DATA_TYPE_SET_MISMATCH),
-                source.getClass().getName(), Types.getTypeString(targetType), (String)null);
+                source.getClass().getName(), Types.getTypeString(targetType), columnName);
         }
     }
 
@@ -1119,7 +1119,7 @@ public final class CrossConverters implements Converter {
         } catch (java.lang.NumberFormatException e) {
             throw new SqlException(agent_.logWriter_, 
             		new ClientMessageId 
-            		(SQLState.LANG_FORMAT_EXCEPTION), "byte", e);
+            		(SQLState.LANG_FORMAT_EXCEPTION), "byte", null, e);
         }
     }
 
@@ -1180,7 +1180,7 @@ public final class CrossConverters implements Converter {
             throw new SqlException(agent_.logWriter_, 
             		new ClientMessageId 
             		(SQLState.LANG_FORMAT_EXCEPTION), 
-            		"short", e);
+            		"short", null, e);
         }
     }
 
@@ -1231,7 +1231,7 @@ public final class CrossConverters implements Converter {
         } catch (java.lang.NumberFormatException e) {
             throw new SqlException(agent_.logWriter_, 
             		new ClientMessageId (SQLState.LANG_FORMAT_EXCEPTION),
-            		"int", e);
+            		"int", null, e);
         }
     }
 
@@ -1273,7 +1273,7 @@ public final class CrossConverters implements Converter {
         } catch (java.lang.NumberFormatException e) {
             throw new SqlException(agent_.logWriter_, 
             		new ClientMessageId (SQLState.LANG_FORMAT_EXCEPTION),
-        			"long", e);
+        			"long", null, e);
         }
     }
 
@@ -1306,7 +1306,7 @@ public final class CrossConverters implements Converter {
         } catch (java.lang.NumberFormatException e) {
             throw new SqlException(agent_.logWriter_, 
             		new ClientMessageId (SQLState.LANG_FORMAT_EXCEPTION),
-                    "float", e);
+                    "float", null, e);
         }
     }
 
@@ -1330,7 +1330,7 @@ public final class CrossConverters implements Converter {
         } catch (java.lang.NumberFormatException e) {
             throw new SqlException(agent_.logWriter_, 
             		new ClientMessageId (SQLState.LANG_FORMAT_EXCEPTION),
-                    "double", e);
+                    "double", null, e);
         }
     }
 
@@ -1348,7 +1348,7 @@ public final class CrossConverters implements Converter {
         } catch (java.lang.NumberFormatException e) {
             throw new SqlException(agent_.logWriter_,
             		new ClientMessageId (SQLState.LANG_FORMAT_EXCEPTION),
-                    "java.math.BigDecimal", e);
+                    "java.math.BigDecimal", null, e);
         }
     }
 
@@ -1386,7 +1386,7 @@ public final class CrossConverters implements Converter {
             return date_valueOf(source);
         } catch (java.lang.IllegalArgumentException e) { // subsumes NumberFormatException
             throw new SqlException(agent_.logWriter_, 
-            		new ClientMessageId (SQLState.LANG_DATE_SYNTAX_EXCEPTION), e);
+            		new ClientMessageId (SQLState.LANG_DATE_SYNTAX_EXCEPTION), null, e);
         }
     }
 
@@ -1405,7 +1405,7 @@ public final class CrossConverters implements Converter {
             return time_valueOf(source);
         } catch (java.lang.IllegalArgumentException e) { // subsumes NumberFormatException
             throw new SqlException(agent_.logWriter_, 
-            		new ClientMessageId (SQLState.LANG_DATE_SYNTAX_EXCEPTION), e);
+            		new ClientMessageId (SQLState.LANG_DATE_SYNTAX_EXCEPTION), null, e);
         }
     }
 
@@ -1420,7 +1420,7 @@ public final class CrossConverters implements Converter {
             return timestamp_valueOf(source);
         } catch (java.lang.IllegalArgumentException e) {  // subsumes NumberFormatException
             throw new SqlException(agent_.logWriter_, 
-            		new ClientMessageId (SQLState.LANG_DATE_SYNTAX_EXCEPTION), e);
+            		new ClientMessageId (SQLState.LANG_DATE_SYNTAX_EXCEPTION), null, e);
         }
     }
 

--- a/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/am/PreparedStatement.java
+++ b/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/am/PreparedStatement.java
@@ -662,7 +662,7 @@ public class PreparedStatement extends Statement
                     //see http://issues.apache.org/jira/browse/DERBY-1610#action_12432568
                     PossibleTypes.throw22005Exception(agent_.logWriter_,
                                                       jdbcType,
-                                                      paramType );
+                                                      paramType, parameterIndex);
                 }
                 
                 setNullX(parameterIndex, jdbcType);
@@ -711,7 +711,7 @@ public class PreparedStatement extends Statement
                     
                     PossibleTypes.throw22005Exception(agent_.logWriter_,
                                                       java.sql.Types.BOOLEAN,
-                                                      paramType);
+                                                      paramType, parameterIndex);
                     
                 }
                 
@@ -747,7 +747,7 @@ public class PreparedStatement extends Statement
                     
                     PossibleTypes.throw22005Exception(agent_.logWriter_,
                                                       java.sql.Types.TINYINT,
-                                                      paramType);
+                                                      paramType, parameterIndex);
                     
                 }
                 
@@ -783,7 +783,7 @@ public class PreparedStatement extends Statement
                     
                     PossibleTypes.throw22005Exception(agent_.logWriter_,
                                                       java.sql.Types.SMALLINT,
-                                                      paramType);
+                                                      paramType, parameterIndex);
                                                   
 
                 }
@@ -825,7 +825,7 @@ public class PreparedStatement extends Statement
                     
                     PossibleTypes.throw22005Exception(agent_.logWriter_,
                                                       java.sql.Types.INTEGER,
-                                                      paramType);
+                                                      paramType, parameterIndex);
                 }
                 
                 setIntX(parameterIndex, x);
@@ -866,7 +866,7 @@ public class PreparedStatement extends Statement
                     
                     PossibleTypes.throw22005Exception(agent_.logWriter_,
                                                       java.sql.Types.INTEGER,
-                                                      paramType);
+                                                      paramType, parameterIndex);
                 }
                 setLongX(parameterIndex, x);
             }
@@ -906,7 +906,7 @@ public class PreparedStatement extends Statement
                     
                     PossibleTypes.throw22005Exception(agent_.logWriter_,
                                                       java.sql.Types.FLOAT,
-                                                      paramType);
+                                                      paramType, parameterIndex);
 
                 }
                 
@@ -935,7 +935,7 @@ public class PreparedStatement extends Statement
                     
                     PossibleTypes.throw22005Exception(agent_.logWriter_,
                                                       java.sql.Types.DOUBLE,
-                                                      paramType);
+                                                      paramType, parameterIndex);
                     
                 }
                 
@@ -964,7 +964,7 @@ public class PreparedStatement extends Statement
                     
                     PossibleTypes.throw22005Exception(agent_.logWriter_,
                                                       java.sql.Types.BIGINT,
-                                                      paramType);
+                                                      paramType, parameterIndex);
                     
                 }
 
@@ -998,7 +998,7 @@ public class PreparedStatement extends Statement
                     
                     PossibleTypes.throw22005Exception(agent_.logWriter_ ,
                                                       java.sql.Types.DATE,
-                                                      paramType);
+                                                      paramType, parameterIndex);
                     
                 }
                 
@@ -1066,7 +1066,7 @@ public class PreparedStatement extends Statement
                     
                     PossibleTypes.throw22005Exception( agent_.logWriter_,
                                                        java.sql.Types.TIME,
-                                                       paramType );
+                                                       paramType, parameterIndex);
                 }
                 
                 parameterMetaData_.clientParamtertype_[parameterIndex - 1] = java.sql.Types.TIME;
@@ -1133,7 +1133,7 @@ public class PreparedStatement extends Statement
                     
                     PossibleTypes.throw22005Exception(agent_.logWriter_,
                                                       java.sql.Types.TIMESTAMP,
-                                                      paramType);
+                                                      paramType, parameterIndex);
                     
                 }
                 
@@ -1206,7 +1206,7 @@ public class PreparedStatement extends Statement
                 if( ! PossibleTypes.POSSIBLE_TYPES_IN_SET_STRING.checkType( paramType ) ){
                     PossibleTypes.throw22005Exception(agent_.logWriter_ ,
                                                       java.sql.Types.VARCHAR,
-                                                      paramType);
+                                                      paramType, parameterIndex);
                 }
                 
                 setStringX(parameterIndex, x);
@@ -1243,7 +1243,7 @@ public class PreparedStatement extends Statement
                     
                     PossibleTypes.throw22005Exception(agent_.logWriter_,
                                                       java.sql.Types.VARBINARY,
-                                                      paramType );
+                                                      paramType, parameterIndex);
                 }
                 
                 setBytesX(parameterIndex, x);
@@ -1405,7 +1405,7 @@ public class PreparedStatement extends Statement
             
             PossibleTypes.throw22005Exception(agent_.logWriter_,
                                               java.sql.Types.LONGVARCHAR,
-                                              paramType);
+                                              paramType, parameterIndex);
             
             
         }
@@ -1418,7 +1418,7 @@ public class PreparedStatement extends Statement
                 checkType(paramType)) {
             PossibleTypes.throw22005Exception(agent_.logWriter_,
                                               java.sql.Types.VARBINARY,
-                                              paramType);
+                                              paramType, parameterIndex);
         }
     }
     
@@ -1429,7 +1429,7 @@ public class PreparedStatement extends Statement
                 checkType(paramType)) {
             PossibleTypes.throw22005Exception(agent_.logWriter_,
                                               java.sql.Types.LONGVARCHAR,
-                                              paramType);
+                                              paramType, parameterIndex);
         }
     }
 
@@ -1440,7 +1440,7 @@ public class PreparedStatement extends Statement
             
             PossibleTypes.throw22005Exception(agent_.logWriter_,
                                               java.sql.Types.BLOB,
-                                              paramType);
+                                              paramType, parameterIndex);
         }
     }
     
@@ -1452,7 +1452,7 @@ public class PreparedStatement extends Statement
                     
             PossibleTypes.throw22005Exception(agent_.logWriter_,
                                               java.sql.Types.CLOB,
-                                              paramType);
+                                              paramType, parameterIndex);
                     
         }
         
@@ -1819,7 +1819,7 @@ public class PreparedStatement extends Statement
         if ( !( paramType == expectedType ) )
         {
             PossibleTypes.throw22005Exception
-                (agent_.logWriter_, expectedType, paramType );
+                (agent_.logWriter_, expectedType, paramType, parameterIndex);
         }
         
         parameterMetaData_.clientParamtertype_[parameterIndex - 1] = expectedType;
@@ -4061,7 +4061,7 @@ public class PreparedStatement extends Statement
         
         static SqlException throw22005Exception( LogWriter logWriter, 
                                                  int valType,
-                                                 int paramType)
+                                                 int paramType, int parameterIndex)
             
             throws SqlException{
             
@@ -4069,7 +4069,7 @@ public class PreparedStatement extends Statement
                                     new ClientMessageId(SQLState.LANG_DATA_TYPE_GET_MISMATCH) ,
                                     new Object[]{ 
                                         Types.getTypeString(valType),
-                                        Types.getTypeString(paramType) 
+                                        Types.getTypeString(paramType), parameterIndex
                                     },
                                     (Throwable) null);
         }

--- a/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/am/SqlException.java
+++ b/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/am/SqlException.java
@@ -446,12 +446,12 @@ public class SqlException extends Exception implements Diagnosable {
 // GemStone changes BEGIN
     public SQLException getSQLException(final Agent agent,
         String columnName) {
-      if (this.args_ != null && this.msgid_ != null) {
+      final Object[] args = this.args_;
+      if (args != null && this.msgid_ != null) {
         if (SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE.equals(this.msgid_)
             || SQLState.LANG_FORMAT_EXCEPTION.equals(this.msgid_)) {
           // add column name to the exception message
-          final Object[] args = this.args_;
-          if (args.length == 1) {
+          if (args.length == 1 || (args.length > 1 && args[1] == null)) {
             final Object[] newArgs = new Object[2];
             if (columnName == null) {
               columnName = "unknown";
@@ -465,8 +465,7 @@ public class SqlException extends Exception implements Diagnosable {
             || SQLState.LANG_DATA_TYPE_SET_MISMATCH.equals(this.msgid_)
             || SQLState.UNSUPPORTED_ENCODING.equals(this.msgid_)) {
           // add column name to the exception message
-          final Object[] args = this.args_;
-          if (args.length == 2) {
+          if (args.length == 2 || (args.length > 2 && args[2] == null)) {
             final Object[] newArgs = new Object[3];
             if (columnName == null) {
               columnName = "unknown";
@@ -480,8 +479,7 @@ public class SqlException extends Exception implements Diagnosable {
         else if (SQLState.LANG_DATE_RANGE_EXCEPTION.equals(this.msgid_)
             || SQLState.LANG_DATE_SYNTAX_EXCEPTION.equals(this.msgid_)) {
           // add column name to the exception message
-          final Object[] args = this.args_;
-          if (args.length == 0) {
+          if (args.length == 0 || (args.length > 0 && args[0] == null)) {
             final Object[] newArgs = new Object[1];
             if (columnName == null) {
               columnName = "unknown";
@@ -729,7 +727,7 @@ class ColumnTypeConversionException extends SqlException {
         String targetType) {
         super(logWriter,
             new ClientMessageId(SQLState.LANG_DATA_TYPE_GET_MISMATCH),
-            sourceType, targetType);
+            sourceType, targetType, (String)null);
     }
 }
 

--- a/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/net/NetSqlca.java
+++ b/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/net/NetSqlca.java
@@ -55,7 +55,7 @@ public class NetSqlca extends Sqlca {
        {
             throw new SqlException(null, 
                   new ClientMessageId(SQLState.UNSUPPORTED_ENCODING),
-                       "sqlstate bytes", "SQLSTATE",uee);
+                       "sqlstate bytes", "SQLSTATE", null, uee);
        }
        sqlErrpBytes_ = sqlErrpBytes;
    }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdVTITemplate.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdVTITemplate.java
@@ -27,6 +27,7 @@ import com.gemstone.gemfire.distributed.DistributedMember;
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
 import com.pivotal.gemfirexd.internal.iapi.reference.SQLState;
 import com.pivotal.gemfirexd.internal.iapi.services.io.FormatableHashtable;
+import com.pivotal.gemfirexd.internal.iapi.sql.ResultColumnDescriptor;
 import com.pivotal.gemfirexd.internal.vti.VTICosting;
 import com.pivotal.gemfirexd.internal.vti.VTIEnvironment;
 import com.pivotal.gemfirexd.internal.vti.VTITemplate;
@@ -217,9 +218,9 @@ public abstract class GfxdVTITemplate extends VTITemplate implements VTICosting 
    * Return a type conversion exception from this type to another.
    */
   protected final StandardException dataTypeConversion(String targetType,
-      String actualType) {
+      ResultColumnDescriptor rcd) {
     return StandardException.newException(SQLState.LANG_DATA_TYPE_GET_MISMATCH,
-        targetType, actualType);
+        targetType, rcd.getType().getTypeName(), rcd.getName());
   }
 
   /** VTI costing interface */

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/resolver/GfxdListPartitionResolver.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/resolver/GfxdListPartitionResolver.java
@@ -609,7 +609,8 @@ public final class GfxdListPartitionResolver extends GfxdPartitionResolver {
           {
               throw StandardException
               .newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE,
-                  "partition by list value not compatible with column type", colRef.getColumnName());       	  
+                  "partition by list value not compatible with column type",
+                  colRef.getColumnName());
           }
           final byte[] bytes = new byte[length];
           dvd.writeBytes(bytes, 0, dtd);
@@ -617,7 +618,7 @@ public final class GfxdListPartitionResolver extends GfxdPartitionResolver {
         } catch (ClassCastException ex) {
           throw StandardException
               .newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, ex,
-                  "partition by list");
+                  "partition by list", colRef.getColumnName());
         }
       }
       return node;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/resolver/GfxdRangePartitionResolver.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/resolver/GfxdRangePartitionResolver.java
@@ -643,7 +643,7 @@ public class GfxdRangePartitionResolver extends GfxdPartitionResolver {
         } catch (ClassCastException ex) {
           throw StandardException.newException(
               SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, ex,
-              "partition by range");
+              "partition by range", colRef.getColumnName());
         }
       }
       return node;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/DistributedMembers.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/DistributedMembers.java
@@ -181,7 +181,7 @@ public final class DistributedMembers extends UpdateVTITemplate {
   public boolean getBoolean(int columnNumber) {
     ResultColumnDescriptor desc = columnInfo[columnNumber - 1];
     if (desc.getType().getJDBCTypeId() != Types.BOOLEAN) {
-      dataTypeConversion("boolean", desc.getType().getTypeName());
+      dataTypeConversion("boolean", desc);
     }
     this.wasNull = false;
     final String columnName = desc.getName();
@@ -205,7 +205,7 @@ public final class DistributedMembers extends UpdateVTITemplate {
   public int getInt(int columnNumber) {
     ResultColumnDescriptor desc = columnInfo[columnNumber - 1];
     if (desc.getType().getJDBCTypeId() != Types.INTEGER) {
-      dataTypeConversion("integer", desc.getType().getTypeName());
+      dataTypeConversion("integer", desc);
     }
     this.wasNull = false;
     final String columnName = desc.getName();

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/QueryStatisticsVTI.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/QueryStatisticsVTI.java
@@ -93,7 +93,7 @@ public class QueryStatisticsVTI extends GfxdVTITemplate {
   public boolean getBoolean(int columnNumber) {
     ResultColumnDescriptor desc = columnInfo[columnNumber - 1];
     if (desc.getType().getJDBCTypeId() != Types.BOOLEAN) {
-      dataTypeConversion("boolean", desc.getType().getTypeName());
+      dataTypeConversion("boolean", desc);
     }
     final String columnName = desc.getName();
     Object stats = this.currentStats.get(columnName);
@@ -111,7 +111,7 @@ public class QueryStatisticsVTI extends GfxdVTITemplate {
   public int getInt(int columnNumber) {
     ResultColumnDescriptor desc = columnInfo[columnNumber - 1];
     if (desc.getType().getJDBCTypeId() != Types.INTEGER) {
-      dataTypeConversion("integer", desc.getType().getTypeName());
+      dataTypeConversion("integer", desc);
     }
     final String columnName = desc.getName();
     Object stats = this.currentStats.get(columnName);
@@ -129,7 +129,7 @@ public class QueryStatisticsVTI extends GfxdVTITemplate {
   public long getLong(int columnNumber) {
     ResultColumnDescriptor desc = columnInfo[columnNumber - 1];
     if (desc.getType().getJDBCTypeId() != Types.BIGINT) {
-      dataTypeConversion("long", desc.getType().getTypeName());
+      dataTypeConversion("long", desc);
     }
     final String columnName = desc.getName();
     Object stats = this.currentStats.get(columnName);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
@@ -124,22 +124,20 @@ public final class SnappyResultHolder extends GfxdDataSerializable {
 
   private void makeTemplateDVDArr() {
     dtds = new DataTypeDescriptor[colTypes.length];
-    DataValueDescriptor[] temp = new DataValueDescriptor[colTypes.length];
-    for(int i=0; i<colTypes.length; i++) {
+    DataValueDescriptor[] dvds = new DataValueDescriptor[colTypes.length];
+    for (int i = 0; i < colTypes.length; i++) {
       int typeId = colTypes[i];
-      DataValueDescriptor dvd = getNewNullDVD(typeId, i, dtds, precisions[i], scales[i]);
-      temp[i] = dvd;
+      DataValueDescriptor dvd = getNewNullDVD(typeId, i, dtds,
+          precisions[i], scales[i]);
+      dvds[i] = dvd;
     }
-    this.templateDVDRow = temp;
-    this.execRow = new ValueRow((templateDVDRow));
+    this.templateDVDRow = dvds;
+    this.execRow = new ValueRow(templateDVDRow);
     // determine eight col groups and partial col
     int numCols = colTypes.length;
     if (numEightColGrps < 0) {
-      numEightColGrps = numCols / 8 + (numCols % 8 == 0 ? 0 : 1);
+      numEightColGrps = numCols / 8;
       numPartialCols = numCols % 8;
-      if (numPartialCols == 0) {
-        numPartialCols = 8;
-      }
     }
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/GemFireXDUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/GemFireXDUtils.java
@@ -226,7 +226,7 @@ public final class GemFireXDUtils {
           new GemFireXDRuntimeException("unexpected format for boot/sys property "
               + Attribute.DEFAULT_RECOVERY_DELAY_PROP
               + " where a long was expected: " + defaultRecoveryDelayStr),
-          TypeId.LONGINT_NAME);
+          TypeId.LONGINT_NAME, (String)null);
     }
 
     // set default-startup-recovery-delay from the system property
@@ -249,7 +249,7 @@ public final class GemFireXDUtils {
           new GemFireXDRuntimeException("unexpected format for boot/sys property "
               + GfxdConstants.DEFAULT_STARTUP_RECOVERY_DELAY_PROP
               + " where a long was expected: " + defaultStartupRecoveryDelayStr),
-          TypeId.LONGINT_NAME);
+          TypeId.LONGINT_NAME, (String)null);
     }
 
     // set initial-capacity for all tables from the system property if provided
@@ -271,7 +271,7 @@ public final class GemFireXDUtils {
           new GemFireXDRuntimeException("unexpected format for boot/sys property "
               + Attribute.DEFAULT_INITIAL_CAPACITY_PROP
               + " where an integer was expected: " + defaultInitialCapacityStr),
-          TypeId.INTEGER_NAME);
+          TypeId.INTEGER_NAME, (String)null);
     }
 
     String propStr = PropertyUtil.getServiceProperty(store,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/locks/GfxdLockSet.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/locks/GfxdLockSet.java
@@ -54,7 +54,7 @@ import com.pivotal.gemfirexd.internal.shared.common.sanity.SanityManager;
  * {@link GfxdLockService}.
  * 
  * Some of the methods need to be protected now (
- * {@link #releaseLock(GfxdLockable, boolean, boolean)} and {@link #unlockAll()}
+ * {@link #releaseLock(GfxdLockable, boolean, boolean)} and {@link #unlockAll}
  * ) since multiple threads can release locks on the same Transaction,
  * particularly with streaming where this should be done after processing is
  * done on all nodes, so release is done by the ResultCollector while TX commit
@@ -101,8 +101,8 @@ public final class GfxdLockSet implements CompatibilitySpace {
   /**
    * An int representing max wait time for distributed lock on a single VM in
    * milliseconds. When this limit is exhausted then the lock acquisition is
-   * retried (to avoid deadlocks) subject to maximum of {@link #MAX_LOCKWAIT}
-   * for the complete distributed acquisition.
+   * retried (to avoid deadlocks) subject to maximum of
+   * {@link GfxdConstants#MAX_LOCKWAIT} for the complete distributed acquisition.
    */
   public static int MAX_VM_LOCKWAIT_VAL = MAX_LOCKWAIT_VAL
       / MAX_VM_LOCKWAIT_RETRIES;
@@ -160,7 +160,7 @@ public final class GfxdLockSet implements CompatibilitySpace {
 
   /**
    * Number of open ResultSets etc. referring to this GfxdLockSet. This governs
-   * whether {@link #unlockAll(boolean)} will actually release all locks or not.
+   * whether {@link #unlockAll} will actually release all locks or not.
    */
   private int numRefs;
 
@@ -205,7 +205,7 @@ public final class GfxdLockSet implements CompatibilitySpace {
 
   /**
    * Static method to initialize {@link GfxdConstants#MAX_LOCKWAIT},
-   * {@link GfxdConstants#MAX_VM_LOCKWAIT} , {@link GfxdConstants#MAX_LEASETIME}
+   * {@link #MAX_VM_LOCKWAIT_VAL}, {@link #MAX_WRITE_WAIT_RETRY}
    * to given values, and return the {@link #MAX_VM_LOCKWAIT_VAL}. NOT
    * THREAD_SAFE.
    */

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/locks/GfxdReadWriteLock.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/locks/GfxdReadWriteLock.java
@@ -115,8 +115,8 @@ public interface GfxdReadWriteLock extends ReadWriteLockObject {
   StringBuilder fillSB(StringBuilder sb);
 
   /**
-   * A value indicating infinite timeout in {@link #attemptReadLock(long)} and
-   * {@link #attemptWriteLock(long)} methods.
+   * A value indicating infinite timeout in {@link #attemptReadLock} and
+   * {@link #attemptWriteLock} methods.
    */
   public static final int TIMEOUT_INFINITE = -1;
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/AbstractCompactExecRow.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/AbstractCompactExecRow.java
@@ -1225,7 +1225,7 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
     final ColumnDescriptor cd = this.formatter.getColumnDescriptor(index);
     throw StandardException.newException(
         SQLState.LANG_DATA_TYPE_GET_MISMATCH, "Blob", cd.getType()
-            .getFullSQLTypeName());
+            .getFullSQLTypeName(), cd.getColumnName());
   }
 
   public Clob getAsClob(int position, ResultWasNull wasNull)
@@ -1234,7 +1234,7 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
     final ColumnDescriptor cd = this.formatter.getColumnDescriptor(index);
     throw StandardException.newException(
         SQLState.LANG_DATA_TYPE_GET_MISMATCH, "Clob", cd.getType()
-            .getFullSQLTypeName());
+            .getFullSQLTypeName(), cd.getColumnName());
   }
 
   protected abstract String getString(int position, ResultWasNull wasNull)

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RowFormatter.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RowFormatter.java
@@ -96,8 +96,9 @@ import com.pivotal.gemfirexd.internal.shared.common.sanity.SanityManager;
  * variable length fields so all the variable length fields are at the end.
  * After the field data, an offset is stored for each variable length field.
  * 
- * More information about the byte format can be found at: {@link https
- * ://wiki.gemstone.com/display/queryteam/Relational+Storage+Model}
+ * More information about the byte format can be found at:
+ * <a href="https://wiki.gemstone.com/display/queryteam/Relational+Storage+Model">
+ *   Relational Storage Model</a>
  * 
  * @author Eric Zoerner
  * @author Rahul Dubey
@@ -175,8 +176,7 @@ public final class RowFormatter implements Serializable {
   /**
    * Token version used for rows recovered from older pre 1.1 version data files
    * that did not have schema version. For such cases this token version is
-   * interpreted as the version just after recovery from disk (
-   * {@link GemFireContainer#setSchemaVersionOnRecovery()}).
+   * interpreted as the version just after recovery from disk.
    */
   public static final int TOKEN_RECOVERY_VERSION = -1;
 
@@ -252,7 +252,7 @@ public final class RowFormatter implements Serializable {
 
   /**
    * This interface allows specification of action to be taken for each column
-   * e.g. for {@link RowFormatter#extractColumn} and other such methods.
+   * e.g. for {@link RowFormatter#extractColumnBytes} and other such methods.
    * 
    * @author swale
    * @since 7.0
@@ -413,8 +413,8 @@ public final class RowFormatter implements Serializable {
 
   /**
    * This interface allows specification of action to be taken for each column
-   * e.g. for {@link RowFormatter#extractColumn} and other such methods for
-   * {@link OffHeapByteSource} rows.
+   * e.g. for {@link RowFormatter#extractColumnBytesOffHeap} and other such
+   * methods for {@link OffHeapByteSource} rows.
    * 
    * @author swale
    * @since gfxd 2.0
@@ -820,7 +820,7 @@ public final class RowFormatter implements Serializable {
    * @return the index where last encoded byte was written i.e. number of bytes
    *         written = (returned offset - passed offset + 1)
    * 
-   * @see InternalDataSerializer#writeSignedVL(int, DataOutput)
+   * @see InternalDataSerializer#writeSignedVL(long, DataOutput)
    */
   public static int writeCompactInt(final byte[] bytes, final int v,
       int offset) {
@@ -890,10 +890,7 @@ public final class RowFormatter implements Serializable {
   /**
    * Returns an <code>int</code> value by reading the specified number of bytes
    * provided as an argument starting at offset.
-   * 
-   * @param bytes
-   * @param offset
-   * @param numBytesToBeRead
+   *
    * @return an <code>int</code> value.
    */
   public static int readInt(final UnsafeWrapper unsafe, long memOffset,
@@ -920,6 +917,12 @@ public final class RowFormatter implements Serializable {
     return intValue;
   }
 
+  /**
+   * Returns an <code>int</code> value by reading the specified number of bytes
+   * provided as an argument starting at offset.
+   *
+   * @return an <code>int</code> value.
+   */
   public static int readInt(final byte[] bytes, int offset,
       final int numBytesToBeRead) {
     assert bytes != null;
@@ -8670,7 +8673,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "BOOLEAN", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -8738,7 +8741,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "BOOLEAN", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -8751,7 +8754,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsByte(bytes, offset, columnWidth,
-          cd.columnType, wasNull);
+          cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -8794,7 +8797,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "TINYINT", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -8809,7 +8812,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsByte(unsafe, memAddr + offset,
-          columnWidth, bs, cd.columnType, wasNull);
+          columnWidth, bs, cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -8862,7 +8865,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "TINYINT", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -8875,7 +8878,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsShort(bytes, offset, columnWidth,
-          cd.columnType, wasNull);
+          cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -8918,7 +8921,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "SMALLINT", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -8933,7 +8936,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsShort(unsafe, memAddr + offset,
-          columnWidth, bs, cd.columnType, wasNull);
+          columnWidth, bs, cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -8986,7 +8989,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "SMALLINT", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -8999,7 +9002,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsInt(bytes, offset, columnWidth,
-          cd.columnType, wasNull);
+          cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9042,7 +9045,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "INTEGER", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -9057,7 +9060,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsInt(unsafe, memAddr + offset,
-          columnWidth, bs, cd.columnType, wasNull);
+          columnWidth, bs, cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9110,7 +9113,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "INTEGER", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -9123,7 +9126,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsLong(bytes, offset, columnWidth,
-          cd.columnType, wasNull);
+          cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9166,7 +9169,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "BIGINT", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -9181,7 +9184,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsLong(unsafe, memAddr + offset,
-          columnWidth, bs, cd.columnType, wasNull);
+          columnWidth, bs, cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9234,7 +9237,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "BIGINT", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -9247,7 +9250,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsFloat(bytes, offset, columnWidth,
-          cd.columnType, wasNull);
+          cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9290,7 +9293,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "FLOAT", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -9305,7 +9308,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsFloat(unsafe, memAddr + offset,
-          columnWidth, bs, cd.columnType, wasNull);
+          columnWidth, bs, cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9358,7 +9361,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "FLOAT", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -9371,7 +9374,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsDouble(bytes, offset, columnWidth,
-          cd.columnType, wasNull);
+          cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9414,7 +9417,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "DOUBLE", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -9429,7 +9432,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsDouble(unsafe, memAddr + offset,
-          columnWidth, bs, cd.columnType, wasNull);
+          columnWidth, bs, cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9482,7 +9485,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "DOUBLE", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -9495,7 +9498,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsBigDecimal(bytes, offset, columnWidth,
-          cd.columnType, wasNull);
+          cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9538,7 +9541,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "DECIMAL", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -9553,7 +9556,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)(offsetAndWidth & LOWER_INT32_MASK);
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsBigDecimal(unsafe, memAddr + offset,
-          columnWidth, bs, cd.columnType, wasNull);
+          columnWidth, bs, cd, wasNull);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9606,7 +9609,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "DECIMAL", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -9828,7 +9831,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "DATE", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -9905,7 +9908,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "DATE", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -9971,7 +9974,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "TIME", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -10048,7 +10051,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "TIME", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -10115,7 +10118,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "TIMESTAMP", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -10192,7 +10195,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "TIMESTAMP", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -10218,7 +10221,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "BLOB", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -10249,7 +10252,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "BLOB", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -10279,7 +10282,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "CLOB", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 
@@ -10321,7 +10324,7 @@ public final class RowFormatter implements Serializable {
     else {
       throw StandardException.newException(
           SQLState.LANG_DATA_TYPE_GET_MISMATCH, "CLOB", cd.getType()
-              .getFullSQLTypeName());
+              .getFullSQLTypeName(), cd.getColumnName());
     }
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/BigIntegerDecimal.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/BigIntegerDecimal.java
@@ -81,7 +81,7 @@ public final class BigIntegerDecimal extends BinaryDecimal
 		
 		// TODO Range checking
 		if (!rangeOk)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT", (String)null);
 		
 		return bi.longValue();
 	}
@@ -457,7 +457,7 @@ public final class BigIntegerDecimal extends BinaryDecimal
 			
 			if (futurePrecision > desiredPrecision)
 				throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, 
-						("DECIMAL/NUMERIC("+desiredPrecision+","+desiredScale+")"));
+						("DECIMAL/NUMERIC("+desiredPrecision+","+desiredScale+")"), (String)null);
 		}
 		
 		if (deltaScale == 0)

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/BinaryDecimal.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/BinaryDecimal.java
@@ -336,7 +336,7 @@ abstract class BinaryDecimal extends NumberDataType
 			// fall through to correct message
 		}
 
-		throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+		throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER", (String)null);
 	}
 
 	/**
@@ -361,7 +361,7 @@ abstract class BinaryDecimal extends NumberDataType
 		}
 
 		throw StandardException.newException(
-				SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+				SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT", (String)null);
 	}
 
 	/**
@@ -384,7 +384,7 @@ abstract class BinaryDecimal extends NumberDataType
 			// fall through to correct message
 		}
 
-		throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+		throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT", (String)null);
 	}
 	
 	

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/DataType.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/DataType.java
@@ -623,7 +623,7 @@ public abstract class DataType
 		if (!instanceOfResultType) {
 				throw StandardException.newException(
 						SQLState.LANG_DATA_TYPE_SET_MISMATCH,
-						theValue.getClass().getName(), getTypeName(resultTypeClassName));
+						theValue.getClass().getName(), getTypeName(resultTypeClassName), (String)null);
 		}
 
 		setObject(theValue);
@@ -700,7 +700,7 @@ public abstract class DataType
 	void throwLangSetMismatch(String argTypeName) throws StandardException
 	{
 		throw StandardException.newException(SQLState.LANG_DATA_TYPE_SET_MISMATCH, 
-									   argTypeName, this.getTypeName());
+									   argTypeName, this.getTypeName(), (String)null);
 		
 	}
 
@@ -1289,7 +1289,7 @@ public abstract class DataType
 	*/
 	protected final StandardException dataTypeConversion(String targetType) {
 		return StandardException.newException(SQLState.LANG_DATA_TYPE_GET_MISMATCH, 
-			targetType, this.getTypeName());
+			targetType, this.getTypeName(), (String)null);
 
 	}
 
@@ -1299,7 +1299,7 @@ public abstract class DataType
 	protected final StandardException outOfRange()
 	{
 		return StandardException.newException(
-				SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, getTypeName());
+				SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, getTypeName(), (String)null);
 	}
 
 	/**
@@ -1308,7 +1308,7 @@ public abstract class DataType
 	protected final StandardException invalidFormat()
 	{
 		return StandardException.newException(
-				SQLState.LANG_FORMAT_EXCEPTION, getTypeName());
+				SQLState.LANG_FORMAT_EXCEPTION, getTypeName(), (String)null);
 	}
 
   // GemStone changes BEGIN

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/DataTypeUtilities.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/DataTypeUtilities.java
@@ -1247,10 +1247,11 @@ public abstract class DataTypeUtilities {
   }
 
   public static final byte getAsByte(final byte[] inBytes, final int offset,
-      final int columnWidth, final DataTypeDescriptor dtd,
+      final int columnWidth, final ColumnDescriptor cd,
       final ResultWasNull wasNull) throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.DOUBLE_TYPE_ID: {
@@ -1258,14 +1259,16 @@ public abstract class DataTypeUtilities {
         if ((value > (Byte.MAX_VALUE + 1.0d))
             || (value < (Byte.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+              cd.getColumnName());
         return (byte)value;
       }
       case StoredFormatIds.INT_TYPE_ID: {
         final int value = SQLInteger.getAsInteger(inBytes, offset);
         if (value > Byte.MAX_VALUE || value < Byte.MIN_VALUE) {
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+              cd.getColumnName());
         }
         return (byte)value;
       }
@@ -1278,7 +1281,8 @@ public abstract class DataTypeUtilities {
             return (byte)lv;
           else {
             throw StandardException.newException(
-                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1290,7 +1294,8 @@ public abstract class DataTypeUtilities {
         final long lv = SQLLongint.getAsLong(inBytes, offset);
         if (lv > Byte.MAX_VALUE || lv < Byte.MIN_VALUE)
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+              cd.getColumnName());
 
         return (byte)lv;
 
@@ -1300,14 +1305,16 @@ public abstract class DataTypeUtilities {
         if ((flt > ((Byte.MAX_VALUE + 1.0d)))
             || (flt < (Byte.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+              cd.getColumnName());
         return (byte)flt;
       }
       case StoredFormatIds.SMALLINT_TYPE_ID: {
         final short shrt = SQLSmallint.getAsShort(inBytes, offset);
         if (shrt > Byte.MAX_VALUE || shrt < Byte.MIN_VALUE)
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+              cd.getColumnName());
         return (byte)shrt;
       }
       case StoredFormatIds.CHAR_TYPE_ID: {
@@ -1318,7 +1325,8 @@ public abstract class DataTypeUtilities {
             return Byte.parseByte(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "TINYINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "TINYINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1336,7 +1344,8 @@ public abstract class DataTypeUtilities {
             return Byte.parseByte(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "TINYINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "TINYINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1360,10 +1369,11 @@ public abstract class DataTypeUtilities {
 
   public static final byte getAsByte(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth,
-      @Unretained final OffHeapByteSource bs, final DataTypeDescriptor dtd,
+      @Unretained final OffHeapByteSource bs, final ColumnDescriptor cd,
       final ResultWasNull wasNull) throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.DOUBLE_TYPE_ID: {
@@ -1371,14 +1381,16 @@ public abstract class DataTypeUtilities {
         if ((value > (Byte.MAX_VALUE + 1.0d))
             || (value < (Byte.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+              cd.getColumnName());
         return (byte)value;
       }
       case StoredFormatIds.INT_TYPE_ID: {
         final int value = SQLInteger.getAsInteger(unsafe, memOffset);
         if (value > Byte.MAX_VALUE || value < Byte.MIN_VALUE) {
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+              cd.getColumnName());
         }
         return (byte)value;
       }
@@ -1391,7 +1403,8 @@ public abstract class DataTypeUtilities {
             return (byte)lv;
           else {
             throw StandardException.newException(
-                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1403,7 +1416,8 @@ public abstract class DataTypeUtilities {
         final long lv = SQLLongint.getAsLong(unsafe, memOffset);
         if (lv > Byte.MAX_VALUE || lv < Byte.MIN_VALUE)
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+              cd.getColumnName());
 
         return (byte)lv;
 
@@ -1413,14 +1427,16 @@ public abstract class DataTypeUtilities {
         if ((flt > ((Byte.MAX_VALUE + 1.0d)))
             || (flt < (Byte.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+              cd.getColumnName());
         return (byte)flt;
       }
       case StoredFormatIds.SMALLINT_TYPE_ID: {
         final short shrt = SQLSmallint.getAsShort(unsafe, memOffset);
         if (shrt > Byte.MAX_VALUE || shrt < Byte.MIN_VALUE)
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+              cd.getColumnName());
         return (byte)shrt;
       }
       case StoredFormatIds.CHAR_TYPE_ID: {
@@ -1431,7 +1447,8 @@ public abstract class DataTypeUtilities {
             return Byte.parseByte(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "TINYINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "TINYINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1449,7 +1466,8 @@ public abstract class DataTypeUtilities {
             return Byte.parseByte(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "TINYINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "TINYINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1474,10 +1492,11 @@ public abstract class DataTypeUtilities {
   // TODO: SW: for both LANG_OUTSIDE_RANGE, LANG_FORMAT errors, should also
   // have the culprit value in exception message
   public static final short getAsShort(final byte[] inBytes, final int offset,
-      final int columnWidth, final DataTypeDescriptor dtd,
+      final int columnWidth, final ColumnDescriptor cd,
       final ResultWasNull wasNull) throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.DOUBLE_TYPE_ID: {
@@ -1485,7 +1504,8 @@ public abstract class DataTypeUtilities {
         if ((value > (Short.MAX_VALUE + 1.0d))
             || (value < (Short.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
+              cd.getColumnName());
         return (short)value;
       }
 
@@ -1493,7 +1513,8 @@ public abstract class DataTypeUtilities {
         final int value = SQLInteger.getAsInteger(inBytes, offset);
         if (value > Short.MAX_VALUE || value < Short.MIN_VALUE)
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
+              cd.getColumnName());
         return (short)value;
 
       }
@@ -1506,7 +1527,8 @@ public abstract class DataTypeUtilities {
             return (short)lv;
           else {
             throw StandardException.newException(
-                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1518,7 +1540,8 @@ public abstract class DataTypeUtilities {
         final long lv = SQLLongint.getAsLong(inBytes, offset);
         if (lv > Short.MAX_VALUE || lv < Short.MIN_VALUE)
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
+              cd.getColumnName());
         return (short)lv;
       }
       case StoredFormatIds.REAL_TYPE_ID: {
@@ -1526,7 +1549,8 @@ public abstract class DataTypeUtilities {
         if ((flt > ((Short.MAX_VALUE + 1.0d)))
             || (flt < (Short.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
+              cd.getColumnName());
         return (short)flt;
       }
       case StoredFormatIds.SMALLINT_TYPE_ID:
@@ -1539,7 +1563,8 @@ public abstract class DataTypeUtilities {
             return Short.parseShort(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1557,7 +1582,8 @@ public abstract class DataTypeUtilities {
             return Short.parseShort(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1581,10 +1607,11 @@ public abstract class DataTypeUtilities {
 
   public static final short getAsShort(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth,
-      @Unretained final OffHeapByteSource bs, final DataTypeDescriptor dtd,
+      @Unretained final OffHeapByteSource bs, final ColumnDescriptor cd,
       final ResultWasNull wasNull) throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.DOUBLE_TYPE_ID: {
@@ -1592,7 +1619,8 @@ public abstract class DataTypeUtilities {
         if ((value > (Short.MAX_VALUE + 1.0d))
             || (value < (Short.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
+              cd.getColumnName());
         return (short)value;
       }
 
@@ -1600,7 +1628,8 @@ public abstract class DataTypeUtilities {
         final int value = SQLInteger.getAsInteger(unsafe, memOffset);
         if (value > Short.MAX_VALUE || value < Short.MIN_VALUE)
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
+              cd.getColumnName());
         return (short)value;
 
       }
@@ -1613,7 +1642,8 @@ public abstract class DataTypeUtilities {
             return (short)lv;
           else {
             throw StandardException.newException(
-                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1625,7 +1655,8 @@ public abstract class DataTypeUtilities {
         final long lv = SQLLongint.getAsLong(unsafe, memOffset);
         if (lv > Short.MAX_VALUE || lv < Short.MIN_VALUE)
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
+              cd.getColumnName());
         return (short)lv;
       }
       case StoredFormatIds.REAL_TYPE_ID: {
@@ -1633,7 +1664,8 @@ public abstract class DataTypeUtilities {
         if ((flt > ((Short.MAX_VALUE + 1.0d)))
             || (flt < (Short.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
+              cd.getColumnName());
         return (short)flt;
       }
       case StoredFormatIds.SMALLINT_TYPE_ID:
@@ -1646,7 +1678,8 @@ public abstract class DataTypeUtilities {
             return Short.parseShort(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1664,7 +1697,8 @@ public abstract class DataTypeUtilities {
             return Short.parseShort(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1687,10 +1721,11 @@ public abstract class DataTypeUtilities {
   }
 
   public static final int getAsInt(final byte[] inBytes, final int offset,
-      final int columnWidth, final DataTypeDescriptor dtd,
+      final int columnWidth, final ColumnDescriptor cd,
       final ResultWasNull wasNull) throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.DOUBLE_TYPE_ID: {
@@ -1698,7 +1733,8 @@ public abstract class DataTypeUtilities {
         if ((value > (Integer.MAX_VALUE + 1.0d))
             || (value < (Integer.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
+              cd.getColumnName());
         return (int)value;
       }
 
@@ -1714,7 +1750,8 @@ public abstract class DataTypeUtilities {
             return (int)lv;
           else {
             throw StandardException.newException(
-                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
+                cd.getColumnName());
           }
         }
         else {
@@ -1726,7 +1763,8 @@ public abstract class DataTypeUtilities {
         final long lv = SQLLongint.getAsLong(inBytes, offset);
         if (lv > Integer.MAX_VALUE || lv < Integer.MIN_VALUE)
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
+              cd.getColumnName());
         return (int)lv;
       }
       case StoredFormatIds.REAL_TYPE_ID: {
@@ -1734,7 +1772,8 @@ public abstract class DataTypeUtilities {
         if ((flt > ((Integer.MAX_VALUE + 1.0d)))
             || (flt < (Integer.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
+              cd.getColumnName());
         return (int)flt;
       }
       case StoredFormatIds.SMALLINT_TYPE_ID:
@@ -1747,7 +1786,8 @@ public abstract class DataTypeUtilities {
             return Integer.parseInt(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "INTEGER");
+                SQLState.LANG_FORMAT_EXCEPTION, "INTEGER",
+                cd.getColumnName());
           }
         }
         else {
@@ -1765,7 +1805,8 @@ public abstract class DataTypeUtilities {
             return Integer.parseInt(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "INTEGER");
+                SQLState.LANG_FORMAT_EXCEPTION, "INTEGER",
+                cd.getColumnName());
           }
         }
         else {
@@ -1789,10 +1830,11 @@ public abstract class DataTypeUtilities {
 
   public static final int getAsInt(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth, final OffHeapByteSource bs,
-      final DataTypeDescriptor dtd, final ResultWasNull wasNull)
+      final ColumnDescriptor cd, final ResultWasNull wasNull)
       throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.DOUBLE_TYPE_ID: {
@@ -1800,7 +1842,8 @@ public abstract class DataTypeUtilities {
         if ((value > (Integer.MAX_VALUE + 1.0d))
             || (value < (Integer.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
+              cd.getColumnName());
         return (int)value;
       }
 
@@ -1816,7 +1859,8 @@ public abstract class DataTypeUtilities {
             return (int)lv;
           else {
             throw StandardException.newException(
-                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
+                cd.getColumnName());
           }
         }
         else {
@@ -1828,7 +1872,8 @@ public abstract class DataTypeUtilities {
         final long lv = SQLLongint.getAsLong(unsafe, memOffset);
         if (lv > Integer.MAX_VALUE || lv < Integer.MIN_VALUE)
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
+              cd.getColumnName());
         return (int)lv;
       }
       case StoredFormatIds.REAL_TYPE_ID: {
@@ -1836,7 +1881,8 @@ public abstract class DataTypeUtilities {
         if ((flt > ((Integer.MAX_VALUE + 1.0d)))
             || (flt < (Integer.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
+              cd.getColumnName());
         return (int)flt;
       }
       case StoredFormatIds.SMALLINT_TYPE_ID:
@@ -1849,7 +1895,8 @@ public abstract class DataTypeUtilities {
             return Integer.parseInt(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "INTEGER");
+                SQLState.LANG_FORMAT_EXCEPTION, "INTEGER",
+                cd.getColumnName());
           }
         }
         else {
@@ -1867,7 +1914,8 @@ public abstract class DataTypeUtilities {
             return Integer.parseInt(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "INTEGER");
+                SQLState.LANG_FORMAT_EXCEPTION, "INTEGER",
+                cd.getColumnName());
           }
         }
         else {
@@ -1890,10 +1938,11 @@ public abstract class DataTypeUtilities {
   }
 
   public static final long getAsLong(final byte[] inBytes, final int offset,
-      final int columnWidth, final DataTypeDescriptor dtd,
+      final int columnWidth, final ColumnDescriptor cd,
       final ResultWasNull wasNull) throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.DOUBLE_TYPE_ID: {
@@ -1901,7 +1950,8 @@ public abstract class DataTypeUtilities {
         if ((value > (Long.MAX_VALUE + 1.0d))
             || (value < (Long.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT",
+              cd.getColumnName());
         return (long)value;
       }
 
@@ -1927,7 +1977,8 @@ public abstract class DataTypeUtilities {
         if ((flt > ((Long.MAX_VALUE + 1.0d)))
             || (flt < (Long.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT",
+              cd.getColumnName());
         return (long)flt;
       }
       case StoredFormatIds.SMALLINT_TYPE_ID:
@@ -1940,7 +1991,8 @@ public abstract class DataTypeUtilities {
             return Long.parseLong(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1958,7 +2010,8 @@ public abstract class DataTypeUtilities {
             return Long.parseLong(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -1982,10 +2035,11 @@ public abstract class DataTypeUtilities {
 
   public static final long getAsLong(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth, final OffHeapByteSource bs,
-      final DataTypeDescriptor dtd, final ResultWasNull wasNull)
+      final ColumnDescriptor cd, final ResultWasNull wasNull)
       throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.DOUBLE_TYPE_ID: {
@@ -1993,7 +2047,8 @@ public abstract class DataTypeUtilities {
         if ((value > (Long.MAX_VALUE + 1.0d))
             || (value < (Long.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT",
+              cd.getColumnName());
         return (long)value;
       }
 
@@ -2019,7 +2074,8 @@ public abstract class DataTypeUtilities {
         if ((flt > ((Long.MAX_VALUE + 1.0d)))
             || (flt < (Long.MIN_VALUE - 1.0d)))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT",
+              cd.getColumnName());
         return (long)flt;
       }
       case StoredFormatIds.SMALLINT_TYPE_ID:
@@ -2032,7 +2088,8 @@ public abstract class DataTypeUtilities {
             return Long.parseLong(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -2050,7 +2107,8 @@ public abstract class DataTypeUtilities {
             return Long.parseLong(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -2073,17 +2131,19 @@ public abstract class DataTypeUtilities {
   }
 
   public static final float getAsFloat(final byte[] inBytes, final int offset,
-      final int columnWidth, final DataTypeDescriptor dtd,
+      final int columnWidth, final ColumnDescriptor cd,
       final ResultWasNull wasNull) throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.DOUBLE_TYPE_ID: {
         final double value = SQLDouble.getAsDouble(inBytes, offset);
         if (Float.isInfinite((float)value))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME);
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME,
+              cd.getColumnName());
         return (float)value;
       }
       case StoredFormatIds.INT_TYPE_ID:
@@ -2113,7 +2173,8 @@ public abstract class DataTypeUtilities {
             return Float.parseFloat(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -2131,7 +2192,8 @@ public abstract class DataTypeUtilities {
             return Float.parseFloat(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT");
+                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
+                cd.getColumnName());
           }
         }
         else {
@@ -2155,17 +2217,19 @@ public abstract class DataTypeUtilities {
 
   public static final float getAsFloat(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth, final OffHeapByteSource bs,
-      final DataTypeDescriptor dtd, final ResultWasNull wasNull)
+      final ColumnDescriptor cd, final ResultWasNull wasNull)
       throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.DOUBLE_TYPE_ID: {
         final double value = SQLDouble.getAsDouble(unsafe, memOffset);
         if (Float.isInfinite((float)value))
           throw StandardException.newException(
-              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME);
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME,
+              cd.getColumnName());
         return (float)value;
       }
       case StoredFormatIds.INT_TYPE_ID:
@@ -2195,7 +2259,8 @@ public abstract class DataTypeUtilities {
             return Float.parseFloat(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, TypeId.REAL_NAME);
+                SQLState.LANG_FORMAT_EXCEPTION, TypeId.REAL_NAME,
+                cd.getColumnName());
           }
         }
         else {
@@ -2213,7 +2278,8 @@ public abstract class DataTypeUtilities {
             return Float.parseFloat(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, TypeId.REAL_NAME);
+                SQLState.LANG_FORMAT_EXCEPTION, TypeId.REAL_NAME,
+                cd.getColumnName());
           }
         }
         else {
@@ -2236,10 +2302,11 @@ public abstract class DataTypeUtilities {
   }
 
   public static final double getAsDouble(final byte[] inBytes,
-      final int offset, final int columnWidth, final DataTypeDescriptor dtd,
+      final int offset, final int columnWidth, final ColumnDescriptor cd,
       final ResultWasNull wasNull) throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.DOUBLE_TYPE_ID:
@@ -2270,7 +2337,8 @@ public abstract class DataTypeUtilities {
             return Double.parseDouble(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME);
+                SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME,
+                cd.getColumnName());
           }
         }
         else {
@@ -2288,7 +2356,8 @@ public abstract class DataTypeUtilities {
             return Double.parseDouble(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME);
+                SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME,
+                cd.getColumnName());
           }
         }
         else {
@@ -2311,10 +2380,11 @@ public abstract class DataTypeUtilities {
 
   public static final double getAsDouble(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth, final OffHeapByteSource bs,
-      final DataTypeDescriptor dtd, final ResultWasNull wasNull)
+      final ColumnDescriptor cd, final ResultWasNull wasNull)
       throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.DOUBLE_TYPE_ID:
@@ -2345,7 +2415,8 @@ public abstract class DataTypeUtilities {
             return Double.parseDouble(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME);
+                SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME,
+                cd.getColumnName());
           }
         }
         else {
@@ -2363,7 +2434,8 @@ public abstract class DataTypeUtilities {
             return Double.parseDouble(str);
           } catch (NumberFormatException nfe) {
             throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME);
+                SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME,
+                cd.getColumnName());
           }
         }
         else {
@@ -2385,10 +2457,11 @@ public abstract class DataTypeUtilities {
   }
 
   public static final BigDecimal getAsBigDecimal(final byte[] inBytes,
-      final int offset, final int columnWidth, final DataTypeDescriptor dtd,
+      final int offset, final int columnWidth, final ColumnDescriptor cd,
       final ResultWasNull wasNull) throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     try {
       switch (formatID) {
@@ -2458,16 +2531,17 @@ public abstract class DataTypeUtilities {
       }
     } catch (NumberFormatException nfe) {
       throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION,
-          "java.math.BigDecimal");
+          "java.math.BigDecimal", cd.getColumnName());
     }
   }
 
   public static final BigDecimal getAsBigDecimal(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth, final OffHeapByteSource bs,
-      final DataTypeDescriptor dtd, final ResultWasNull wasNull)
+      final ColumnDescriptor cd, final ResultWasNull wasNull)
       throws StandardException {
 
     assert wasNull != null;
+    final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     try {
       switch (formatID) {
@@ -2538,7 +2612,7 @@ public abstract class DataTypeUtilities {
       }
     } catch (NumberFormatException nfe) {
       throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION,
-          "java.math.BigDecimal");
+          "java.math.BigDecimal", cd.getColumnName());
     }
   }
 
@@ -3293,15 +3367,6 @@ public abstract class DataTypeUtilities {
   /**
    * Null handling is done. Caller must handle default column values.
    * 
-   * @param lhs
-   * @param lhsDVD
-   * @param rhs
-   * @param lhsOffsetWidth
-   * @param rhsOffsetWidth
-   * @param nullsOrderedLow
-   * @param caseSensitive
-   * @param cd
-   * @return
    * @throws StandardException
    */
   public static final int compare(byte[] lhs, byte[] rhs,
@@ -3495,15 +3560,6 @@ public abstract class DataTypeUtilities {
   /**
    * Null handling is done. Caller must handle default column values.
    * 
-   * @param lhs
-   * @param lhsDVD
-   * @param rhs
-   * @param lhsOffsetWidth
-   * @param rhsOffsetWidth
-   * @param nullsOrderedLow
-   * @param caseSensitive
-   * @param cd
-   * @return
    * @throws StandardException
    */
   public static final int compare(DataValueDescriptor lhsDVD, byte[] rhs,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/NumberDataType.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/NumberDataType.java
@@ -433,7 +433,7 @@ public abstract class NumberDataType extends DataType
 			setValue(bigDecimal.longValue());
 		} else {
 
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, getTypeName());
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, getTypeName(), (String)null);
 		}
 	}
 	
@@ -486,7 +486,7 @@ public abstract class NumberDataType extends DataType
              ((v > 0) && (v < Limits.DB2_SMALLEST_POSITIVE_REAL)) ||
              ((v < 0) && (v > Limits.DB2_LARGEST_NEGATIVE_REAL)) )
         {
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME);
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME, (String)null);
         }
         // Normalize negative floats to be "positive" (can't detect easily without using Float object because -0.0f = 0.0f)
         if (v == 0.0f) v = 0.0f;
@@ -512,7 +512,7 @@ public abstract class NumberDataType extends DataType
              ((v > 0) && (v < Limits.DB2_SMALLEST_POSITIVE_REAL)) ||
              ((v < 0) && (v > Limits.DB2_LARGEST_NEGATIVE_REAL)) )
         {
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME);
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME, (String)null);
         }
         // Normalize negative floats to be "positive" (can't detect easily without using Float object because -0.0f = 0.0f)
         if (v == 0.0d) v = 0.0d;
@@ -532,7 +532,7 @@ public abstract class NumberDataType extends DataType
              ((v > 0) && (v < Limits.DB2_SMALLEST_POSITIVE_DOUBLE)) ||
              ((v < 0) && (v > Limits.DB2_LARGEST_NEGATIVE_DOUBLE)) )
         {
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.DOUBLE_NAME);
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.DOUBLE_NAME, (String)null);
         }
         // Normalize negative doubles to be "positive" (can't detect easily without using Double object because -0.0f = 0.0f)
         if (v == 0.0d) v = 0.0d;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLBoolean.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLBoolean.java
@@ -1265,12 +1265,12 @@ public final class SQLBoolean
           return true;
         default:
           throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION,
-              TypeId.BOOLEAN_NAME);
+              TypeId.BOOLEAN_NAME, (String)null);
       }
     }
     else {
       throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION,
-          TypeId.BOOLEAN_NAME);
+          TypeId.BOOLEAN_NAME, (String)null);
     }
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLChar.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLChar.java
@@ -339,7 +339,7 @@ public class SQLChar
         catch (NumberFormatException nfe) 
         {
             throw StandardException.newException(
-                    SQLState.LANG_FORMAT_EXCEPTION, "byte");
+                    SQLState.LANG_FORMAT_EXCEPTION, "byte", (String)null);
         }
     }
 
@@ -366,7 +366,7 @@ public class SQLChar
         catch (NumberFormatException nfe) 
         {
             throw StandardException.newException(
-                    SQLState.LANG_FORMAT_EXCEPTION, "short");
+                    SQLState.LANG_FORMAT_EXCEPTION, "short", (String)null);
         }
     }
 
@@ -393,7 +393,7 @@ public class SQLChar
         {
           // GemStone changes BEGIN
           throw StandardException.newException(
-              SQLState.LANG_FORMAT_EXCEPTION, "int (" + nfe.getMessage() + ")");
+              SQLState.LANG_FORMAT_EXCEPTION, "int (" + nfe.getMessage() + ")", (String)null);
             /*(original code) throw StandardException.newException(
                     SQLState.LANG_FORMAT_EXCEPTION, "int");*/
           // GemStone changes END
@@ -423,7 +423,7 @@ public class SQLChar
         catch (NumberFormatException nfe) 
         {
             throw StandardException.newException(
-                    SQLState.LANG_FORMAT_EXCEPTION, "long");
+                    SQLState.LANG_FORMAT_EXCEPTION, "long", (String)null);
         }
     }
 
@@ -449,7 +449,7 @@ public class SQLChar
         catch (NumberFormatException nfe) 
         {
             throw StandardException.newException(
-                    SQLState.LANG_FORMAT_EXCEPTION, "float");
+                    SQLState.LANG_FORMAT_EXCEPTION, "float", (String)null);
         }
     }
 
@@ -475,7 +475,7 @@ public class SQLChar
         catch (NumberFormatException nfe) 
         {
             throw StandardException.newException(
-                    SQLState.LANG_FORMAT_EXCEPTION, "double");
+                SQLState.LANG_FORMAT_EXCEPTION, "double", (String)null);
         }
     }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLDecimal.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLDecimal.java
@@ -516,7 +516,7 @@ public final class SQLDecimal extends NumberDataType implements VariableSizeData
 		} catch (StandardException se) {
 		}
 
-		throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+		throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER", (String)null);
 	}
 
 	/**
@@ -536,7 +536,7 @@ public final class SQLDecimal extends NumberDataType implements VariableSizeData
 		} catch (StandardException se) {
 		}
 
-		throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+		throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT", (String)null);
 	}
         
         
@@ -558,7 +558,7 @@ public final class SQLDecimal extends NumberDataType implements VariableSizeData
 		} catch (StandardException se) {
 		}
 
-		throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+		throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT", (String)null);
 	}
 
 	/**
@@ -592,7 +592,7 @@ public final class SQLDecimal extends NumberDataType implements VariableSizeData
                         return localValue.longValue();
                 }
 
-                throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+                throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT", (String)null);
         }
 
 	/**
@@ -1512,7 +1512,7 @@ public final class SQLDecimal extends NumberDataType implements VariableSizeData
 			((desiredPrecision - desiredScale) <  SQLDecimal.getWholeDigits(getBigDecimal())))
 		{
 			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, 
-									("DECIMAL/NUMERIC("+desiredPrecision+","+desiredScale+")"));
+									("DECIMAL/NUMERIC("+desiredPrecision+","+desiredScale+")"), (String)null);
 		}
 		value = value.setScale(desiredScale, BigDecimal.ROUND_DOWN);
 		rawData = null;
@@ -1579,7 +1579,7 @@ public final class SQLDecimal extends NumberDataType implements VariableSizeData
 			try {
 				return new BigDecimal(value.getString().trim());
 			} catch (NumberFormatException nfe) {
-				throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, "java.math.BigDecimal");
+				throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, "java.math.BigDecimal", (String)null);
 			}
 		case Types.BIGINT:
 			return BigDecimal.valueOf(value.getLong());

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLDouble.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLDouble.java
@@ -115,7 +115,7 @@ public final class SQLDouble extends NumberDataType
 	{
 	    // REMIND: do we want to check for truncation?
 		if ((value > (((double) Integer.MAX_VALUE) + 1.0d)) || (value < (((double) Integer.MIN_VALUE) - 1.0d)))
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER", (String)null);
 		return (int)value;
 	}
 
@@ -125,7 +125,7 @@ public final class SQLDouble extends NumberDataType
 	public byte	getByte() throws StandardException
 	{
           if ((this.value > (((double) Byte.MAX_VALUE) + 1.0d)) || (this.value < (((double) Byte.MIN_VALUE) - 1.0d)))
-            throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+            throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT", (String)null);
           return (byte) value;
 	}
         
@@ -136,7 +136,7 @@ public final class SQLDouble extends NumberDataType
 	public short	getShort() throws StandardException
 	{
 		if ((value > (((double) Short.MAX_VALUE) + 1.0d)) || (value < (((double) Short.MIN_VALUE) - 1.0d)))
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT", (String)null);
 		return (short) value;
 	}
 
@@ -146,7 +146,7 @@ public final class SQLDouble extends NumberDataType
 	public long	getLong() throws StandardException
 	{
 		if ((value > (((double) Long.MAX_VALUE) + 1.0d)) || (value < (((double) Long.MIN_VALUE) - 1.0d)))
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT", (String)null);
 		return (long) value;
 	}
 
@@ -156,7 +156,7 @@ public final class SQLDouble extends NumberDataType
 	public float	getFloat() throws StandardException
 	{
 		if (Float.isInfinite((float)value))
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME);
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME, (String)null);
 		return (float) value;
 	}
 
@@ -750,7 +750,7 @@ public final class SQLDouble extends NumberDataType
 		double tempResult = leftValue * rightValue;
         // check underflow (result rounded to 0.0)
         if ( (tempResult == 0.0) && ( (leftValue != 0.0) && (rightValue != 0.0) ) ) {
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.DOUBLE_NAME);
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.DOUBLE_NAME, (String)null);
         }
 
 		result.setValue(tempResult);
@@ -808,7 +808,7 @@ public final class SQLDouble extends NumberDataType
 
         // check underflow (result rounded to 0.0d)
         if ((divideResult == 0.0d) && (dividendValue != 0.0d)) {
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.DOUBLE_NAME);
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.DOUBLE_NAME, (String)null);
         }
 
 		result.setValue(divideResult);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLInteger.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLInteger.java
@@ -100,7 +100,7 @@ public final class SQLInteger
 	public byte	getByte() throws StandardException
 	{
           if (this.value > Byte.MAX_VALUE || this.value < Byte.MIN_VALUE)
-            throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+            throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT", (String)null);
           return (byte) value;
 	}
         
@@ -110,7 +110,7 @@ public final class SQLInteger
 	public short	getShort() throws StandardException
 	{
 		if (value > Short.MAX_VALUE || value < Short.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT", (String)null);
 		return (short) value;
 	}
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLLongint.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLLongint.java
@@ -111,7 +111,7 @@ public final class SQLLongint
 		/* This value is bogus if the SQLLongint is null */
 
 		if (value > Integer.MAX_VALUE || value < Integer.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER", (String)null);
 		return (int) value;
 	}
 
@@ -121,7 +121,7 @@ public final class SQLLongint
 	public byte	getByte() throws StandardException
 	{
 		if (value > Byte.MAX_VALUE || value < Byte.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT", (String)null);
 		return (byte) value;
 	}
         
@@ -133,7 +133,7 @@ public final class SQLLongint
 	public short	getShort() throws StandardException
 	{
 		if (value > Short.MAX_VALUE || value < Short.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT", (String)null);
 		return (short) value;
 	}
 
@@ -432,7 +432,7 @@ public final class SQLLongint
 
 		if (theValue > Long.MAX_VALUE
 			|| theValue < Long.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT", (String)null);
 
 		float floorValue = (float)Math.floor(theValue);
 
@@ -451,7 +451,7 @@ public final class SQLLongint
 
 		if (theValue > Long.MAX_VALUE
 			|| theValue < Long.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT", (String)null);
 
 		double floorValue = Math.floor(theValue);
 
@@ -679,7 +679,7 @@ public final class SQLLongint
 			*/
 			if ((addend1Long < 0) != (resultValue < 0))
 			{
-				throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+				throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT", (String)null);
 			}
 		}
 		result.setValue(resultValue);
@@ -734,7 +734,7 @@ public final class SQLLongint
 			*/
 			if ((left.getLong() < 0) != (diff < 0))
 			{
-				throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+				throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT", (String)null);
 			}
 		}
 
@@ -785,7 +785,7 @@ public final class SQLLongint
 		tempResult = left.getLong() * right.getLong();
 		if ((right.getLong() != 0) && (left.getLong() != tempResult / right.getLong()))
 		{
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT", (String)null);
 		}
 
 		result.setValue(tempResult);
@@ -898,7 +898,7 @@ public final class SQLLongint
 		*/
 		if (operandValue == Long.MIN_VALUE)
 		{
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT", (String)null);
 		}
 
 		result.setValue(-operandValue);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLReal.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLReal.java
@@ -117,7 +117,7 @@ public final class SQLReal
 	public int	getInt() throws StandardException
 	{
 		if ((value > (((double) Integer.MAX_VALUE + 1.0d))) || (value < (((double) Integer.MIN_VALUE) - 1.0d)))
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER", (String)null);
 		return (int) value;
 	}
 
@@ -128,7 +128,7 @@ public final class SQLReal
 	public byte	getByte() throws StandardException
 	{
 		if ((value > (((double) Byte.MAX_VALUE + 1.0d))) || (value < (((double) Byte.MIN_VALUE) - 1.0d)))
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT", (String)null);
 		return (byte) value;
 	}
 
@@ -139,7 +139,7 @@ public final class SQLReal
 	public short	getShort() throws StandardException
 	{
 		if ((value > (((double) Short.MAX_VALUE + 1.0d))) || (value < (((double) Short.MIN_VALUE) - 1.0d)))
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT", (String)null);
 		return (short) value;
 	}
 
@@ -150,7 +150,7 @@ public final class SQLReal
 	public long	getLong() throws StandardException
 	{
 		if ((value > (((double) Long.MAX_VALUE + 1.0d))) || (value < (((double) Long.MIN_VALUE) - 1.0d)))
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "BIGINT", (String)null);
 		return (long) value;
 	}
 
@@ -470,7 +470,7 @@ public final class SQLReal
 		float fv = (float) theValue;
         // detect rounding taking place at cast time
         if (fv == 0.0f && theValue != 0.0d) {
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME);
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME, (String)null);
         }
         setValue(fv);
 	}
@@ -768,7 +768,7 @@ public final class SQLReal
 		double tempResult = leftValue * rightValue;
         // check underflow (result rounded to 0.0)
         if ( (tempResult == 0.0) && ( (leftValue != 0.0) && (rightValue != 0.0) ) ) {
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME);
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME, (String)null);
         }
 
 		result.setValue(tempResult);
@@ -820,7 +820,7 @@ public final class SQLReal
 
         // check underflow (result rounded to 0.0)
         if ((resultValue == 0.0e0d) && (dividendValue != 0.0e0d)) {
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME);
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME, (String)null);
         }
 
 		result.setValue(resultValue);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLSmallint.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLSmallint.java
@@ -113,7 +113,7 @@ public final class SQLSmallint
 	public byte	getByte() throws StandardException
 	{
 		if (value > Byte.MAX_VALUE || value < Byte.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT", (String)null);
 		return (byte) value;
 	}
 
@@ -419,7 +419,7 @@ public final class SQLSmallint
 	public void setValue(int theValue) throws StandardException
 	{
 		if (theValue > Short.MAX_VALUE || theValue < Short.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT", (String)null);
 		value = (short)theValue;
 		isnull = false;
 	}
@@ -430,7 +430,7 @@ public final class SQLSmallint
 	public void setValue(long theValue) throws StandardException
 	{
 		if (theValue > Short.MAX_VALUE || theValue < Short.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT", (String)null);
 		value = (short)theValue;
 		isnull = false;
 	}
@@ -445,7 +445,7 @@ public final class SQLSmallint
 		theValue = NumberDataType.normalizeREAL(theValue);
 
 		if (theValue > Short.MAX_VALUE || theValue < Short.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT", (String)null);
 
 		float floorValue = (float)Math.floor(theValue);
 
@@ -463,7 +463,7 @@ public final class SQLSmallint
 		theValue = NumberDataType.normalizeDOUBLE(theValue);
 
 		if (theValue > Short.MAX_VALUE || theValue < Short.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT", (String)null);
 
 		double floorValue = Math.floor(theValue);
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLTimestamp.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLTimestamp.java
@@ -1141,7 +1141,7 @@ public final class SQLTimestamp extends DataType
             String state = se.getSQLState();
             if( state != null && state.length() > 0 && SQLState.LANG_DATE_RANGE_EXCEPTION.startsWith( state))
             {
-                throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TIMESTAMP");
+                throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TIMESTAMP", (String)null);
             }
             throw se;
         }
@@ -1238,7 +1238,7 @@ public final class SQLTimestamp extends DataType
             if( secondsDiff >= 0)
             {
                 if (ldiff >= Integer.MAX_VALUE)
-                    throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+                    throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER", (String)null);
                 // cal holds the time for time1
                 cal.add( Calendar.MONTH, (int) (ldiff + 1));
                 for(;;)
@@ -1252,7 +1252,7 @@ public final class SQLTimestamp extends DataType
             else
             {
                 if (ldiff <= Integer.MIN_VALUE)
-                    throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+                    throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER", (String)null);
                 // cal holds the time for time1
                 cal.add( Calendar.MONTH, (int) (ldiff - 1));
                 for(;;)
@@ -1273,7 +1273,7 @@ public final class SQLTimestamp extends DataType
             if( secondsDiff >= 0)
             {
                 if (ldiff >= Integer.MAX_VALUE)
-                    throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+                    throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER", (String)null);
                 // cal holds the time for time1
                 cal.add( Calendar.YEAR, (int) (ldiff + 1));
                 for(;;)
@@ -1287,7 +1287,7 @@ public final class SQLTimestamp extends DataType
             else
             {
                 if (ldiff <= Integer.MIN_VALUE)
-                    throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+                    throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER", (String)null);
                 // cal holds the time for time1
                 cal.add( Calendar.YEAR, (int) (ldiff - 1));
                 for(;;)

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLTinyint.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLTinyint.java
@@ -397,7 +397,7 @@ public final class SQLTinyint
 	public void setValue(short theValue) throws StandardException
 	{
 		if (theValue > Byte.MAX_VALUE || theValue < Byte.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT", (String)null);
 		value = (byte)theValue;
 		isnull = false;
 	}
@@ -408,7 +408,7 @@ public final class SQLTinyint
 	public void setValue(int theValue) throws StandardException
 	{
 		if (theValue > Byte.MAX_VALUE || theValue < Byte.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT", (String)null);
 		value = (byte)theValue;
 		isnull = false;
 	}
@@ -419,7 +419,7 @@ public final class SQLTinyint
 	public void setValue(long theValue) throws StandardException
 	{
 		if (theValue > Byte.MAX_VALUE || theValue < Byte.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT", (String)null);
 		value = (byte)theValue;
 		isnull = false;
 	}
@@ -434,7 +434,7 @@ public final class SQLTinyint
 		theValue = NumberDataType.normalizeREAL(theValue);
 
 		if (theValue > Byte.MAX_VALUE || theValue < Byte.MIN_VALUE)
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT", (String)null);
 
 		float floorValue = (float)Math.floor(theValue);
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/ConnectionChild.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/ConnectionChild.java
@@ -206,6 +206,10 @@ abstract class ConnectionChild {
 	SQLException newSQLException(String messageId, Object arg1, Object arg2) {
 		return localConn.newSQLException(messageId, arg1, arg2);
 	}
+	SQLException newSQLException(String messageId, Object arg1,
+	    Object arg2, Object arg3) {
+	  return Util.generateCsSQLException(messageId, arg1, arg2, arg3);
+	}
 }
 
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedCallableStatement20.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedCallableStatement20.java
@@ -1193,7 +1193,7 @@ public abstract class EmbedCallableStatement20
 
             default:
                 throw newSQLException(SQLState.LANG_DATA_TYPE_GET_MISMATCH, 
-                        "java.io.Reader", Util.typeName(paramType));
+                        "java.io.Reader", Util.typeName(paramType), parameterIndex);
         } 
         // Update wasNull. 
         wasNull = (reader == null);
@@ -1221,7 +1221,7 @@ public abstract class EmbedCallableStatement20
                 break;
             default:
                 throw newSQLException(SQLState.LANG_DATA_TYPE_GET_MISMATCH, 
-                        "java.io.InputStream", Util.typeName(paramType));
+                        "java.io.InputStream", Util.typeName(paramType), parameterIndex);
         }
 
         boolean pushStack = false;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedPreparedStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedPreparedStatement.java
@@ -853,7 +853,7 @@ public abstract class EmbedPreparedStatement
         */
         if (!lengthLess && length > Integer.MAX_VALUE)
                throw newSQLException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE,
-                                     getParameterSQLType(parameterIndex));
+                                     getParameterSQLType(parameterIndex), parameterIndex);
 
         try {
             ReaderToUTF8Stream utfIn;
@@ -1014,7 +1014,7 @@ public abstract class EmbedPreparedStatement
         if ( !lengthLess && length > Integer.MAX_VALUE ) {
             throw newSQLException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE,
                getEmbedParameterSetMetaData().getParameterTypeName(
-                   parameterIndex));
+                   parameterIndex), parameterIndex);
         }
 
         try {
@@ -1075,7 +1075,7 @@ public abstract class EmbedPreparedStatement
      *  ignored if the parameter is not a user-defined type or REF
      * @exception SQLException if a database access error occurs or
      * this method is called on a closed <code>PreparedStatement</code>
-     * @exception SQLFeatureNotSupportedException if <code>sqlType</code> is
+     * @exception java.sql.SQLFeatureNotSupportedException if <code>sqlType</code> is
      * a <code>ARRAY</code>, <code>BLOB</code>, <code>CLOB</code>,
      * <code>DATALINK</code>, <code>JAVA_OBJECT</code>, <code>NCHAR</code>,
      * <code>NCLOB</code>, <code>NVARCHAR</code>, <code>LONGNVARCHAR</code>,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedResultSet.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedResultSet.java
@@ -5315,12 +5315,14 @@ public abstract class EmbedResultSet extends ConnectionChild
 
 	private final SQLException dataTypeConversion(String targetType, int column) {
 		return newSQLException(SQLState.LANG_DATA_TYPE_GET_MISMATCH, targetType,
-                getColumnSQLType(column));
+                getColumnSQLType(column),
+	        resultDescription.getColumnDescriptor(column).getName());
 	}
 
 	private final SQLException dataTypeConversion(int column, String targetType) {
 		return newSQLException(SQLState.LANG_DATA_TYPE_GET_MISMATCH,
-                getColumnSQLType(column), targetType);
+                getColumnSQLType(column), targetType,
+	        resultDescription.getColumnDescriptor(column).getName());
 	}
     
     /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedStatement.java
@@ -221,7 +221,8 @@ public class EmbedStatement extends ConnectionChild
 	      || SQLState.LANG_FORMAT_EXCEPTION.equals(msgId)) {
 	    // add column name to the exception message
 	    final Object[] args = se.getArguments();
-	    if (args != null && args.length == 1) {
+	    if (args != null && (args.length == 1 ||
+	        (args.length > 1 && args[1] == null))) {
 	      final Object[] newArgs = new Object[2];
 	      String colName = (columnName == null
 	          ? a.getCurrentColumnName() : columnName);
@@ -238,7 +239,8 @@ public class EmbedStatement extends ConnectionChild
 	      || SQLState.UNSUPPORTED_ENCODING.equals(msgId)) {
 	    // add column name to the exception message
 	    final Object[] args = se.getArguments();
-	    if (args != null && args.length == 2) {
+	    if (args != null && (args.length == 2 ||
+	        (args.length > 2 && args[2] == null))) {
 	      final Object[] newArgs = new Object[3];
 	      String colName = (columnName == null
 	          ? a.getCurrentColumnName() : columnName);
@@ -255,7 +257,8 @@ public class EmbedStatement extends ConnectionChild
 	      || SQLState.LANG_DATE_SYNTAX_EXCEPTION.equals(msgId)) {
 	    // add column name to the exception message
 	    final Object[] args = se.getArguments();
-	    if (args == null || args.length == 0) {
+	    if (args == null || (args.length == 0 ||
+	        (args.length > 0 && args[0] == null))) {
 	      final Object[] newArgs = new Object[1];
 	      String colName = (columnName == null
 	          ? a.getCurrentColumnName() : columnName);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericParameterValueSet.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericParameterValueSet.java
@@ -252,7 +252,7 @@ public final class GenericParameterValueSet implements ParameterValueSet
 
 				if (throwError) {
 					throw StandardException.newException(SQLState.LANG_DATA_TYPE_SET_MISMATCH, t,
-						ClassInspector.readableClassName(value.getClass()), gp.declaredClassName);
+						ClassInspector.readableClassName(value.getClass()), gp.declaredClassName, null);
 				}
 			}
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/CastNode.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/CastNode.java
@@ -480,7 +480,7 @@ public class CastNode extends ValueNode
 				}
 				else
 				{
-					throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, "boolean");
+					throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, "boolean", (String)null);
 				}
 
 			case Types.DATE:
@@ -514,7 +514,7 @@ public class CastNode extends ValueNode
 				catch (NumberFormatException nfe)
 				{
 					String sqlName = TypeId.getBuiltInTypeId(destJDBCTypeId).getSQLTypeName();
-					throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, sqlName);
+					throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, sqlName, (String)null);
 				}
 			case Types.REAL:
 				Float floatValue;
@@ -524,7 +524,7 @@ public class CastNode extends ValueNode
 				}
 				catch (NumberFormatException nfe)
 				{
-					throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, "float");
+					throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, "float", (String)null);
 				}
 				return (ValueNode) getNodeFactory().getNode(
 											C_NodeTypes.FLOAT_CONSTANT_NODE,
@@ -538,7 +538,7 @@ public class CastNode extends ValueNode
 				}
 				catch (NumberFormatException nfe)
 				{
-					throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, "double");
+					throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, "double", (String)null);
 				}
 				return (ValueNode) getNodeFactory().getNode(
 											C_NodeTypes.DOUBLE_CONSTANT_NODE,
@@ -587,7 +587,7 @@ public class CastNode extends ValueNode
 				if (longValue < Byte.MIN_VALUE ||
 					longValue > Byte.MAX_VALUE)
 				{
-					throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT");
+					throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT", (String)null);
 				}
 				return (ValueNode) getNodeFactory().getNode(
 										C_NodeTypes.TINYINT_CONSTANT_NODE,
@@ -598,7 +598,7 @@ public class CastNode extends ValueNode
 				if (longValue < Short.MIN_VALUE ||
 					longValue > Short.MAX_VALUE)
 				{
-					throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SHORT");
+					throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SHORT", (String)null);
 				}
 				return (ValueNode) getNodeFactory().getNode(
 											C_NodeTypes.SMALLINT_CONSTANT_NODE,
@@ -610,7 +610,7 @@ public class CastNode extends ValueNode
 				if (longValue < Integer.MIN_VALUE ||
 					longValue > Integer.MAX_VALUE)
 				{
-					throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER");
+					throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER", (String)null);
 				}
 				return (ValueNode) getNodeFactory().getNode(
 												C_NodeTypes.INT_CONSTANT_NODE,
@@ -627,7 +627,7 @@ public class CastNode extends ValueNode
 			case Types.REAL:
 				if (Math.abs(longValue) > Float.MAX_VALUE)
 				{
-					throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "REAL");
+					throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "REAL", (String)null);
 				}
 				return (ValueNode) getNodeFactory().getNode(
 											C_NodeTypes.FLOAT_CONSTANT_NODE,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/MethodCallNode.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/MethodCallNode.java
@@ -982,7 +982,7 @@ abstract class MethodCallNode extends JavaValueNode
         			
         			if (!type.equals(rsType))
         				throw StandardException.newException(SQLState.LANG_DATA_TYPE_GET_MISMATCH, 
-                				type, rsType);
+                				type, rsType, (String)null);
 
         			if (signatureTypes.length == signature.length)
         			{
@@ -1023,7 +1023,7 @@ abstract class MethodCallNode extends JavaValueNode
 				}
 			}
         	throw StandardException.newException(SQLState.LANG_DATA_TYPE_GET_MISMATCH, 
-        				type, paramTypeId.getSQLTypeName()); // type conversion error
+        				type, paramTypeId.getSQLTypeName(), (String)null); // type conversion error
         }
         
         // Did signature end with trailing comma?

--- a/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
+++ b/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
@@ -2184,7 +2184,7 @@ public class SQLParser
 		  return i;
 		} catch (Exception e) {
 			throw StandardException.newException
-			  (SQLState.LANG_FORMAT_EXCEPTION, TypeId.INTEGER_NAME);
+			  (SQLState.LANG_FORMAT_EXCEPTION, TypeId.INTEGER_NAME, (String)null);
 		}
 	}
 
@@ -2195,7 +2195,7 @@ public class SQLParser
 		  return l;
 		} catch (Exception e) {
 			throw StandardException.newException
-			  (SQLState.LANG_FORMAT_EXCEPTION, TypeId.LONGINT_NAME);
+			  (SQLState.LANG_FORMAT_EXCEPTION, TypeId.LONGINT_NAME, (String)null);
 		}
 	}
 
@@ -14576,7 +14576,7 @@ numericLiteral(String sign) throws StandardException :
 		}
 		catch (NumberFormatException nfe)
 		{
-			throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME);
+			throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME, (String)null);
 		}
 
 		double dv = doubleValue.doubleValue();

--- a/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/thrift/common/Converters.java
+++ b/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/thrift/common/Converters.java
@@ -2595,7 +2595,8 @@ public abstract class Converters {
   public static final SQLException newTypeConversionException(
       String sourceType, String targetType, Throwable cause) {
     return ThriftExceptionUtil.newSQLException(
-        SQLState.LANG_DATA_TYPE_GET_MISMATCH, cause, sourceType, targetType);
+        SQLState.LANG_DATA_TYPE_GET_MISMATCH, cause, sourceType,
+        targetType, null);
   }
 
   public static final SQLException newTypeConversionException(


### PR DESCRIPTION
As noted in SNAP-607 one of the issues is an AssertFailure on missing arguments in exception message causing the actual message to get hidden. The second is root cause of the failure itself. These changes largely deal for former while latter is mainly dealt by the corresponding PR on snappydata.
- setting the columnName explicitly to either a proper value or an explicit null for all call points of these SQLStates for which we dynamically fill in the columnName later (in EmbedStatement.fillInColumnName and SqlException.getSQLException): LANG_OUTSIDE_RANGE_FOR_DATATYPE, LANG_FORMAT_EXCEPTION, LANG_DATA_TYPE_GET_MISMATCH, LANG_DATA_TYPE_SET_MISMATCH, UNSUPPORTED_ENCODING, LANG_DATE_RANGE_EXCEPTION, LANG_DATE_SYNTAX_EXCEPTION
- simplify the handling of splitting into groups of 8 to just use /8 and %8. This matches with changes in the corresponding PR on snappydata.
