### PR TITLE
Snap 593

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DHMBase64Serializer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DHMBase64Serializer.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2010-2015 Pivotal Software, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.pivotal.gemfirexd.internal.engine.map;
+
+import com.google.common.hash.Hashing;
+
+/**
+ * Tries to compress key with base64 encoding assuming ascii characters only,
+ * in other words, assuming [a-z][A-Z][0-9] and [.*,- ] special characters only.
+ * <p/>
+ * note: one cannot have escape character '\' as well. only dot, asterik,
+ * hyphen, comma and space characters are allowed. Other characters appear as
+ * space and won't match different impls of {@code getHashCode} and {@code equals} methods.
+ */
+class DHMBase64Serializer implements DenseHashMapSerializer<String> {
+
+  private static final boolean DEBUGDEBUG = false;
+
+  private static final int VALUE_WIDTH = 1;
+  private static final int MAX_VALUE;
+
+  static {
+    int max = 0;
+    for (int i = 0; i < VALUE_WIDTH; i++)
+      max |= (1 << VALUE_WIDTH * 8);
+    MAX_VALUE = max - 1;
+  }
+
+  //FNV-1a hash
+  private final long addToHash(char c, long hash) {
+    return (int)((hash ^ (int)c) * 16777619);
+  }
+
+  protected long baseHashValue() {
+    return 2166136261L;
+  }
+
+  @Override
+  public boolean equals(String key, byte[] entry) {
+
+    for (int i = 0, j = 0, len = key.length(); j < len; i += 3) {
+
+      int val = ((entry[i] & 0xff) >>> 2) & 0x00ff;
+      char c = decodedChar(val); // 6 bits
+      char t = key.charAt(j++);
+      if (t != c) {
+        return false;
+      }
+
+      if (i + 1 >= len) break;
+
+      val = (((entry[i] & 0xff) << 6) & 0x00ff) >>> 2;
+      val = (byte)(val | (byte)((entry[i + 1] & 0xff) >> 4)); // 2 bits + 4 bits
+      c = decodedChar(val);
+      t = key.charAt(j++);
+      if (t != c) {
+        return false;
+      }
+
+      if (i + 2 >= len) break;
+
+      val = (((entry[i + 1] & 0xff) << 4) & 0x00ff) >>> 2;
+      val = (byte)(val | ((entry[i + 2] & 0xff) >>> 6) & 0x00ff); // 4 bits + 2 bits
+      c = decodedChar(val);
+      t = key.charAt(j++);
+      if (t != c) {
+        return false;
+      }
+
+      val = (((entry[i + 2] & 0xff) << 2) & 0x00ff) >> 2; // 6 bits
+      c = decodedChar(val);
+      t = key.charAt(j++);
+      if (t != c) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public boolean equals(byte[] entry1, byte[] entry2) {
+
+    if (entry1.length - VALUE_WIDTH != entry2.length - VALUE_WIDTH) {
+      return false;
+    }
+
+    for (int i = 0, len = entry1.length; i < len; i++) {
+      if (entry1[i] != entry2[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public int deserializeValue(byte[] entry) {
+    return MAX_VALUE & DenseIntValueHashMap.readInt(entry, entry.length - VALUE_WIDTH, VALUE_WIDTH);
+  }
+
+  @Override
+  public int getHashCode(String key) {
+
+    final int keyLen = key.length();
+
+    long hash = baseHashValue();
+    for (int i = 0; i < keyLen; i++) {
+      hash = addToHash(key.charAt(i), hash);
+    }
+
+    //return Integer.rotateLeft((int)hash, 3);
+    return Hashing.murmur3_32().hashInt((int)hash).asInt();
+  }
+
+  @Override
+  public int getHashCode(byte[] entry) {
+    int len = entry.length - VALUE_WIDTH;
+    long hash = baseHashValue();
+
+    for (int i = 0; i < len; i += 3) {
+
+      int val = ((entry[i] & 0xff) >>> 2) & 0x00ff;
+      char c = decodedChar(val); // 6 bits
+
+      hash = addToHash(c, hash);
+
+
+      if (i + 1 >= len) break;
+
+      val = (((entry[i] & 0xff) << 6) & 0x00ff) >>> 2;
+      val = (byte)(val | (byte)((entry[i + 1] & 0xff) >> 4)); // 2 bits + 4 bits
+      c = decodedChar(val);
+
+      hash = addToHash(c, hash);
+
+      if (i + 2 >= len) break;
+
+      val = (((entry[i + 1] & 0xff) << 4) & 0x00ff) >>> 2;
+      val = (byte)(val | ((entry[i + 2] & 0xff) >>> 6) & 0x00ff); // 4 bits + 2 bits
+      c = decodedChar(val);
+      hash = addToHash(c, hash);
+
+
+      val = (((entry[i + 2] & 0xff) << 2) & 0x00ff) >> 2;
+      c = decodedChar(val);
+
+      hash = addToHash(c, hash);
+    }
+
+    //return Integer.rotateLeft((int)hash, 3);
+    return Hashing.murmur3_32().hashInt((int)hash).asInt();
+  }
+
+  @Override
+  public byte[] serialize(String key, int value) {
+
+    final int keyLen = key.length();
+
+    final int roundOfflen = (int)Math.ceil((6d * keyLen) / 8);
+
+    final byte[] tgtVal;
+    int beginWrite;
+
+    tgtVal = new byte[roundOfflen + VALUE_WIDTH];
+    beginWrite = 0;
+
+    for (int i = 0; i < keyLen; i += 4) {
+
+      int c = encodedIntVal(key.charAt(i));
+      writeToHigherNibble(tgtVal, beginWrite, (byte)c, 6); //byte-1
+
+      if (i + 1 >= keyLen) break;
+
+      c = encodedIntVal(key.charAt(i + 1));
+      writeToLowerNibble(tgtVal, beginWrite, (byte)c, 2); //byte-1
+
+      if (DEBUGDEBUG) {
+        String s1 = binString(tgtVal[beginWrite]);
+        System.out.println(s1);
+        String bit = s1.substring(0, 6);
+        int v1 = Integer.parseInt(bit, 2);
+        char c1 = decodedChar(v1);
+        assert c1 == key.charAt(i);
+      }
+
+      beginWrite++;
+      writeToHigherNibble(tgtVal, beginWrite, (byte)c, 4); //byte-2
+
+      if (i + 2 >= keyLen) break;
+
+      c = encodedIntVal(key.charAt(i + 2));
+      writeToLowerNibble(tgtVal, beginWrite, (byte)c, 4); //byte-2
+
+      if (DEBUGDEBUG) {
+        String s1 = binString(tgtVal[beginWrite - 1]);
+        String s2 = binString(tgtVal[beginWrite]);
+        System.out.println(s2);
+        String bit = s1.substring(6, 8) + s2.substring(0, 4);
+        int v2 = Integer.parseInt(bit, 2);
+        char c2 = decodedChar(v2);
+        assert c2 == key.charAt(i + 1);
+      }
+
+      beginWrite++;
+      writeToHigherNibble(tgtVal, beginWrite, (byte)c, 2); //byte-3
+
+      if (i + 3 >= keyLen) break;
+
+      c = encodedIntVal(key.charAt(i + 3));
+      writeToLowerNibble(tgtVal, beginWrite, (byte)c, 6); //byte-3
+
+      if (DEBUGDEBUG) {
+        String s2 = binString(tgtVal[beginWrite - 1]);
+        String s3 = binString(tgtVal[beginWrite]);
+        System.out.println(s3);
+        int v3 = Integer.parseInt(s2.substring(4, 8) + s3.substring(0, 2), 2);
+        char c3 = decodedChar(v3);
+        assert c3 == key.charAt(i + 2);
+
+        int v4 = Integer.parseInt(s3.substring(2, 8), 2);
+        char c4 = decodedChar(v4);
+        assert c4 == key.charAt(i + 3);
+
+        System.out.println();
+      }
+
+      beginWrite++;
+
+    }
+
+    assert value <= MAX_VALUE : value + " " + MAX_VALUE;
+    assert beginWrite + VALUE_WIDTH == tgtVal.length;
+
+    assert equals(key, tgtVal);
+
+    DenseIntValueHashMap.writeInt(tgtVal, value, beginWrite, VALUE_WIDTH);
+
+    return tgtVal;
+  }
+
+  private String binString(byte b) {
+    String s = Integer.toBinaryString(b);
+    if (s.length() < 8) {
+      int pad = 8 - s.length();
+      for (int i = 0; i < pad; i++) {
+        s = "0" + s;
+      }
+    }
+    return s.substring(s.length() - 8, s.length());
+  }
+
+  private static final void writeToHigherNibble(final byte[] encode, final int offset, final byte c, final int numBits) {
+    encode[offset] = (byte)(c << (8 - numBits));
+  }
+
+  private static final void writeToLowerNibble(final byte[] encode, final int offset, final byte c, final int numBits) {
+    encode[offset] = (byte)(encode[offset] | (byte)(c >>> (6 - numBits)));
+  }
+
+  private static final int encodedIntVal(final char ch) {
+    int chaVal = 0;
+    // @formatter:off
+    switch(ch){
+      case' ':chaVal=0;break; case'a':chaVal=1;break;
+      case'b':chaVal=2;break; case'c':chaVal=3;break;
+      case'd':chaVal=4;break; case'e':chaVal=5;break;
+      case'f':chaVal=6;break; case'g':chaVal=7;break;
+      case'h':chaVal=8;break; case'i':chaVal=9;break;
+      case'j':chaVal=10;break; case'k':chaVal=11;break;
+      case'l':chaVal=12;break; case'm':chaVal=13;break;
+      case'n':chaVal=14;break; case'o':chaVal=15;break;
+      case'p':chaVal=16;break; case'q':chaVal=17;break;
+      case'r':chaVal=18;break; case's':chaVal=19;break;
+      case't':chaVal=20;break; case'u':chaVal=21;break;
+      case'v':chaVal=22;break; case'w':chaVal=23;break;
+      case'x':chaVal=24;break; case'y':chaVal=25;break;
+      case'z':chaVal=26;break; case'.':chaVal=27;break;
+      case'*':chaVal=28;break; case',':chaVal=29;break;
+      case'-':chaVal=30;break; case'2':chaVal=31;break;
+      case'A':chaVal=32;break; case'B':chaVal=33;break;
+      case'C':chaVal=34;break; case'D':chaVal=35;break;
+      case'E':chaVal=36;break; case'F':chaVal=37;break;
+      case'G':chaVal=38;break; case'H':chaVal=39;break;
+      case'I':chaVal=40;break; case'J':chaVal=41;break;
+      case'K':chaVal=42;break; case'L':chaVal=43;break;
+      case'M':chaVal=44;break; case'N':chaVal=45;break;
+      case'O':chaVal=46;break; case'P':chaVal=47;break;
+      case'Q':chaVal=48;break; case'R':chaVal=49;break;
+      case'S':chaVal=50;break; case'T':chaVal=51;break;
+      case'U':chaVal=52;break; case'V':chaVal=53;break;
+      case'W':chaVal=54;break; case'0':chaVal=55;break;
+      case'1':chaVal=56;break; case'3':chaVal=57;break;
+      case'4':chaVal=58;break;case'5':chaVal=59;break;
+      case'6':chaVal=60;break;case'7':chaVal=61;break;
+      case'8':chaVal=62;break;case'9':chaVal=63;break;
+      default:chaVal=0;
+    }
+    // @formatter:on
+    return chaVal;
+  }
+
+  char decodedChar(int val) {
+    char ch = ' ';
+    // @formatter:off
+    switch(val){
+      case 0:ch=' ';break; case 1:ch='a';break;
+      case 2:ch='b';break; case 3 :ch='c';break;
+      case 4:ch='d';break; case 5 :ch='e';break;
+      case 6:ch='f';break; case 7 :ch='g';break;
+      case 8:ch='h';break; case 9 :ch='i';break;
+      case 10:ch='j';break; case 11:ch='k';break;
+      case 12:ch='l';break; case 13:ch='m';break;
+      case 14:ch='n';break; case 15:ch='o';break;
+      case 16:ch='p';break; case 17:ch='q';break;
+      case 18:ch='r';break; case 19:ch='s';break;
+      case 20:ch='t';break; case 21:ch='u';break;
+      case 22:ch='v';break; case 23:ch='w';break;
+      case 24:ch='x';break; case 25:ch='y';break;
+      case 26:ch='z';break; case 27:ch='.';break;
+      case 28:ch='*';break; case 29:ch=',';break;
+      case 30:ch='-';break; case 31 :ch='2';break;
+      case 32:ch='A';break; case 33:ch='B';break;
+      case 34:ch='C';break; case 35:ch='D';break;
+      case 36:ch='E';break; case 37:ch='F';break;
+      case 38:ch='G';break; case 39:ch='H';break;
+      case 40:ch='I';break; case 41:ch='J';break;
+      case 42:ch='K';break; case 43:ch='L';break;
+      case 44:ch='M';break; case 45:ch='N';break;
+      case 46:ch='O';break; case 47:ch='P';break;
+      case 48:ch='Q';break; case 49:ch='R';break;
+      case 50:ch='S';break; case 51:ch='T';break;
+      case 52:ch='U';break; case 53:ch='V';break;
+      case 54:ch='W';break; case 55:ch='0';break;
+      case 56:ch='1';break; case 57:ch='3';break;
+      case 58:ch='4';break; case 59:ch='5';break;
+      case 60:ch='6';break; case 61:ch='7';break;
+      case 62:ch='8';break; case 63:ch='9';break;
+      default:ch=' ';
+    }
+    // @formatter:on
+    return ch;
+  }
+}
+

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DHMDefaultSerializer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DHMDefaultSerializer.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2010-2015 Pivotal Software, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.pivotal.gemfirexd.internal.engine.map;
+
+import com.google.common.hash.Hashing;
+
+/**
+ * Default serializer for {@link DenseIntValueHashMap}
+ * assumes 1 byte characters in key strings.
+ */
+public final class DHMDefaultSerializer implements DenseHashMapSerializer<String> {
+
+  private static final int VALUE_WIDTH = 1;
+
+  //FNV-1a hash
+  private final long addToHash(char c, long hash) {
+    return (int)((hash ^ (int)c) * 16777619);
+  }
+
+  protected long baseHashValue() {
+    return 2166136261L;
+  }
+
+  @Override
+  public boolean equals(String key, byte[] entry) {
+
+    for (int i = 0, len = key.length(); i < len; i++) {
+      if (key.charAt(i) != entry[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public boolean equals(byte[] entry1, byte[] entry2) {
+
+    if (entry1.length != entry2.length - VALUE_WIDTH) {
+      return false;
+    }
+
+    for (int i = 0, len = entry1.length; i < len; i++) {
+      if (entry1[i] != entry2[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public int deserializeValue(byte[] entry) {
+    return DenseIntValueHashMap.readInt(entry, entry.length - VALUE_WIDTH, VALUE_WIDTH);
+  }
+
+  @Override
+  public int getHashCode(String key) {
+
+    final int keyLen = key.length();
+
+    long hash = baseHashValue();
+    for (int i = 0; i < keyLen; i++) {
+      hash = addToHash(key.charAt(i), hash);
+    }
+
+    //return Integer.rotateLeft((int)hash, 3);
+    return Hashing.murmur3_32().hashInt((int)hash).asInt();
+  }
+
+  @Override
+  public int getHashCode(byte[] entry) {
+    int len = entry.length - VALUE_WIDTH;
+    long hash = baseHashValue();
+    for (int i = 0; i < len; i++) {
+      hash = addToHash((char)entry[i], hash);
+    }
+    //return Integer.rotateLeft((int)hash, 3);
+    return Hashing.murmur3_32().hashInt((int)hash).asInt();
+  }
+
+  @Override
+  public byte[] serialize(String key, int value) {
+
+    final int keyLen = key.length();
+
+    final byte[] tgtVal;
+    int beginWrite;
+
+    tgtVal = new byte[keyLen + VALUE_WIDTH];
+    beginWrite = 0;
+
+    for (int i = 0; i < keyLen; i++) {
+      tgtVal[beginWrite++] = (byte)key.charAt(i);
+    }
+
+    DenseIntValueHashMap.writeInt(tgtVal, value, beginWrite, VALUE_WIDTH);
+
+    return tgtVal;
+  }
+}

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DHMDefaultSerializer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DHMDefaultSerializer.java
@@ -39,7 +39,7 @@ public final class DHMDefaultSerializer implements DenseHashMapSerializer<String
   public boolean equals(String key, byte[] entry) {
 
     for (int i = 0, len = key.length(); i < len; i++) {
-      if (key.charAt(i) != entry[i]) {
+      if (key.charAt(i) != (char)entry[i]) {
         return false;
       }
     }
@@ -61,6 +61,16 @@ public final class DHMDefaultSerializer implements DenseHashMapSerializer<String
     }
 
     return true;
+  }
+
+  @Override
+  public String getKey(byte[] entry) {
+    int len = entry.length - VALUE_WIDTH;
+    char[] v = new char[len];
+    for (int i = 0; i < len; i++) {
+      v[i] = (char)entry[i];
+    }
+    return new String(v);
   }
 
   @Override

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DenseHashMapSerializer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DenseHashMapSerializer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2010-2015 Pivotal Software, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.pivotal.gemfirexd.internal.engine.map;
+
+/**
+ * An interface that serializes/deserializes key/value objects stored in {@link DenseIntValueHashMap}.
+ * The interface primarily attempts to reduce garbage by avoiding de-serialization of the key to the extent possible.
+ * Implementation of this must be stateless and immutable.
+ *
+ * @param <K> Any Java object as key.
+ */
+public interface DenseHashMapSerializer<K> {
+
+  /**
+   * Serialize a given (key, value) of a hashmap.
+   * <p/>
+   * note: length of the key is not required to be recorded due to
+   * fixed width value. (byte[].length - 4) will be key length, thus
+   * saves up to 4 bytes.
+   *
+   * @param key   key to be recorded
+   * @param value int value.
+   * @return serialized byte[]
+   */
+  byte[] serialize(K key, int value);
+
+  /**
+   * Returns hash code of the key object. This should be consistent with
+   * {@code equals} method.
+   *
+   * @param key the object supplied by the user.
+   * @return hash code of the key
+   */
+  int getHashCode(K key);
+
+  /**
+   * Returns the hash code of the key from an entry (byte[]) returned
+   * from {@code serialize} method. This should be consistent with
+   * {@code equals} method.
+   *
+   * @param entry
+   * @return
+   */
+  int getHashCode(byte[] entry);
+
+  /**
+   * Returns keys' equality.
+   *
+   * @param key   incoming user key object.
+   * @param entry byte[] returned using {@code serialize} method.
+   * @return boolean {@code true} if equal, {@code false} otherwise.
+   */
+  boolean equals(K key, byte[] entry);
+
+  /**
+   * Returns keys' equality. Mainly used during rehashing.
+   *
+   * @param entry1 first entry (byte[]) returned using {@code serialize} method.
+   * @param entry2 another entry (byte[]) returned using {@code serialize} method.
+   * @return boolean {@code true} if both entries are equal, {@code false} otherwise.
+   */
+  boolean equals(byte[] entry1, byte[] entry2);
+
+  /**
+   * Extract int value from the serialized entry.
+   *
+   * @param entry byte[] returnred from {@code serialize} method.
+   * @return int value stored earlier.
+   */
+  int deserializeValue(byte[] entry);
+}

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DenseHashMapSerializer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DenseHashMapSerializer.java
@@ -76,6 +76,14 @@ public interface DenseHashMapSerializer<K> {
   boolean equals(byte[] entry1, byte[] entry2);
 
   /**
+   * Mainly for debugging purposes, extract key from the serialized value.
+   *
+   * @param entry byte[] returned from {@code serialize} method.
+   * @return key value with K type.
+   */
+  K getKey(byte[] entry);
+
+  /**
    * Extract int value from the serialized entry.
    *
    * @param entry byte[] returnred from {@code serialize} method.

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DenseIntValueHashMap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DenseIntValueHashMap.java
@@ -24,73 +24,109 @@ import com.pivotal.gemfirexd.internal.engine.store.RowFormatter;
  * depends on {@link DenseHashMapSerializer} implementation. The interface offers
  * opportunity to avoid full key deserialization during hashCode computation, equal comparison
  * and rehashing.
- *
+ * <p/>
  * Per Entry overhead is 4 bytes (pointer to byte[]). Its by experiment found
  * the best put/get performance and memory usage tradeoff is achieved with simple key and fixed
  * width value serialization. A base64 encoded key (assuming ascii only) or multiple entries packed
  * together into a single entry (a.k.a separate chaining) did not yield much memory benefit whereas
  * performance was significantly effected. In fact, for separate chaining memory consumption increased due to
  * every entry length written consuming 4 more bytes.
- *
+ * <p/>
  * Concurrency is for the time being at Segment level. Number of segments by default is twice the number of
  * cpu cores and should be sufficient for parallelism. Per entry locking if required can
  * be done using a separate array with bit indicator for read/write (0 - Read, 1 - Write)
  * operation.
- *
+ * <p/>
  * This is based on open addressing and suffers usual primary clustering problem. This might show up
  * even more because of LoadFactor being 0.85 by default unlike 0.50 but compensates for it during expansion
  * which brings down the LoadFactor to 0.65. Due to sparsity of the byte[][] total memory consumed for 1 million
- * entries shows 12 bytes per entry overhead when measured using runtime memory usage.
- *
+ * entries shows 12 bytes per entry overhead when measured using runtime memory usage
+ * (computationally it has only 4 bytes overhead).
+ * <p/>
  * TODO:
  * a) Add segment level read/write lock.
- * b) Add #remove method.
- *
  */
 public class DenseIntValueHashMap<K> {
 
   private static final byte[] TOMBSTONE = new byte[0];
 
-  private static final int numSegments = Integer.getInteger("com.pivotal.gemfirexd.internal.engine.map.DenseIntValueHashMap.NUM_SEGMENTS", Runtime.getRuntime().availableProcessors() * 8);
-
   protected final DenseHashMapSerializer<K> serializer;
-
-  private int size = 0;
 
   private double loadFactor = 0.85f;
 
-  private DenseIntValueHashMap.Segment[] segments = new DenseIntValueHashMap.Segment[numSegments];
+  private final DenseIntValueHashMap.Segment[] segments;
+
+  public DenseIntValueHashMap() {
+    this(new DHMDefaultSerializer(), 32, -1);
+  }
+
+  public DenseIntValueHashMap(int initialCapacity) {
+    this(new DHMDefaultSerializer(), initialCapacity, -1);
+  }
+
+  public DenseIntValueHashMap(int initialCapacity,
+      int concurrency) {
+    this(new DHMDefaultSerializer(), initialCapacity, concurrency);
+  }
+
+  public DenseIntValueHashMap(DenseHashMapSerializer serializer) {
+    this(serializer, 32, -1);
+  }
 
   public DenseIntValueHashMap(DenseHashMapSerializer serializer,
       int initialCapacity) {
+    this(serializer, initialCapacity, -1);
+  }
+
+  public DenseIntValueHashMap(DenseHashMapSerializer serializer,
+      int initialCapacity,
+      int concurrency) {
 
     this.serializer = serializer;
+    if (concurrency <= 0) {
+      concurrency = Runtime.getRuntime().availableProcessors() * 8;
+    }
+    segments = new DenseIntValueHashMap.Segment[concurrency];
 
     int capacity = 1;
     // make capacity power of 2 instead of just taking a rounded off number.
     // a rounded off number isn't good for probing.
-    while(capacity < initialCapacity)
+    while (capacity < initialCapacity)
       capacity *= 2;
 
     for (int i = 0; i < segments.length; i++) {
-      segments[i] = new DenseIntValueHashMap.Segment(capacity);
+      segments[i] = new DenseIntValueHashMap.Segment(i, capacity);
     }
   }
 
-  public int size() {
-    return size;
+  public final int size() {
+    int sz = 0;
+    for (Segment s : segments) {
+      if (s != null) {
+        sz += s.size;
+      }
+    }
+    return sz;
   }
 
-  public int put(K key, int value) {
+  public void put(K key, int value) {
     int hash = serializer.getHashCode(key);
-    segments[hash & (segments.length - 1)].putEntry(key, hash, value);
-    size++;
-    return value;
+    segments[hash & (segments.length - 1)].putEntry(key, hash, value, false);
   }
 
-  public int get(Object key) {
+  public void putIfAbsent(K key, int value) {
+    int hash = serializer.getHashCode(key);
+    segments[hash & (segments.length - 1)].putEntry(key, hash, value, true);
+  }
+
+  public int get(K key) {
     int hash = serializer.getHashCode((K)key);
     return segments[hash & (segments.length - 1)].getEntry(key, hash);
+  }
+
+  public int remove(K key) {
+    int hash = serializer.getHashCode((K)key);
+    return segments[hash & (segments.length - 1)].removeEntry(key, hash);
   }
 
   public final static int readInt(byte[] kv, int offset, int numBytes) {
@@ -102,104 +138,37 @@ public class DenseIntValueHashMap<K> {
     RowFormatter.writeInt(kv, val, offset, numBytes);
   }
 
-  private final int probeLinear(final K key,
-      int keyHash, final byte[][] table,
-      final byte[] entry1,
-      final int numBits) {
-
-    assert key != null || entry1 != null : "key not supplied... ";
-
-    final boolean useIndexInTable = entry1 != null;
-
-    int maxOffset = table.length - 1;
-
-    final int hashCode = useIndexInTable ?
-        serializer.getHashCode(entry1) :
-        keyHash;
-
-    int index = hashCode & maxOffset;
-
-    byte[] entry2 = table[index];
-
-    if (entry2 == null) {
-      return index;
-    } else if (entry2 == TOMBSTONE) {
-      return index;
-    } else if (useIndexInTable) {
-      if (serializer.equals(entry1, entry2)) {
-        return index;
-      }
-    } else if (serializer.equals(key, entry2)) {
-      return index;
-    }
-
-    int stepValue = (hashCode >>> numBits) & maxOffset;
-    stepValue = stepValue > 0 ? stepValue : 1;
-    index = (index + stepValue) & maxOffset;
-
-    int beginIdx = index;
-    for (; ; ) {
-
-      entry2 = table[index];
-
-      if (entry2 == null) {
-        return index;
-      } else if (entry2 == TOMBSTONE) {
-        return index;
-      } else if (useIndexInTable) {
-        if (serializer.equals(entry1, entry2)) {
-          return index;
-        }
-      } else if (serializer.equals(key, entry2)) {
-        return index;
-      }
-
-      index = index + 1 & maxOffset;
-
-      assert (beginIdx != index) : "exhausted all the slots. This should have never happened.";
-    }
-  }
-
   private final class Segment {
 
+    private final int id;
     private byte[][] table; // a pair of key/value held here.
     private int size = 0;
     private int numBits;
+    private int numRehash = 0;
 
-    protected Segment(int initCapacity) {
+    protected Segment(int id, int initCapacity) {
+      this.id = id;
       table = new byte[initCapacity][];
       this.numBits = Integer.bitCount(initCapacity);
     }
 
-    private void putEntry(K key, final int keyHash, int value) {
+    private void putEntry(K key, final int keyHash, int value, boolean putIfAbsent) {
 
-      int index = probeLinear(key, keyHash, this.table, null, this.numBits);
+      int index = probeLinear(key, keyHash, this.table, null, this.numBits, true);
+
+      if (index < 0) {
+        if (putIfAbsent) {
+          return;
+        }
+        index = -index;
+      }
+
       table[index] = serializer.serialize(key, value);
-      size++;
+      if (index >= 0) {
+        size++;
+      }
 
       ensureCapacity();
-    }
-
-    private void ensureCapacity() {
-      if ((double)size / table.length > loadFactor) {
-        int newCapacity = table.length;
-        while ((double)size / newCapacity > (loadFactor-0.2))
-          newCapacity *= 2;
-
-        final byte[][] newTable = new byte[newCapacity][];
-        final int newNumBits = Integer.bitCount(newCapacity);
-
-        for (byte[] entry : table) {
-          if (entry == null) {
-            continue;
-          }
-          int index = probeLinear(null, -1, newTable, entry, newNumBits);
-          newTable[index] = entry;
-        }
-
-        this.table = newTable;
-        this.numBits = newNumBits;
-      }
     }
 
     private int getEntry(K key, int keyHash) {
@@ -207,11 +176,143 @@ public class DenseIntValueHashMap<K> {
       final byte[][] tab = this.table;
       final int numBits = this.numBits;
 
-      final int index = probeLinear(key, keyHash, tab, null, numBits);
+      int index = probeLinear(key, keyHash, tab, null, numBits, false);
+      if (index < 0) {
+        index = -index;
+      }
+
       return serializer.deserializeValue(tab[index]);
     }
 
-  }
+    public int removeEntry(K key, int keyHash) {
+      final byte[][] tab = this.table;
+      final int numBits = this.numBits;
+
+      int index = probeLinear(key, keyHash, tab, null, numBits, false);
+      if (index < 0) {
+        index = -index;
+      }
+
+      int retVal = serializer.deserializeValue(tab[index]);
+      tab[index] = TOMBSTONE;
+      size--;
+
+      reduceCapacity();
+
+      return retVal;
+    }
+
+    private final int probeLinear(final K key,
+        int keyHash, final byte[][] table,
+        final byte[] entry1,
+        final int numBits,
+        final boolean forInsert) {
+
+      assert key != null || entry1 != null : "key not supplied... ";
+
+      final boolean useIndexInTable = entry1 != null;
+
+      int maxOffset = table.length - 1;
+
+      final int hashCode = useIndexInTable ?
+          serializer.getHashCode(entry1) :
+          keyHash;
+
+      int index = hashCode & maxOffset;
+
+      byte[] entry2 = table[index];
+
+      if (entry2 == null) {
+        return index;
+      } else if (entry2 == TOMBSTONE) {
+        if(forInsert) {
+          return index;
+        }
+      } else if (useIndexInTable) {
+        if (serializer.equals(entry1, entry2)) {
+          return -index;
+        }
+      } else if (serializer.equals(key, entry2)) {
+        return -index;
+      }
+
+      int stepValue = (hashCode >>> numBits) & maxOffset;
+      stepValue = stepValue > 0 ? stepValue : 1;
+      index = (index + stepValue) & maxOffset;
+
+      int beginIdx = index;
+      for (; ; ) {
+
+        entry2 = table[index];
+
+        if (entry2 == null) {
+          return index;
+        } else if (entry2 == TOMBSTONE) {
+          if(forInsert) {
+            return index;
+          }
+        } else if (useIndexInTable) {
+          if (serializer.equals(entry1, entry2)) {
+            return -index;
+          }
+        } else if (serializer.equals(key, entry2)) {
+          return -index;
+        }
+
+        index = index + 1 & maxOffset;
+
+        assert (beginIdx != index) : "exhausted all the slots. This should have never happened.";
+      }
+    }
+
+    private void ensureCapacity() {
+      if ((double)size / table.length > loadFactor) {
+        int newCapacity = table.length;
+        // expand until loadFactor goes down 20% lesser than configured.
+        while ((double)size / newCapacity > (loadFactor - 0.2)) {
+          newCapacity *= 2;
+        }
+
+        rehash(newCapacity);
+      }
+    }
+
+    private void reduceCapacity() {
+      int length = table.length;
+      // are we dropping beyond 50% usage and 25% of loadFactor.
+      while (length >= 2 && (double)size / length < (loadFactor / 4) && size < (length / 2)) {
+        length /= 2;
+      }
+
+      if (length < table.length) {
+        rehash(length);
+      }
+    }
+
+    private final void rehash(final int newCapacity) {
+      numRehash++;
+      final byte[][] newTable = new byte[newCapacity][];
+      final int newNumBits = Integer.bitCount(newCapacity);
+
+      for (byte[] entry : table) {
+        if (entry == null || entry == TOMBSTONE) {
+          continue;
+        }
+        int index = probeLinear(null, -1, newTable, entry, newNumBits, false);
+//        System.out.println(numRehash + " id=" + id + ", key=" + serializer.getKey(entry) + " @ " + index);
+        newTable[index] = entry;
+      }
+
+      this.table = newTable;
+      this.numBits = newNumBits;
+    }
+
+    @Override
+    public String toString() {
+      return "Segment=" + id;
+    }
+
+  } // Segment
 
 
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DenseIntValueHashMap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DenseIntValueHashMap.java
@@ -66,8 +66,14 @@ public class DenseIntValueHashMap<K> {
 
     this.serializer = serializer;
 
+    int capacity = 1;
+    // make capacity power of 2 instead of just taking a rounded off number.
+    // a rounded off number isn't good for probing.
+    while(capacity < initialCapacity)
+      capacity *= 2;
+
     for (int i = 0; i < segments.length; i++) {
-      segments[i] = new DenseIntValueHashMap.Segment(initialCapacity);
+      segments[i] = new DenseIntValueHashMap.Segment(capacity);
     }
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DenseIntValueHashMap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DenseIntValueHashMap.java
@@ -33,18 +33,15 @@ import com.pivotal.gemfirexd.internal.engine.store.RowFormatter;
  * width value serialization. A base64 encoded key (assuming ascii only) or multiple entries packed
  * together into a single entry (a.k.a separate chaining) did not yield much memory benefit whereas
  * performance was significantly effected. In fact, for separate chaining memory consumption increased due to
- * every entry length written consuming 4 more bytes.
+ * length prefixed every entry consuming 4 more bytes.
  * <p/>
- * Concurrency is for the time being at Segment level. Number of segments by default is twice the number of
- * cpu cores and should be sufficient for parallelism. Per entry locking if required can
- * be done using a separate array with bit indicator for read/write (0 - Read, 1 - Write)
- * operation.
+ * Concurrency is at the Segment level. Number of segments by default is 8 times the number of
+ * cpu cores and should be sufficient for parallelism.
  * <p/>
  * This is based on open addressing and suffers usual primary clustering problem. This might show up
- * even more because of LoadFactor being 0.85 by default unlike 0.50 but compensates for it during expansion
+ * even more because of LoadFactor being 0.85 by default unlike proposed 0.50 but compensates for it during expansion
  * which brings down the LoadFactor to 0.65. Due to sparsity of the byte[][] total memory consumed for 1 million
- * entries shows 12 bytes per entry overhead when measured using runtime memory usage
- * (computationally it has only 4 bytes overhead).
+ * entries shows 12 bytes per entry overhead when measured using runtime memory usage.
  * <p/>
  */
 public class DenseIntValueHashMap<K> {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DenseIntValueHashMap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/map/DenseIntValueHashMap.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2010-2015 Pivotal Software, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.pivotal.gemfirexd.internal.engine.map;
+
+import com.pivotal.gemfirexd.internal.engine.store.RowFormatter;
+
+/**
+ * A compact hash map with any key object but only with int value.
+ * This avoids Integer object creation and key object deserialization
+ * depends on {@link DenseHashMapSerializer} implementation. The interface offers
+ * opportunity to avoid full key deserialization during hashCode computation, equal comparison
+ * and rehashing.
+ *
+ * Per Entry overhead is 4 bytes (pointer to byte[]). Its by experiment found
+ * the best put/get performance and memory usage tradeoff is achieved with simple key and fixed
+ * width value serialization. A base64 encoded key (assuming ascii only) or multiple entries packed
+ * together into a single entry (a.k.a separate chaining) did not yield much memory benefit whereas
+ * performance was significantly effected. In fact, for separate chaining memory consumption increased due to
+ * every entry length written consuming 4 more bytes.
+ *
+ * Concurrency is for the time being at Segment level. Number of segments by default is twice the number of
+ * cpu cores and should be sufficient for parallelism. Per entry locking if required can
+ * be done using a separate array with bit indicator for read/write (0 - Read, 1 - Write)
+ * operation.
+ *
+ * This is based on open addressing and suffers usual primary clustering problem. This might show up
+ * even more because of LoadFactor being 0.85 by default unlike 0.50 but compensates for it during expansion
+ * which brings down the LoadFactor to 0.65. Due to sparsity of the byte[][] total memory consumed for 1 million
+ * entries shows 12 bytes per entry overhead when measured using runtime memory usage.
+ *
+ * TODO:
+ * a) Add segment level read/write lock.
+ * b) Add #remove method.
+ *
+ */
+public class DenseIntValueHashMap<K> {
+
+  private static final byte[] TOMBSTONE = new byte[0];
+
+  private static final int numSegments = Integer.getInteger("com.pivotal.gemfirexd.internal.engine.map.DenseIntValueHashMap.NUM_SEGMENTS", Runtime.getRuntime().availableProcessors() * 8);
+
+  protected final DenseHashMapSerializer<K> serializer;
+
+  private int size = 0;
+
+  private double loadFactor = 0.85f;
+
+  private DenseIntValueHashMap.Segment[] segments = new DenseIntValueHashMap.Segment[numSegments];
+
+  public DenseIntValueHashMap(DenseHashMapSerializer serializer,
+      int initialCapacity) {
+
+    this.serializer = serializer;
+
+    for (int i = 0; i < segments.length; i++) {
+      segments[i] = new DenseIntValueHashMap.Segment(initialCapacity);
+    }
+  }
+
+  public int size() {
+    return size;
+  }
+
+  public int put(K key, int value) {
+    int hash = serializer.getHashCode(key);
+    segments[hash & (segments.length - 1)].putEntry(key, hash, value);
+    size++;
+    return value;
+  }
+
+  public int get(Object key) {
+    int hash = serializer.getHashCode((K)key);
+    return segments[hash & (segments.length - 1)].getEntry(key, hash);
+  }
+
+  public final static int readInt(byte[] kv, int offset, int numBytes) {
+    return RowFormatter.readInt(kv, offset, numBytes);
+  }
+
+  public final static void writeInt(byte[] kv, int val, int offset, int numBytes) {
+    assert val < 0xffff || numBytes != 2;
+    RowFormatter.writeInt(kv, val, offset, numBytes);
+  }
+
+  private final int probeLinear(final K key,
+      int keyHash, final byte[][] table,
+      final byte[] entry1,
+      final int numBits) {
+
+    assert key != null || entry1 != null : "key not supplied... ";
+
+    final boolean useIndexInTable = entry1 != null;
+
+    int maxOffset = table.length - 1;
+
+    final int hashCode = useIndexInTable ?
+        serializer.getHashCode(entry1) :
+        keyHash;
+
+    int index = hashCode & maxOffset;
+
+    byte[] entry2 = table[index];
+
+    if (entry2 == null) {
+      return index;
+    } else if (entry2 == TOMBSTONE) {
+      return index;
+    } else if (useIndexInTable) {
+      if (serializer.equals(entry1, entry2)) {
+        return index;
+      }
+    } else if (serializer.equals(key, entry2)) {
+      return index;
+    }
+
+    int stepValue = (hashCode >>> numBits) & maxOffset;
+    stepValue = stepValue > 0 ? stepValue : 1;
+    index = (index + stepValue) & maxOffset;
+
+    int beginIdx = index;
+    for (; ; ) {
+
+      entry2 = table[index];
+
+      if (entry2 == null) {
+        return index;
+      } else if (entry2 == TOMBSTONE) {
+        return index;
+      } else if (useIndexInTable) {
+        if (serializer.equals(entry1, entry2)) {
+          return index;
+        }
+      } else if (serializer.equals(key, entry2)) {
+        return index;
+      }
+
+      index = index + 1 & maxOffset;
+
+      assert (beginIdx != index) : "exhausted all the slots. This should have never happened.";
+    }
+  }
+
+  private final class Segment {
+
+    private byte[][] table; // a pair of key/value held here.
+    private int size = 0;
+    private int numBits;
+
+    protected Segment(int initCapacity) {
+      table = new byte[initCapacity][];
+      this.numBits = Integer.bitCount(initCapacity);
+    }
+
+    private void putEntry(K key, final int keyHash, int value) {
+
+      int index = probeLinear(key, keyHash, this.table, null, this.numBits);
+      table[index] = serializer.serialize(key, value);
+      size++;
+
+      ensureCapacity();
+    }
+
+    private void ensureCapacity() {
+      if ((double)size / table.length > loadFactor) {
+        int newCapacity = table.length;
+        while ((double)size / newCapacity > (loadFactor-0.2))
+          newCapacity *= 2;
+
+        final byte[][] newTable = new byte[newCapacity][];
+        final int newNumBits = Integer.bitCount(newCapacity);
+
+        for (byte[] entry : table) {
+          if (entry == null) {
+            continue;
+          }
+          int index = probeLinear(null, -1, newTable, entry, newNumBits);
+          newTable[index] = entry;
+        }
+
+        this.table = newTable;
+        this.numBits = newNumBits;
+      }
+    }
+
+    private int getEntry(K key, int keyHash) {
+
+      final byte[][] tab = this.table;
+      final int numBits = this.numBits;
+
+      final int index = probeLinear(key, keyHash, tab, null, numBits);
+      return serializer.deserializeValue(tab[index]);
+    }
+
+  }
+
+
+}

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/internal/engine/map/DHMTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/internal/engine/map/DHMTest.java
@@ -31,8 +31,8 @@ public class DHMTest extends TestCase {
 
   public void test1M() {
 
-    DenseIntValueHashMap<String> map = new DenseIntValueHashMap<>(new DHMDefaultSerializer(), 32);
-//    com.pivotal.gemfirexd.internal.engine.map.DenseIntValueHashMap<String> map = new com.pivotal.gemfirexd.internal.engine.map.DenseIntValueHashMap<>(new com.pivotal.gemfirexd.internal.engine.map.DHMBase64Serializer(), 32);
+    DenseIntValueHashMap<String> map = new DenseIntValueHashMap<>(new DHMDefaultSerializer(), 100);
+//    DenseIntValueHashMap<String> map = new DenseIntValueHashMap<>(new com.pivotal.gemfirexd.internal.engine.map.DHMBase64Serializer(), 32);
 //    HashMap<String, Integer> map = new HashMap<>(32);
 //    ConcurrentHashMap<String, Integer> map = new ConcurrentHashMap<>(32);
 //    TObjectIntHashMap map = new TObjectIntHashMap(32);

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/internal/engine/map/DHMTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/internal/engine/map/DHMTest.java
@@ -64,8 +64,8 @@ public class DHMTest extends TestCase {
     for (int i = 0; i < count; i++) {
       try {
         String k = UUID.randomUUID().toString();
-        map.put(k, i%113);
-        assert map.get(k) == i%113;
+        map.put(k, i % 113);
+        assert map.get(k) == i % 113;
         if (System.currentTimeMillis() - lastReport > 1000) {
           System.gc();
           System.gc();
@@ -99,10 +99,66 @@ public class DHMTest extends TestCase {
 
   }
 
+  public void test1MAddRemove() {
+
+    DenseIntValueHashMap<String> map = new DenseIntValueHashMap<>(new DHMDefaultSerializer(), 100);
+
+    final Random r = new Random(System.currentTimeMillis());
+
+    final int count = 1000000;
+    Runtime rt = Runtime.getRuntime();
+
+    //String[] keys = getStaticKeys(count);
+
+    System.out.println("populating keys");
+    StringBuilder sb = new StringBuilder("new String[] {");
+    String[] keys = new String[count];
+    for (int i = 0; i < count; i++) {
+      keys[i] = UUID.randomUUID().toString();
+    }
+
+    System.out.println("starting inserts.. in-memory keys taking " + (rt.totalMemory() - rt.freeMemory()) / 1048576.0 + " mb");
+
+    System.out.printf("Count %d, Memory = %.2f mb", map.size(), (rt.totalMemory() - rt.freeMemory()) / 1048576.0).println();
+    long lastReport = System.currentTimeMillis();
+    for (int i = 0; i < count; i++) {
+      try {
+        map.put(keys[i], i % 113);
+        int _r = map.get(keys[i]);
+        assert _r % 113 == i % 113 : "r=" + _r + ",i=" + i;
+        if (System.currentTimeMillis() - lastReport > 1000) {
+          System.out.printf("\rCount %d, Memory = %.2f mb", map.size(), (rt.totalMemory() - rt.freeMemory()) / 1048576.0).println();
+          lastReport = System.currentTimeMillis();
+        }
+      } catch (RuntimeException e) {
+        e.printStackTrace();
+        break;
+      }
+    }
+
+    System.out.printf("\rCount %d, Memory = %.2f mb ", map.size(), (rt.totalMemory() - rt.freeMemory()) / 1048576.0);
+
+    for (int c = 0; c < keys.length; c++) {
+      int o = map.get(keys[c]);
+      assert o % 113 == c % 113 : "o=" + o + ",c=" + c;
+    }
+
+    for (int c = 0; c < keys.length; c++) {
+      int o = map.remove(keys[c]);
+      assert o % 113 == c % 113 : "o=" + o + ",c=" + c;
+    }
+
+    System.out.println("\nAfter removing keys");
+    System.gc();
+    System.gc();
+    System.gc();
+    System.out.printf("\rCount %d, Memory = %.2f mb ", map.size(), (rt.totalMemory() - rt.freeMemory()) / 1048576.0);
+  }
+
   public void __test50M() {
 
     DenseIntValueHashMap<String> map = new DenseIntValueHashMap<>(new DHMDefaultSerializer(), 32);
-//    com.pivotal.gemfirexd.internal.engine.map.DenseIntValueHashMap<String> map = new com.pivotal.gemfirexd.internal.engine.map.DenseIntValueHashMap<>(new com.pivotal.gemfirexd.internal.engine.map.DHMBase64Serializer(), 32);
+//    DenseIntValueHashMap<String> map = new DenseIntValueHashMap<>(new com.pivotal.gemfirexd.internal.engine.map.DHMBase64Serializer(), 32);
 
     final int count = 50000000;
     final Runtime rt = Runtime.getRuntime();
@@ -122,7 +178,7 @@ public class DHMTest extends TestCase {
     for (int i = 0; i < count; i++) {
       try {
         final String k = UUID.randomUUID().toString();
-        map.put(k, i%113);
+        map.put(k, i % 113);
         if (System.currentTimeMillis() - lastReport > 10000) {
           System.out.printf("\rCount %d, Memory = %.2f mb", map.size(), (rt.totalMemory() - rt.freeMemory()) / 1048576.0).println();
           lastReport = System.currentTimeMillis();
@@ -145,6 +201,124 @@ public class DHMTest extends TestCase {
     System.gc();
     System.gc();
     System.out.printf("\rCount %d, Memory = %.2f mb ", map.size(), (rt.totalMemory() - rt.freeMemory()) / 1048576.0);
+  }
+
+  private String[] getStaticKeys(int count) {
+    final boolean generateKeys = false;
+    if (generateKeys) {
+      System.out.println("populating keys");
+      StringBuilder sb = new StringBuilder("new String[] {");
+      for (int i = 0; i < count; i++) {
+        sb.append("\"").append(UUID.randomUUID().toString()).append("\",\n");
+      }
+
+      sb.append("};");
+      System.out.println(sb.toString());
+      System.exit(565);
+    }
+
+    return new String[] {"fe1e7fbc-8eb5-4252-95be-69f3eeb6a882",
+        "0773284f-9c09-4c00-aebd-e699e4b797be",
+        "de594b70-2dc7-453b-b930-8206c264644c",
+        "59da0d29-49b8-4c72-9e4f-b2b35b8d7b90",
+        "4b892092-8650-4564-9190-a02cb8e3a828",
+        "228e22e7-3253-4e9b-b7a3-9a9d32638567",
+        "4249e206-7fca-4d61-8a05-6bff6f47bcfa",
+        "a0e74522-3d45-4cc6-93ca-ee45cf2b6b3b",
+        "ab67023f-0b00-4633-81f3-a586c50c4924",
+        "61830265-55ad-4291-a2e1-4323411dea8a",
+        "46de7803-8531-4d2d-b4b0-a3a33e86d04c",
+        "7c84983f-9be3-41eb-ad31-e31ceb258af5",
+        "cdbf1d3a-d4fe-49e9-8e5d-a38a34b0ca3e",
+        "1f9c22b5-a16c-4666-8529-0d6286ecf41a",
+        "2aedb0fa-308c-40e1-ba56-0ac1ed802d22",
+        "61e30dbe-4cf0-41e0-b0ef-501fcd6ba9fe",
+        "2a840b9d-7a01-4678-897e-a617502c296d",
+        "346275b1-3d8e-446b-87ed-fff959442b13",
+        "4f3d4a24-5977-4c02-8608-2a0531ac2996",
+        "ea4cf8cd-017a-43d2-ad2c-9b6e26801143",
+        "6b135ab1-bebb-457d-815c-476910c2a798",
+        "8314e6a2-9f6f-4516-a685-c6faedc09794",
+        "b8122157-942f-415a-b822-dfbc753b78b1",
+        "a08989c8-440c-4146-9843-6a92efa49c26",
+        "78e7da93-6ecb-47a4-bb78-989cbcbdbc12",
+        "ddc94cb9-11f6-4a65-ab90-59c2c0aba50e",
+        "f1280740-a5ac-4909-b841-43473a66f13b",
+        "9b8c8ddc-5ab8-4011-9cdd-d883687ca41a",
+        "af66656e-a907-4ae4-9fe4-157373d5b428",
+        "50ed52e4-e65f-42d0-b1c5-f43ba80d0a2e",
+        "99c889d7-d19c-4444-8b34-16f3c5eab828",
+        "8a98c691-c202-4632-9394-72fe218063d1",
+        "76af995a-0535-4172-af41-21fe0a01546e",
+        "bc79bd9f-6e8f-4e39-9c08-8bfe5885a3f4",
+        "c4fceb09-ef03-4c4d-a7cb-1c4b5a2f3628",
+        "4792e26a-b233-471d-803a-e8fcb2bc5c95",
+        "5e417a3a-9d73-4146-8985-b83f52ac9fb1",
+        "820b0721-ce18-459e-86a2-6730572e7dde",
+        "93440fc9-ca1a-47bb-a0eb-4c5c72dff1d3",
+        "576737eb-8398-40d6-aa0d-afd22893064b",
+        "df07ea35-b581-466f-ad22-da17e1aee887",
+        "775b0b8e-087a-4f09-9e89-ee3f217182e9",
+        "de3b2bd3-c2f6-4eb6-8654-75f5674c3203",
+        "474ecbf8-4bdd-4067-a1fc-196ea290a32a",
+        "eab37491-7844-4043-adda-58824cb57562",
+        "0e70ef8f-6783-4952-90af-d342713e9208",
+        "391f2db8-2c51-4c5a-9b32-ecaf089aa275",
+        "114ad264-6a3e-4e9e-b942-b0b3507492c9",
+        "ac044bcf-c020-4dc9-b51d-8e74f1e0d0a2",
+        "aecfdf85-6349-48bf-867f-562090e0c25b",
+        "84f99b97-0943-412b-a5a4-02b0c281930b",
+        "fee0982c-fe9b-44cd-9215-694f801df03f",
+        "f02c3eb2-92f6-4ff5-9d8a-362fee4f9efa",
+        "0d3f2401-eceb-4283-8b4c-74ddd09007cf",
+        "ea98192e-d29a-422d-bfa3-f8185e7ac5db",
+        "e0ecb9b8-51a4-4320-9acd-3b25921f5f34",
+        "5d408b95-b577-442e-acc4-58843d8363ac",
+        "c0518401-cf5e-4332-9740-1e298a5e0d96",
+        "f499a184-ceb0-4506-bcd9-e8564fa73ec3",
+        "c0a9ab75-05e5-428e-949c-1c99d7280e20",
+        "c8605ef6-7cad-48e4-96ff-f7f4f9cf60e2",
+        "09b8e6c2-50bf-4591-91ad-8d7ddc0131b6",
+        "ed72107c-a19f-4974-a3e3-1d222ffe838d",
+        "2e707612-133d-4cca-b1c9-918229df4776",
+        "325dffac-55e5-45e9-9aa3-126a6c99d881",
+        "0578e4e2-f904-4732-9de9-4ea9d85063dd",
+        "be78432b-cf1b-489d-9b83-47ef3a3a3613",
+        "f68b4e51-06b4-4b4c-af14-e601b3e9f9a0",
+        "3ec87921-090e-42b9-85f9-e4720356966b",
+        "1391fd83-d40e-4419-be03-98196f8a7954",
+        "5deecde5-d6e2-4e57-a756-0240ab6e3c7d",
+        "8d78b41f-4afc-4754-a11c-1f5865594e29",
+        "fd4290ac-3dd2-44bb-897b-440e5365f6c2",
+        "b7f408b5-87f1-4c89-9e0b-1e03506a5fec",
+        "13c847e0-0e7f-49af-98df-fe64736ea7f5",
+        "daae55c9-8de7-4e96-bb1c-27455d81e0e1",
+        "d32c1452-a2ca-495c-9d5b-91c75e00765c",
+        "f8aded07-9fc3-4d88-9240-609036ae1c8d",
+        "569f21d8-984b-4794-a9c8-776687556445",
+        "6ed1e9ab-f368-4da1-840c-ed89fda19f86",
+        "3228cab4-b90b-4ac2-a478-d91a53356bd5",
+        "d58c3b95-6da4-49e7-afc4-44c1a239d03f",
+        "7fc01760-f754-4cb7-9c2a-d5f6d4237916",
+        "c0af267e-a55f-4fd4-ac52-444ee563c334",
+        "1c97d7c9-0f75-4441-88f3-4bf6cfd1f06a",
+        "e0410fc1-0f51-4953-80ac-5b34c1e91d69",
+        "1b3b97d1-c1cd-416d-b09c-2a565a51fe52",
+        "fa2c879b-ed24-4497-9b88-c2f667f47de2",
+        "a4510320-9d41-4eff-a84f-3cfe6e1c8376",
+        "5ac2d8c3-4199-4e28-ace4-389263eeb39e",
+        "33c0861c-5743-4d88-a36c-d324d38fe6a7",
+        "3b4a0359-75dc-4b2a-a656-697e4a86e1bf",
+        "fbad8e7d-d3d1-4d79-ae6c-a2e251a35b6a",
+        "be24017b-a757-4eaa-a353-8982330a6971",
+        "c8a00f33-265d-4653-8fa8-4be3a1525dfd",
+        "18336ed1-a69b-4ea7-a219-59e1a5ff82d6",
+        "cb549ccf-1d6d-497c-bb03-6f0defd3c647",
+        "09d3e662-96ca-4dda-8657-28e8f96e11bf",
+        "27e3958d-f11b-4255-8f95-7006c642a8cf",
+        "4a47af2a-41c0-4134-83d2-6048c2604034",
+    };
+
   }
 
 }

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/internal/engine/map/DHMTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/internal/engine/map/DHMTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2010-2015 Pivotal Software, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.pivotal.gemfirexd.internal.engine.map;
+
+import java.util.Random;
+import java.util.UUID;
+
+import junit.framework.TestCase;
+
+public class DHMTest extends TestCase {
+
+  public static void main(String[] args) {
+    DHMTest t = new DHMTest();
+    t.test1M();
+    t.__test50M();
+  }
+
+  public void test1M() {
+
+    DenseIntValueHashMap<String> map = new DenseIntValueHashMap<>(new DHMDefaultSerializer(), 32);
+//    com.pivotal.gemfirexd.internal.engine.map.DenseIntValueHashMap<String> map = new com.pivotal.gemfirexd.internal.engine.map.DenseIntValueHashMap<>(new com.pivotal.gemfirexd.internal.engine.map.DHMBase64Serializer(), 32);
+//    HashMap<String, Integer> map = new HashMap<>(32);
+//    ConcurrentHashMap<String, Integer> map = new ConcurrentHashMap<>(32);
+//    TObjectIntHashMap map = new TObjectIntHashMap(32);
+
+    final Random r = new Random(System.currentTimeMillis());
+
+    final int count = 1000000;
+    Runtime rt = Runtime.getRuntime();
+    System.out.println("populating keys");
+/*
+    String[] keys = new String[count];
+    for (int i = 0; i < count; i++) {
+      keys[i] = UUID.randomUUID().toString();
+    }
+*/
+
+    long lastReport = System.currentTimeMillis();
+    System.gc();
+    System.gc();
+    System.gc();
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    System.out.println("starting inserts.. in-memory keys taking " + (rt.totalMemory() - rt.freeMemory()) / 1048576.0 + " mb");
+
+    System.out.printf("Count %d, Memory = %.2f mb", map.size(), (rt.totalMemory() - rt.freeMemory()) / 1048576.0).println();
+    for (int i = 0; i < count; i++) {
+      try {
+        String k = UUID.randomUUID().toString();
+        map.put(k, i%113);
+        assert map.get(k) == i%113;
+        if (System.currentTimeMillis() - lastReport > 1000) {
+          System.gc();
+          System.gc();
+          System.gc();
+          System.out.printf("\rCount %d, Memory = %.2f mb", map.size(), (rt.totalMemory() - rt.freeMemory()) / 1048576.0).println();
+          lastReport = System.currentTimeMillis();
+        }
+      } catch (RuntimeException e) {
+        e.printStackTrace();
+        break;
+      }
+    }
+
+    System.gc();
+    System.gc();
+    System.gc();
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    System.out.printf("\rCount %d, Memory = %.2f mb ", map.size(), (rt.totalMemory() - rt.freeMemory()) / 1048576.0);
+
+/*
+    for (int c = 0; c < keys.length; c++) {
+      Object o = map.get(keys[c]);
+      assert o != null;
+    }
+*/
+
+
+  }
+
+  public void __test50M() {
+
+    DenseIntValueHashMap<String> map = new DenseIntValueHashMap<>(new DHMDefaultSerializer(), 32);
+//    com.pivotal.gemfirexd.internal.engine.map.DenseIntValueHashMap<String> map = new com.pivotal.gemfirexd.internal.engine.map.DenseIntValueHashMap<>(new com.pivotal.gemfirexd.internal.engine.map.DHMBase64Serializer(), 32);
+
+    final int count = 50000000;
+    final Runtime rt = Runtime.getRuntime();
+
+    long lastReport = System.currentTimeMillis();
+    System.gc();
+    System.gc();
+    System.gc();
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    System.out.println("starting inserts.. in-memory keys taking " + (rt.totalMemory() - rt.freeMemory()) / 1048576.0 + " mb");
+
+    System.out.printf("Count %d, Memory = %.2f mb", map.size(), (rt.totalMemory() - rt.freeMemory()) / 1048576.0).println();
+    for (int i = 0; i < count; i++) {
+      try {
+        final String k = UUID.randomUUID().toString();
+        map.put(k, i%113);
+        if (System.currentTimeMillis() - lastReport > 10000) {
+          System.out.printf("\rCount %d, Memory = %.2f mb", map.size(), (rt.totalMemory() - rt.freeMemory()) / 1048576.0).println();
+          lastReport = System.currentTimeMillis();
+        }
+      } catch (RuntimeException e) {
+        e.printStackTrace();
+        break;
+      }
+    }
+
+    System.gc();
+    System.gc();
+    System.gc();
+    try {
+      Thread.sleep(2000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    System.gc();
+    System.gc();
+    System.gc();
+    System.out.printf("\rCount %d, Memory = %.2f mb ", map.size(), (rt.totalMemory() - rt.freeMemory()) / 1048576.0);
+  }
+
+}


### PR DESCRIPTION
/**
- A compact hash map with any key object but only with int value.
- This avoids Integer object creation and key object deserialization
- depends on {@link DenseHashMapSerializer} implementation. The interface offers
- opportunity to avoid full key deserialization during hashCode computation, equal comparison
- and rehashing.
- <p/>
- Per Entry overhead is 4 bytes (pointer to byte[]). Its by experiment found
- the best put/get performance and memory usage tradeoff is achieved with simple key and fixed
- width value serialization. A base64 encoded key (assuming ascii only) or multiple entries packed
- together into a single entry (a.k.a separate chaining) did not yield much memory benefit whereas
- performance was significantly effected. In fact, for separate chaining memory consumption increased due to
- length prefixed every entry consuming 4 more bytes.
- <p/>
- Concurrency is at the Segment level. Number of segments by default is 8 times the number of
- cpu cores and should be sufficient for parallelism.
- <p/>
- This is based on open addressing and suffers usual primary clustering problem. This might show up
- even more because of LoadFactor being 0.85 by default unlike proposed 0.50 but compensates for it during expansion
- which brings down the LoadFactor to 0.65. Due to sparsity of the byte[][] total memory consumed for 1 million
- entries shows 12 bytes per entry overhead when measured using runtime memory usage.
- <p/>
  */
  @suranjan @dshirish @kneeraj Please review and suggest.
  I would like to introduce this for GI caching map instead of CHM there as of now. See switches in the test to compare various hashmap implementations.

@jramnara FYI, this is to reduce footprint in global index. Right now plan to introduce in caching global index information on each node if required that will expedite SMART update throughput where GI lookup showed up quite a contributor in slowing down things. Right now GI caching is by default turned off and its going to be like that. This is just to make some progress around it as there is no immediate delivery commitment but suddenly might become a priority. At that time we can ask them to turn caching on with optionally this map as well if they have taken Snappy 0.5 . 
