### PR TITLE
[SNAP-606] Add ComplexTypeSerializer for compound types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -503,7 +503,7 @@ subprojects {
   })
   junit.dependsOn junitParallel, junitReport
 
-  task dunitTest(type:Test) {
+  task dunitTest(type:Test, overwrite: true) {
     dependsOn "${subprojectBase}product"
     maxParallelForks = Math.max((int)Math.sqrt(Runtime.getRuntime().availableProcessors() + 1) + 1, 2)
     minHeapSize = '512m'

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/i18n/LocalizedStrings.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/i18n/LocalizedStrings.java
@@ -1536,7 +1536,7 @@ public class LocalizedStrings extends ParentLocalizedStrings {
   public static final StringId DiskStoreStillAtVersion_0 = new StringIdImpl(4897, "This disk store is still at version {0}.");
 
   public static final StringId DistributedRegion_NO_DATA_STORE_FOUND_FOR_DISTRIBUTION = new StringIdImpl(
-      4898, "No Data Store found for distribution for : {0}.");
+      4898, "No Data Store found in the distributed system for: {0}");
   public static final StringId GemFireUtilLauncher_SystemAdmin_Usage = new StringIdImpl(
       4899, "Various administrative utilities for a GemFire distributed system");
   public static final StringId CacheServerLauncher_EVICTION_HEAP_PERCENTAGE =

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
@@ -24,7 +24,10 @@ import java.util.UUID;
 import com.gemstone.gemfire.internal.cache.BucketRegion;
 
 public interface StoreCallbacks {
+
   String SHADOW_TABLE_SUFFIX = "_COLUMN_STORE_";
+
   Set createCachedBatch(BucketRegion region, UUID batchID, int bucketID);
+
   List<String> getInternalTableSchemas();
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/Misc.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/Misc.java
@@ -800,7 +800,7 @@ public abstract class Misc {
           op);
     }
     else if (gfeex instanceof NoDataStoreAvailableException) {
-      String[] messageParts = gfeex.getMessage().split(": ")
+      String[] messageParts = gfeex.getMessage().split(": ");
       return StandardException.newException(SQLState.NO_DATASTORE_FOUND, cause,
           messageParts.length > 1 ? messageParts[1] : op);
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/Misc.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/Misc.java
@@ -800,8 +800,9 @@ public abstract class Misc {
           op);
     }
     else if (gfeex instanceof NoDataStoreAvailableException) {
+      String[] messageParts = gfeex.getMessage().split(": ")
       return StandardException.newException(SQLState.NO_DATASTORE_FOUND, cause,
-          op);
+          messageParts.length > 1 ? messageParts[1] : op);
     }
     else if (gfeex instanceof PartitionOfflineException) {
       return StandardException.newException(SQLState.INSUFFICIENT_DATASTORE,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/OpenMemIndex.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/OpenMemIndex.java
@@ -89,24 +89,7 @@ public final class OpenMemIndex {
 
   /**
    * DOCUMENT ME!
-   * 
-   * @param open_user_scans
-   *          DOCUMENT ME!
-   * @param xact_manager
-   *          DOCUMENT ME!
-   * @param conglomerate
-   *          DOCUMENT ME!
-   * @param rawtran
-   *          DOCUMENT ME!
-   * @param hold
-   *          DOCUMENT ME!
-   * @param open_mode
-   *          DOCUMENT ME!
-   * @param lockLevel
-   *          DOCUMENT ME!
-   * @param dynamicInfo
-   *          DOCUMENT ME!
-   * 
+   *
    * @throws StandardException
    *           DOCUMENT ME!
    */

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/resolver/GfxdPartitionByExpressionResolver.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/resolver/GfxdPartitionByExpressionResolver.java
@@ -937,7 +937,8 @@ public final class GfxdPartitionByExpressionResolver extends
             numPositions);
       }
       else if (vclass == byte[].class) {
-        return computeHashCode((byte[])val, rf, columnPositions, numPositions);
+        return computeHashCode((byte[])val, rf, columnPositions,
+            numPositions);
       }
       else if (vclass == OffHeapRow.class) {
         bsRow = (OffHeapRow)val;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
@@ -25,6 +25,7 @@ import com.gemstone.gemfire.internal.cache.NoDataStoreAvailableException;
 import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import com.gemstone.gemfire.internal.shared.Version;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
+import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.distributed.GfxdDistributionAdvisor;
 import com.pivotal.gemfirexd.internal.engine.distributed.GfxdResultCollector;
 import com.pivotal.gemfirexd.internal.engine.distributed.SnappyResultHolder;
@@ -70,22 +71,19 @@ public final class LeadNodeExecutorMsg extends MemberExecutorMessage<Object> {
   @Override
   public Set<DistributedMember> getMembers() {
     GfxdDistributionAdvisor advisor = GemFireXDUtils.getGfxdAdvisor();
-    InternalDistributedSystem ids = InternalDistributedSystem
-        .getConnectedInstance();
-    if (ids != null) {
-      if (ids.isLoner()) {
-        return Collections.<DistributedMember>singleton(
-            ids.getDistributedMember());
-      }
-      Set<DistributedMember> allMembers = ids.getAllOtherMembers();
-      for (DistributedMember m : allMembers) {
-        GfxdDistributionAdvisor.GfxdProfile profile = advisor
-            .getProfile((InternalDistributedMember)m);
-        if (profile != null && profile.hasSparkURL()) {
-          Set<DistributedMember> s = new HashSet<DistributedMember>();
-          s.add(m);
-          return Collections.unmodifiableSet(s);
-        }
+    InternalDistributedSystem ids = Misc.getDistributedSystem();
+    if (ids.isLoner()) {
+      return Collections.<DistributedMember>singleton(
+          ids.getDistributedMember());
+    }
+    Set<DistributedMember> allMembers = ids.getAllOtherMembers();
+    for (DistributedMember m : allMembers) {
+      GfxdDistributionAdvisor.GfxdProfile profile = advisor
+          .getProfile((InternalDistributedMember)m);
+      if (profile != null && profile.hasSparkURL()) {
+        Set<DistributedMember> s = new HashSet<DistributedMember>();
+        s.add(m);
+        return Collections.unmodifiableSet(s);
       }
     }
     throw new NoDataStoreAvailableException(LocalizedStrings

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
@@ -21,6 +21,8 @@ import com.gemstone.gemfire.DataSerializer;
 import com.gemstone.gemfire.distributed.DistributedMember;
 import com.gemstone.gemfire.distributed.internal.InternalDistributedSystem;
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
+import com.gemstone.gemfire.internal.cache.NoDataStoreAvailableException;
+import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import com.gemstone.gemfire.internal.shared.Version;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
 import com.pivotal.gemfirexd.internal.engine.distributed.GfxdDistributionAdvisor;
@@ -86,17 +88,18 @@ public final class LeadNodeExecutorMsg extends MemberExecutorMessage<Object> {
         }
       }
     }
-    return Collections.emptySet();
+    throw new NoDataStoreAvailableException(LocalizedStrings
+        .DistributedRegion_NO_DATA_STORE_FOUND_FOR_DISTRIBUTION
+        .toLocalizedString("SnappyData Lead Node"));
   }
 
   @Override
   public void postExecutionCallback() {
-
   }
 
   @Override
   public boolean isHA() {
-    return false;
+    return true;
   }
 
   @Override

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
@@ -254,7 +254,7 @@ public final class RegionEntryUtils {
    * partitioning; can even that be avoided?
    * 
    * @param val
-   * @param validColumns
+   * @param validColumn
    *          - this is 1 based i.e. logicalPosition and will be substracted by
    *          1 for DVD[] access.
    * @param gfContainer

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/snappy/ComplexTypeSerializer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/snappy/ComplexTypeSerializer.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.pivotal.gemfirexd.snappy;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+import java.util.Map;
+
+import com.gemstone.gemfire.internal.ClassPathLoader;
+
+/**
+ * Serialization facilities for complex types supported by SnappyData:
+ * ARRAY, MAP, STRUCT.
+ * <p>
+ * The result of {@link ComplexTypeSerializer#getBytes} should be used to
+ * send across the bytes for the BLOB storage as used for these types. The
+ * following type of java objects are allowed for respective types:
+ * <ul>
+ * <li><b>ARRAY: </b>Object[], generic arrays and java.util.Collection</li>
+ * <li><b>MAP: </b>java.util.Map</li>
+ * <li><b>STRUCT: </b>Object[], generic arrays and java.util.Collection</li>
+ * </ul>
+ */
+public abstract class ComplexTypeSerializer {
+
+  private static final Constructor<?> implConstructor;
+
+  static {
+    Constructor<?> cons;
+    try {
+      Class<?> implClass = ClassPathLoader.getLatest().forName(
+          "io.snappydata.impl.ComplexTypeSerializerImpl");
+      cons = implClass.getConstructor(Object.class);
+    } catch (ClassNotFoundException | NoSuchMethodException e) {
+      cons = null;
+    }
+    implConstructor = cons;
+  }
+
+  protected ComplexTypeSerializer() {
+  }
+
+  public static ComplexTypeSerializer create(Object dataType) {
+    if (implConstructor != null) {
+      try {
+        return (ComplexTypeSerializer)implConstructor.newInstance(dataType);
+      } catch (InstantiationException | IllegalAccessException e) {
+        throw new IllegalArgumentException(e.getMessage(), e);
+      } catch (InvocationTargetException ite) {
+        Throwable cause = ite.getCause();
+        throw new IllegalArgumentException(cause.getMessage(), cause);
+      }
+    } else {
+      throw new UnsupportedOperationException(
+          "Compound types are supported only with the SnappyData product.");
+    }
+  }
+
+  /**
+   * Serialize an ARRAY or STRUCT type having values in order in an array.
+   */
+  public abstract <T> byte[] getBytes(T[] v);
+
+  /**
+   * Serialize an ARRAY or STRUCT type having values in order in a collection.
+   */
+  public abstract <T> byte[] getBytes(Collection<T> v);
+
+  /**
+   * Serialize a MAP.
+   */
+  public abstract <K, V> byte[] getBytes(Map<K, V> v);
+
+  /**
+   * Serialize an ARRAY, MAP or STRUCT depending on type of object.
+   */
+  public abstract byte[] getBytes(Object v);
+}


### PR DESCRIPTION
## Changes proposed in this pull request
- ComplexTypeSerializer allows for client side bytes/BLOB serialization of ARRAY, MAP, STRUCT
  types supported by SnappyData column tables. Only works if the snappydata-assembly jar is
  accessible in the classpath
- User has to provide the appropriate DataType/StructField object for the type to avoid the
  overhead of getting the same from server from table schema
- Throw exception if no lead is found in LeadNodeExecutorMsg; also made it HA
- Improved the exception message for SQLState.NO_DATASTORE_FOUND to give proper reason from original exception
## Patch testing

PR on snappydata adds test class that serializes over external JDBC client connections using the new API
## Other PRs

Snappydata PR (fill in)
