### PR TITLE
Fix for trac#51906

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/metadata/UpdateQueryInfo.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/metadata/UpdateQueryInfo.java
@@ -303,7 +303,10 @@ public class UpdateQueryInfo extends DMLQueryInfo {
         }
         this.updateCols[this.currentColumnIndex - 1][1] =rhs;
         //TODO: Asif: Identify a cleaner way
-        if(rhs == QueryInfoConstants.DUMMY) {
+        if(rhs == QueryInfoConstants.DUMMY ||
+            // #51906 clear flag for update query with set statement with no ValueQueryInfo
+            // for ex. update t1 set col2  = col3 where col1 =1
+            rhs instanceof ColumnQueryInfo) {
           this.queryType = GemFireXDUtils.clear(this.queryType,IS_PRIMARY_KEY_TYPE);
         }
         

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/BugsDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/BugsDUnit.java
@@ -4659,4 +4659,19 @@ public class BugsDUnit extends DistributedSQLTestBase {
       });
     }
   }
+
+  public void test51906() throws Exception {
+    startVMs(1, 1);
+    Connection conn = TestUtil.getConnection();
+    Statement stmt = conn.createStatement();
+
+    stmt.execute("CREATE TABLE T1 (COL1 INT NOT NULL PRIMARY KEY, " +
+        "COL2 VARCHAR(10), COL3 CHAR(10), COL4 INT NOT NULL)");
+    stmt.execute("INSERT INTO T1 VALUES(1, '1', '11', 1)");
+    stmt.execute("UPDATE T1 SET COL2 = COL3 WHERE COL1 = 1");
+    ResultSet rs = stmt.executeQuery("SELECT COL2 FROM T1");
+    assertTrue(rs.next());
+    assertEquals("11", rs.getString(1).trim());
+    conn.close();
+  }
 }


### PR DESCRIPTION
## Changes proposed in this pull request

ClassCastException for query like following:-

UPDATE T1 SET COL2 = COL3 WHERE COL1 = 1

Col1 is a primary key. The above query got converted to put and and expected RHS of SET to a ValueQueryInfo, in UpdateQueryInfo.getChangedRowAndFormatableBitSet. Fixed it by clearing IS_PRIMARY_KEY_TYPE flag in 
UpdateQueryInfo#handleResultColumnNode. Note this was already happening if RHS was an expression (for example for, UPDATE TABLE SET CO2L = COL3*2 WHERE COL1 =<>)

Exception

``` Java
Caused by: java.lang.ClassCastException: com.pivotal.gemfirexd.internal.engine.distributed.metadata.ColumnQueryInfo cannot be cast to com.pivotal.gemfirexd.internal.engine.distributed.metadata.ValueQueryInfo
    at com.pivotal.gemfirexd.internal.engine.distributed.metadata.UpdateQueryInfo.getChangedRowAndFormatableBitSet(UpdateQueryInfo.java:262)
    at com.pivotal.gemfirexd.internal.engine.sql.execute.GemFireUpdateActivation.executeWithResultSet(GemFireUpdateActivation.java:122)
    at com.pivotal.gemfirexd.internal.engine.sql.execute.AbstractGemFireActivation.execute(AbstractGemFireActivation.java:165)
    at com.pivotal.gemfirexd.internal.impl.sql.GenericActivationHolder.execute(GenericActivationHolder.java:462)
    at com.pivotal.gemfirexd.internal.impl.sql.GenericPreparedStatement.execute(GenericPreparedStatement.java:586)
    at com.pivotal.gemfirexd.internal.impl.jdbc.EmbedStatement.executeStatement(EmbedStatement.java:2132)
    at com.pivotal.gemfirexd.internal.impl.jdbc.EmbedStatement.execute(EmbedStatement.java:1277)
    at com.pivotal.gemfirexd.internal.impl.jdbc.EmbedStatement.execute(EmbedStatement.java:1000)
    at com.pivotal.gemfirexd.internal.impl.jdbc.EmbedStatement.execute(EmbedStatement.java:966)
    at com.pivotal.gemfirexd.ddl.BugsDUnit.test51906(BugsDUnit.java:4671)
```
## Patch testing

Ran precheckin, added a unit test.
## Other PRs

(Does this change required changes in other projects- snappyData, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
