### PR TITLE
SNAP-618: update to hbase 0.98.X to be compatible with Spark's version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ allprojects {
     jerseyVersion = '1.9'
     hadoopJettyVersion = '6.1.26'
     jsr305Version = '1.3.9'
-    hbaseVersion = '0.94.27'
+    hbaseVersion = '0.98.17-hadoop2'
     derbyVersion = '10.10.2.0'
     //hbaseVersion = '0.94.4-gemfire-r45047'
     //hadoopVersion = '2.2.0-gphd-3.1.0.0'
@@ -800,8 +800,8 @@ def includeJar(def jarFile) {
   return jarName.contains('jetty') || jarName.contains('spring') ||
     jarName.contains('hadoop') || jarName.contains('protobuf') ||
     jarName.contains('jersey') || jarName.contains('jetty') ||
-    jarName.contains('hbase') || jarName.contains('jsr305') ||
-    jarName.contains('pxf') || jarName.contains('jline')
+    jarName.contains('jsr305') || jarName.contains('pxf') ||
+    jarName.contains('jline')
 }
 
 // pack the entire GemFireXD product tree

--- a/gemfire-core/build.gradle
+++ b/gemfire-core/build.gradle
@@ -58,8 +58,34 @@ dependencies {
   provided "com.sun.jersey:jersey-server:${jerseyVersion}"
   provided "org.mortbay.jetty:jetty:${hadoopJettyVersion}"
   provided "org.mortbay.jetty:jetty-util:${hadoopJettyVersion}"
-  provided "org.apache.hbase:hbase:${hbaseVersion}"
   provided "com.google.code.findbugs:jsr305:${jsr305Version}"
+
+  compile group: 'org.apache.hbase', name: 'hbase-protocol', version: hbaseVersion
+  compile(group: 'org.apache.hbase', name: 'hbase-common', version: hbaseVersion) {
+    exclude(group: 'org.apache.hbase', module: 'hbase-annotations')
+  }
+  compile(group: 'org.apache.hbase', name: 'hbase-client', version: hbaseVersion) {
+    exclude(group: 'org.apache.hbase', module: 'hbase-annotations')
+    exclude(group: 'io.netty', module: 'netty')
+  }
+  compile(group: 'org.apache.hbase', name: 'hbase-server', version: hbaseVersion) {
+    exclude(group: 'org.apache.hbase', module: 'hbase-annotations')
+    exclude(group: 'org.apache.hadoop', module: 'hadoop-core')
+    exclude(group: 'org.apache.hadoop', module: 'hadoop-client')
+    exclude(group: 'org.apache.hadoop', module: 'hadoop-mapreduce-client-jobclient')
+    exclude(group: 'org.apache.hadoop', module: 'hadoop-mapreduce-client-core')
+    exclude(group: 'org.apache.hadoop', module: 'hadoop-auth')
+    exclude(group: 'org.apache.hadoop', module: 'hadoop-annotations')
+    exclude(group: 'org.apache.hadoop', module: 'hadoop-hdfs')
+    exclude(group: 'org.apache.hbase', module: 'hbase-hadoop1-compat')
+    exclude(group: 'commons-math', module: 'commons-math')
+    exclude(group: 'org.slf4j', module: 'slf4j-api')
+    exclude(group: 'com.sun.jersey', module: 'jersey-server')
+    exclude(group: 'com.sun.jersey', module: 'jersey-core')
+    exclude(group: 'com.sun.jersey', module: 'jersey-json')
+    exclude(group: 'commons-io', module: 'commons-io')
+  }
+  compile 'org.cloudera.htrace:htrace-core:2.05'
 
   compile 'com.google.guava:guava:14.0.1'
   compile 'xml-apis:xml-apis:1.4.01'

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/cache/hdfs/internal/HDFSStoreImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/cache/hdfs/internal/HDFSStoreImpl.java
@@ -54,7 +54,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.hfile.BlockCache;
 import org.apache.hadoop.hbase.io.hfile.LruBlockCache;
 import org.apache.hadoop.hbase.regionserver.StoreFile;
-import org.apache.hadoop.hbase.regionserver.metrics.SchemaMetrics;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.net.ConnectTimeoutException;
@@ -68,6 +67,8 @@ import org.apache.hadoop.security.UserGroupInformation;
  */
 public class HDFSStoreImpl implements HDFSStore {
   public static final String ALLOW_STANDALONE_HDFS_FILESYSTEM_PROP = "gemfire.ALLOW_STANDALONE_HDFS_FILESYSTEM";
+  public static final int DEFAULT_BLOCKSIZE_SMALL = 8 * 1024;
+
   private final boolean ALLOW_TEST_FILE_SYSTEM = Boolean.getBoolean(ALLOW_STANDALONE_HDFS_FILESYSTEM_PROP);
   final LogWriterI18n logger;
 
@@ -125,7 +126,7 @@ public class HDFSStoreImpl implements HDFSStore {
 //      this.blockCache = new LruBlockCache(cacheSize,
 //          StoreFile.DEFAULT_BLOCKSIZE_SMALL, hconf, HFileSortedOplogFactory.convertStatistics(stats));
       this.blockCache = new LruBlockCache(cacheSize,
-          StoreFile.DEFAULT_BLOCKSIZE_SMALL, hconf);
+          DEFAULT_BLOCKSIZE_SMALL, hconf);
     } else {
       this.blockCache = null;
     }
@@ -205,7 +206,8 @@ public class HDFSStoreImpl implements HDFSStore {
           new String[]{"org.apache.hadoop.io.serializer.WritableSerialization"});
       // create writer
 
-      SchemaMetrics.configureGlobally(hconf);
+      // [sumedh] should not be required with the new metrics2
+      // SchemaMetrics.configureGlobally(hconf);
       
       String nameNodeURL = null;
       if ((nameNodeURL = getNameNodeURL()) == null) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/cache/hdfs/internal/hoplog/mapreduce/RWSplitIterator.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/cache/hdfs/internal/hoplog/mapreduce/RWSplitIterator.java
@@ -24,7 +24,6 @@ import com.gemstone.gemfire.cache.hdfs.internal.hoplog.AbstractHoplog;
 import com.gemstone.gemfire.cache.hdfs.internal.hoplog.HFileSortedOplog;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.regionserver.metrics.SchemaMetrics;
 
 /**
  * An iterator that iterates over a split in a read/write hoplog
@@ -38,7 +37,8 @@ public class RWSplitIterator extends HDFSSplitIterator {
 
   @Override
   protected AbstractHoplog getHoplog(FileSystem fs, Path path) throws IOException {
-    SchemaMetrics.configureGlobally(fs.getConf());
+    // [sumedh] should not be required with the new metrics2
+    // SchemaMetrics.configureGlobally(fs.getConf());
     return HFileSortedOplog.getHoplogForLoner(fs, path); 
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/ArraySerializedComparator.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/ArraySerializedComparator.java
@@ -37,8 +37,7 @@ import com.gemstone.gemfire.internal.util.Bytes;
  * 
  * @author bakera
  */
-public class ArraySerializedComparator implements CompositeSerializedComparator, 
-DelegatingSerializedComparator {
+public class ArraySerializedComparator extends DelegatingSerializedComparator {
 
   /** the comparators */
   private volatile SerializedComparator[] comparators;
@@ -51,11 +50,6 @@ DelegatingSerializedComparator {
    */
   public void setComparators(SerializedComparator[] comparators) {
     this.comparators = comparators;
-  }
-  
-  @Override
-  public int compare(byte[] o1, byte[] o2) {
-    return compare(o1, 0, o1.length, o2, 0, o2.length);
   }
 
   @Override

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/ByteComparator.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/ByteComparator.java
@@ -23,24 +23,20 @@ import com.gemstone.gemfire.internal.cache.persistence.soplog.SortedReader.Seria
 /**
  * Compares objects byte-by-byte.  This is fast and sufficient for cases when
  * lexicographic ordering is not important or the serialization is order-
- * preserving. 
- * 
+ * preserving.
+ *
  * @author bakera
  */
-public class ByteComparator implements SerializedComparator {
-  @Override
-  public int compare(byte[] rhs, byte[] lhs) {
-    return compare(rhs, 0, rhs.length, lhs, 0, lhs.length);
-  }
+public class ByteComparator extends SerializedComparator {
 
   @Override
   public int compare(byte[] r, int rOff, int rLen, byte[] l, int lOff, int lLen) {
     return compareBytes(r, rOff, rLen, l, lOff, lLen);
   }
-  
+
   /**
    * Compares two byte arrays element-by-element.
-   * 
+   *
    * @param r the right array
    * @param rOff the offset of r
    * @param rLen the length of r to compare
@@ -49,8 +45,8 @@ public class ByteComparator implements SerializedComparator {
    * @param lLen the length of l to compare
    * @return -1 if r < l; 0 if r == l; 1 if r > 1
    */
-  
-  public static int compareBytes(byte[] r, int rOff, int rLen, byte[] l, int lOff, int lLen) {
+  public static int compareBytes(byte[] r, int rOff, int rLen, byte[] l,
+      int lOff, int lLen) {
     return Bytes.compareTo(r, rOff, rLen, l, lOff, lLen);
   }
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/CompositeSerializedComparator.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/CompositeSerializedComparator.java
@@ -22,19 +22,21 @@ import com.gemstone.gemfire.internal.cache.persistence.soplog.SortedReader.Seria
 
 /**
  * Creates and compares composite keys.
- * 
+ *
  * @author bakera
  */
-public interface CompositeSerializedComparator extends SerializedComparator  {
+public abstract class CompositeSerializedComparator
+    extends SerializedComparator {
+
   /**
    * Constructs a composite key consisting of a primary key and a secondary key.
-   * 
+   *
    * @param key1 the primary key
    * @param key2 the secondary key
    * @return the composite key
    */
-  public byte[] createCompositeKey(byte[] key1, byte[] key2);
-  
+  public abstract byte[] createCompositeKey(byte[] key1, byte[] key2);
+
   /**
    * Constructs a composite key by combining the supplied keys.  The number of
    * keys and their order must match the comparator set.
@@ -42,16 +44,17 @@ public interface CompositeSerializedComparator extends SerializedComparator  {
    * The <code>WILDCARD_KEY</code> token may be used to match all subkeys in the
    * given ordinal position.  This is useful when constructing a search key to
    * retrieve all keys for a given primary key, ignoring the remaining subkeys.
-   * 
+   *
    * @param keys the keys, ordered by sort priority
    * @return the composite key
    */
-  public byte[] createCompositeKey(byte[]... keys);
-  
+  public abstract byte[] createCompositeKey(byte[]... keys);
+
   /**
    * Returns subkey for the given ordinal position.
+   *
    * @param key the composite key
    * @return the subkey
    */
-  public ByteBuffer getKey(ByteBuffer key, int ordinal);
+  public abstract ByteBuffer getKey(ByteBuffer key, int ordinal);
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/DelegatingSerializedComparator.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/DelegatingSerializedComparator.java
@@ -20,19 +20,23 @@ import com.gemstone.gemfire.internal.cache.persistence.soplog.SortedReader.Seria
 
 /**
  * Delegates object comparisons to one or more embedded comparators.
- *  
+ *
  * @author bakera
  */
-public interface DelegatingSerializedComparator extends SerializedComparator {
+public abstract class DelegatingSerializedComparator
+    extends CompositeSerializedComparator {
+
   /**
    * Injects the embedded comparators.
+   *
    * @param comparators the comparators for delegation
    */
-  void setComparators(SerializedComparator[] comparators);
-  
+  public abstract void setComparators(SerializedComparator[] comparators);
+
   /**
    * Returns the embedded comparators.
+   *
    * @return the comparators
    */
-  SerializedComparator[] getComparators();
+  public abstract SerializedComparator[] getComparators();
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/IndexSerializedComparator.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/IndexSerializedComparator.java
@@ -34,9 +34,8 @@ import com.gemstone.gemfire.internal.util.Bytes;
  * 
  * @author bakera
  */
-public class IndexSerializedComparator implements CompositeSerializedComparator, 
-DelegatingSerializedComparator {
-  
+public class IndexSerializedComparator extends DelegatingSerializedComparator {
+
   private volatile SerializedComparator primary;
   private volatile SerializedComparator secondary;
   
@@ -58,11 +57,6 @@ DelegatingSerializedComparator {
     return new SerializedComparator[] { primary, secondary };
   }
 
-  @Override
-  public int compare(byte[] o1, byte[] o2) {
-    return compare(o1, 0, o1.length, o2, 0, o2.length);
-  }
-  
   @Override
   public int compare(byte[] b1, int o1, int l1, byte[] b2, int o2, int l2) {
     int klen1 = Bytes.getVarInt(b1, o1);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/LexicographicalComparator.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/LexicographicalComparator.java
@@ -53,7 +53,7 @@ import com.gemstone.gemfire.internal.util.Bytes;
  * 
  * @author bakera
  */
-public class LexicographicalComparator implements SerializedComparator {
+public class LexicographicalComparator extends SerializedComparator {
 
   //////////////////////////////////////////////////////////////////////////////
   //
@@ -113,12 +113,7 @@ public class LexicographicalComparator implements SerializedComparator {
   private static final int STRING_TO_STRING_BYTES       = DSCODE.STRING       << 8 | DSCODE.STRING_BYTES;
   private static final int STRING_BYTES_TO_STRING       = DSCODE.STRING_BYTES << 8 | DSCODE.STRING;
   private static final int STRING_BYTES_TO_STRING_BYTES = DSCODE.STRING_BYTES << 8 | DSCODE.STRING_BYTES;
-  
-  @Override
-  public int compare(byte[] o1, byte[] o2) {
-    return compare(o1, 0, o1.length, o2, 0, o2.length);
-  }
-  
+
   @Override
   public int compare(byte[] b1, int o1, int l1, byte[] b2, int o2, int l2) {
     byte type1 = b1[o1];

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/ReversingSerializedComparator.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/ReversingSerializedComparator.java
@@ -16,6 +16,8 @@
  */
 package com.gemstone.gemfire.internal.cache.persistence.soplog;
 
+import java.nio.ByteBuffer;
+
 import com.gemstone.gemfire.internal.cache.persistence.soplog.SortedReader.SerializedComparator;
 
 /**
@@ -27,7 +29,9 @@ import com.gemstone.gemfire.internal.cache.persistence.soplog.SortedReader.Seria
  *  
  * @author bakera
  */
-public class ReversingSerializedComparator implements DelegatingSerializedComparator {
+public class ReversingSerializedComparator
+    extends DelegatingSerializedComparator {
+
   private volatile SerializedComparator delegate;
 
   @Override
@@ -40,12 +44,7 @@ public class ReversingSerializedComparator implements DelegatingSerializedCompar
   public SerializedComparator[] getComparators() {
     return new SerializedComparator[] { delegate };
   }
-  
-  @Override
-  public int compare(byte[] o1, byte[] o2) {
-    return compare(o1, 0, o1.length, o2, 0, o2.length);
-  }
-  
+
   @Override
   public int compare(byte[] b1, int o1, int l1, byte[] b2, int o2, int l2) {
     return delegate.compare(b2, o2, l2, b1, o1, l1);
@@ -63,5 +62,20 @@ public class ReversingSerializedComparator implements DelegatingSerializedCompar
     rev.delegate = sc;
     
     return rev;
+  }
+
+  @Override
+  public byte[] createCompositeKey(byte[] key1, byte[] key2) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte[] createCompositeKey(byte[]... keys) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ByteBuffer getKey(ByteBuffer key, int ordinal) {
+    throw new UnsupportedOperationException();
   }
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/SortedBuffer.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/SortedBuffer.java
@@ -61,7 +61,8 @@ public class SortedBuffer<T> extends AbstractSortedReader {
     
     this.tag = tag;
     
-    buffer = new ConcurrentSkipListMap<byte[], byte[]>(config.getComparator());
+    buffer = new ConcurrentSkipListMap<byte[], byte[]>(
+        config.getComparator().toBytesComparator());
     stats = new BufferStats();
     metadata = new EnumMap<Metadata, byte[]>(Metadata.class);
     
@@ -245,7 +246,7 @@ public class SortedBuffer<T> extends AbstractSortedReader {
 
   @Override
   public SerializedComparator getComparator() {
-    return (SerializedComparator) buffer.comparator();
+    return ((BytesComparator)buffer.comparator()).getSerializedComparator();
   }
 
   @Override

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/hfile/HFileSortedOplogFactory.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/hfile/HFileSortedOplogFactory.java
@@ -19,8 +19,8 @@ package com.gemstone.gemfire.internal.cache.persistence.soplog.hfile;
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.hadoop.hbase.io.compress.Compression.Algorithm;
 import org.apache.hadoop.hbase.io.hfile.BlockCache;
-import org.apache.hadoop.hbase.io.hfile.Compression.Algorithm;
 import org.apache.hadoop.hbase.io.hfile.HFileDataBlockEncoder;
 import org.apache.hadoop.hbase.io.hfile.NoOpDataBlockEncoder;
 import org.apache.hadoop.hbase.util.ChecksumType;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/nofile/NoFileSortedOplog.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/nofile/NoFileSortedOplog.java
@@ -57,7 +57,8 @@ public class NoFileSortedOplog implements SortedOplog {
     synchronized (metadata) {
       metadata.clear();
     }
-    data.set(new ConcurrentSkipListMap<byte[], byte[]>(config.getComparator()));
+    data.set(new ConcurrentSkipListMap<byte[], byte[]>(
+        config.getComparator().toBytesComparator()));
     
     return new NoFileWriter();
   }
@@ -146,7 +147,8 @@ public class NoFileSortedOplog implements SortedOplog {
 
     @Override
     public SerializedComparator getComparator() {
-      return (SerializedComparator) data.get().comparator();
+      return ((BytesComparator)data.get().comparator())
+          .getSerializedComparator();
     }
 
     @Override

--- a/gemfire-junit/build.gradle
+++ b/gemfire-junit/build.gradle
@@ -44,7 +44,6 @@ dependencies {
   provided "com.sun.jersey:jersey-server:${jerseyVersion}"
   provided "org.mortbay.jetty:jetty:${hadoopJettyVersion}"
   provided "org.mortbay.jetty:jetty-util:${hadoopJettyVersion}"
-  provided "org.apache.hbase:hbase:${hbaseVersion}"
   provided "com.google.code.findbugs:jsr305:${jsr305Version}"
 
   provided "org.apache.hadoop:hadoop-common:${hadoopVersion}:tests"

--- a/gemfire-junit/src/main/java/com/gemstone/gemfire/cache/hdfs/internal/HDFSConfigJUnitTest.java
+++ b/gemfire-junit/src/main/java/com/gemstone/gemfire/cache/hdfs/internal/HDFSConfigJUnitTest.java
@@ -456,7 +456,7 @@ public class HDFSConfigJUnitTest extends TestCase {
       
       //Configure a block cache to cache about 20 blocks.
       long heapSize = HeapMemoryMonitor.getTenuredPoolMaxMemory();
-      int blockSize = StoreFile.DEFAULT_BLOCKSIZE_SMALL;
+      int blockSize = HDFSStoreImpl.DEFAULT_BLOCKSIZE_SMALL;
       int blockCacheSize = 5 * blockSize;
       int entrySize = blockSize / 2;
       

--- a/gemfire-junit/src/main/java/com/gemstone/gemfire/cache/hdfs/internal/hoplog/mapreduce/HDFSSplitIteratorJUnitTest.java
+++ b/gemfire-junit/src/main/java/com/gemstone/gemfire/cache/hdfs/internal/hoplog/mapreduce/HDFSSplitIteratorJUnitTest.java
@@ -19,6 +19,7 @@ package com.gemstone.gemfire.cache.hdfs.internal.hoplog.mapreduce;
 import com.gemstone.gemfire.cache.hdfs.internal.hoplog.BaseHoplogTestCase;
 import com.gemstone.gemfire.cache.hdfs.internal.hoplog.HFileSortedOplog;
 import com.gemstone.gemfire.cache.hdfs.internal.hoplog.Hoplog;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
@@ -56,7 +57,8 @@ public class HDFSSplitIteratorJUnitTest extends BaseHoplogTestCase {
     createHoplog(2000, oplog);
     
     FileSystem fs = hdfsStore.getFileSystem();
-    Reader reader = HFile.createReader(fs, path, new CacheConfig(fs.getConf()));
+    Reader reader = HFile.createReader(fs, path,
+        new CacheConfig(fs.getConf()), fs.getConf());
     BlockIndexReader bir = reader.getDataBlockIndexReader();
     int blockCount = bir.getRootBlockCount();
     reader.close();
@@ -123,7 +125,8 @@ public class HDFSSplitIteratorJUnitTest extends BaseHoplogTestCase {
     createHoplog(2000, oplog);
     
     FileSystem fs = hdfsStore.getFileSystem();
-    Reader reader = HFile.createReader(fs, path1, new CacheConfig(fs.getConf()));
+    Reader reader = HFile.createReader(fs, path1,
+        new CacheConfig(fs.getConf()), fs.getConf());
     BlockIndexReader bir = reader.getDataBlockIndexReader();
     int blockCount = bir.getRootBlockCount();
     reader.close();

--- a/gemfire-junit/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/SortedReaderTestCase.java
+++ b/gemfire-junit/src/main/java/com/gemstone/gemfire/internal/cache/persistence/soplog/SortedReaderTestCase.java
@@ -274,8 +274,8 @@ public abstract class SortedReaderTestCase extends TestCase {
 
   @Override
   protected final void setUp() throws IOException {
-    data = new TreeMap<byte[], byte[]>(new ByteComparator());
-    
+    data = new TreeMap<>(new ByteComparator().toBytesComparator());
+
     for (int i = 0; i < 100; i++) {
       data.put(wrapInt(i), wrapInt(i));
     }

--- a/gemfirexd/core/build.gradle
+++ b/gemfirexd/core/build.gradle
@@ -27,7 +27,6 @@ dependencies {
   provided "com.sun.jersey:jersey-server:${jerseyVersion}"
   provided "org.mortbay.jetty:jetty:${hadoopJettyVersion}"
   provided "org.mortbay.jetty:jetty-util:${hadoopJettyVersion}"
-  provided "org.apache.hbase:hbase:${hbaseVersion}"
   provided "com.google.code.findbugs:jsr305:${jsr305Version}"
 }
 

--- a/gemfirexd/tools/build.gradle
+++ b/gemfirexd/tools/build.gradle
@@ -47,7 +47,6 @@ dependencies {
   provided "org.mortbay.jetty:jetty-util:${hadoopJettyVersion}"
   provided "org.mortbay.jetty:jetty:${hadoopJettyVersion}"
   provided "org.mortbay.jetty:jetty-util:${hadoopJettyVersion}"
-  provided "org.apache.hbase:hbase:${hbaseVersion}"
   provided "com.google.code.findbugs:jsr305:${jsr305Version}"
 
   testCompile "org.apache.hadoop:hadoop-common:${hadoopVersion}:tests"

--- a/tests/core/build.gradle
+++ b/tests/core/build.gradle
@@ -53,7 +53,6 @@ dependencies {
   provided "com.sun.jersey:jersey-server:${jerseyVersion}"
   provided "org.mortbay.jetty:jetty:${hadoopJettyVersion}"
   provided "org.mortbay.jetty:jetty-util:${hadoopJettyVersion}"
-  provided "org.apache.hbase:hbase:${hbaseVersion}"
   provided "com.google.code.findbugs:jsr305:${jsr305Version}"
   provided "org.springframework:spring-core:${springVersion}"
   provided 'org.springframework.shell:spring-shell:1.0.0.RELEASE'

--- a/tests/sql/build.gradle
+++ b/tests/sql/build.gradle
@@ -34,7 +34,6 @@ dependencies {
   provided "com.sun.jersey:jersey-server:${jerseyVersion}"
   provided "org.mortbay.jetty:jetty:${hadoopJettyVersion}"
   provided "org.mortbay.jetty:jetty-util:${hadoopJettyVersion}"
-  provided "org.apache.hbase:hbase:${hbaseVersion}"
   provided "com.google.code.findbugs:jsr305:${jsr305Version}"
 
   provided "org.springframework:spring-aop:${springVersion}"


### PR DESCRIPTION
This will allow inclusion of hbase in our assembly jar avoiding user to include the jar and its dependencies explicitly. It also avoids the problems that will arise if some app were to use hbase deps of Spark (which comes in from hive-client) with HDFS support of GemXD.
- added dependencies to hbase 0.98.X with excludes like in Spark and explicit inclusion of htrace-core required at runtime
  - corrected the Comparator hierarchy to now inherit from KVComparator with the interfaces like SerializedComparator
    now being abstract classes; fixed a number of overrides to be consistent with the new expected methods
    (see RawBytesComparator in hbase code for an example)
  - as a result of changing interfaces to abstract base, DelegatingSerializedComparator now extends
    CompositeSerializedComparator (which is somewhat out of place but required)
  - corrected the HFile creation to use HFileContextBuilder for the new HFileContext as required in new APIs
  - added an intermediate BytesComparator to wrap a SerializedCompator as a thin veneer to provide a
    Comparator<byte[]> on top of Comparator<Cell> that SerializedCompator now implements (due to extending KVComparator)
  - commented out SchemaMetrics initialization which is now gone and should not be required with metrics2
