### PR TITLE
[GEMXD-18] Disallow LOB/UDT in keys and indexes

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/CreateIndexNode.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/CreateIndexNode.java
@@ -32,13 +32,13 @@ import com.pivotal.gemfirexd.internal.iapi.reference.Property;
 import com.pivotal.gemfirexd.internal.iapi.reference.SQLState;
 import com.pivotal.gemfirexd.internal.iapi.services.property.PropertyUtil;
 import com.pivotal.gemfirexd.internal.iapi.services.sanity.SanityManager;
-import com.pivotal.gemfirexd.internal.iapi.sql.compile.CompilerContext;
 import com.pivotal.gemfirexd.internal.iapi.sql.dictionary.ColumnDescriptor;
 import com.pivotal.gemfirexd.internal.iapi.sql.dictionary.DataDictionary;
 import com.pivotal.gemfirexd.internal.iapi.sql.dictionary.SchemaDescriptor;
 import com.pivotal.gemfirexd.internal.iapi.sql.dictionary.TableDescriptor;
 import com.pivotal.gemfirexd.internal.iapi.sql.execute.ConstantAction;
 import com.pivotal.gemfirexd.internal.iapi.types.DataTypeDescriptor;
+import com.pivotal.gemfirexd.internal.iapi.types.TypeId;
 
 /**
  * A CreateIndexNode is the root of a QueryTree that represents a CREATE INDEX
@@ -198,6 +198,15 @@ public class CreateIndexNode extends DDLStatementNode
 				throw StandardException.newException(SQLState.LANG_COLUMN_NOT_ORDERABLE_DURING_EXECUTION,
 					columnDescriptor.getType().getTypeId().getSQLTypeName());
 			}
+// GemStone changes BEGIN
+			// Don't allow index on a LOB/XML column
+			TypeId typeId = columnDescriptor.getType().getTypeId();
+			if (typeId.isLOBTypeId() || typeId.isXMLTypeId()) {
+			  throw StandardException.newException(
+			      SQLState.LANG_ADD_PRIMARY_KEY_OR_INDEX_ON_LOB_UDT,
+			      columnDescriptor.getColumnName(), typeId.getSQLTypeName());
+                       }
+// GemStone changes END
 		}
 
 		/* Check for number of key columns to be less than 16 to match DB2 */

--- a/gemfirexd/core/src/main/resources/com/pivotal/gemfirexd/internal/loc/messages.xml
+++ b/gemfirexd/core/src/main/resources/com/pivotal/gemfirexd/internal/loc/messages.xml
@@ -1561,6 +1561,13 @@ Guide.
             </msg>
 
             <msg>
+                <name>42832</name>
+                <text>Column '{0}' of type '{1}' cannot be part of a primary/unique key or index because it is of LOB/UDT type.</text>
+                <arg>columnName</arg>
+                <arg>type</arg>
+            </msg>
+
+            <msg>
                 <name>42834</name>
                 <text>SET NULL cannot be specified because FOREIGN KEY '{0}'  cannot contain null values.  </text>
                 <arg>key</arg>

--- a/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/shared/common/reference/SQLState.java
+++ b/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/shared/common/reference/SQLState.java
@@ -813,6 +813,9 @@ public interface SQLState {
 	String LANG_DB2_INVALID_COLS_SPECIFIED                             = "42802";
         String LANG_DB2_INVALID_SELECT_COL_FOR_HAVING = "42803";
 	String LANG_DB2_ADD_UNIQUE_OR_PRIMARY_KEY_ON_NULL_COLS			   = "42831";
+// GemStone changes BEGIN
+	String LANG_ADD_PRIMARY_KEY_OR_INDEX_ON_LOB_UDT = "42832";
+// GemStone changes END
 	String LANG_DB2_REPLACEMENT_ERROR								   = "42815.S.713";
 	String LANG_DB2_COALESCE_DATATYPE_MISMATCH								   = "42815.S.171";
 	String LANG_DB2_TOO_LONG_FLOATING_POINT_LITERAL			           = "42820";

--- a/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/thrift/common/OptimizedElementArray.java
+++ b/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/thrift/common/OptimizedElementArray.java
@@ -34,18 +34,7 @@ import com.gemstone.gemfire.internal.shared.FinalizeObject;
 import com.gemstone.gnu.trove.TIntArrayList;
 import com.pivotal.gemfirexd.internal.shared.common.ResolverUtils;
 import com.pivotal.gemfirexd.internal.shared.common.reference.Limits;
-import com.pivotal.gemfirexd.thrift.BlobChunk;
-import com.pivotal.gemfirexd.thrift.ClobChunk;
-import com.pivotal.gemfirexd.thrift.ColumnDescriptor;
-import com.pivotal.gemfirexd.thrift.ColumnValue;
-import com.pivotal.gemfirexd.thrift.DateTime;
-import com.pivotal.gemfirexd.thrift.Decimal;
-import com.pivotal.gemfirexd.thrift.FieldType;
-import com.pivotal.gemfirexd.thrift.FieldValue;
-import com.pivotal.gemfirexd.thrift.GFXDType;
-import com.pivotal.gemfirexd.thrift.JSONObject;
-import com.pivotal.gemfirexd.thrift.PDXObject;
-import com.pivotal.gemfirexd.thrift.Timestamp;
+import com.pivotal.gemfirexd.thrift.*;
 
 /**
  * A compact way to represent a set of primitive and non-primitive values. The
@@ -245,7 +234,7 @@ public class OptimizedElementArray {
    * 
    * @param sqlTypes
    *          the list of element types ordered by their position
-   * @param boolean useTypes if true then also store the {@link GFXDType}s
+   * @param useTypes if true then also store the {@link GFXDType}s
    *        explicitly else the types will be tracked separately elsewhere and
    *        this class will expect proper getter/setter methods to be invoked
    * @param forSQLTypes
@@ -261,7 +250,7 @@ public class OptimizedElementArray {
    * 
    * @param metadata
    *          the list of {@link ColumnDescriptor}s ordered by their position
-   * @param boolean useTypes if true then also store the {@link GFXDType}s
+   * @param useTypes if true then also store the {@link GFXDType}s
    *        explicitly else the types will be tracked separately elsewhere and
    *        this class will expect proper getter/setter methods to be invoked
    */
@@ -270,7 +259,7 @@ public class OptimizedElementArray {
     this(getTypes(metadata), useTypes);
   }
 
-  public static final GFXDType[] getTypes(List<ColumnDescriptor> metadata) {
+  public static GFXDType[] getTypes(List<ColumnDescriptor> metadata) {
     final GFXDType[] types = new GFXDType[metadata.size()];
     int index = 0;
     for (ColumnDescriptor cd : metadata) {
@@ -322,7 +311,7 @@ public class OptimizedElementArray {
     int result = prims[primIndex++] & 0xff;
     result = (result << 8) | (prims[primIndex++] & 0xff);
     result = (result << 8) | (prims[primIndex++] & 0xff);
-    return ((result << 8) | (prims[primIndex++] & 0xff));
+    return ((result << 8) | (prims[primIndex] & 0xff));
   }
 
   public final long getLong(int index) {
@@ -335,7 +324,7 @@ public class OptimizedElementArray {
     result = (result << 8) | (prims[primIndex++] & 0xff);
     result = (result << 8) | (prims[primIndex++] & 0xff);
     result = (result << 8) | (prims[primIndex++] & 0xff);
-    return ((result << 8) | (prims[primIndex++] & 0xff));
+    return ((result << 8) | (prims[primIndex] & 0xff));
   }
 
   public final float getFloat(int index) {
@@ -735,7 +724,7 @@ public class OptimizedElementArray {
       case (1 << FieldValue.__CHAR_VAL_ISSET_ID):
         ensurePrimCapacity(2);
         this.positionMap[this.size] = this.primSize;
-        setPrimShort(this.primSize, (short)fv.char_val);
+        setPrimShort(this.primSize, fv.char_val);
         setType(this.size, FieldType.CHAR);
         this.size++;
         this.primSize += 2;
@@ -1238,27 +1227,14 @@ public class OptimizedElementArray {
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof OptimizedElementArray) {
-      return equals((OptimizedElementArray)other);
-    }
-    else {
-      return false;
-    }
+    return other instanceof OptimizedElementArray &&
+        equals((OptimizedElementArray)other);
   }
 
   public boolean equals(OptimizedElementArray other) {
-    if (!Arrays.equals(this.positionMap, other.positionMap)) {
-      return false;
-    }
-    if (!Arrays.equals(this.types, other.types)) {
-      return false;
-    }
-    if (!Arrays.equals(this.primitives, other.primitives)) {
-      return false;
-    }
-    if (!Arrays.equals(this.nonPrimitives, other.nonPrimitives)) {
-      return false;
-    }
-    return true;
+    return Arrays.equals(this.positionMap, other.positionMap) &&
+        Arrays.equals(this.types, other.types) &&
+        Arrays.equals(this.primitives, other.primitives) &&
+        Arrays.equals(this.nonPrimitives, other.nonPrimitives);
   }
 }

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/CreateTableTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/CreateTableTest.java
@@ -38,6 +38,7 @@
 
 package com.pivotal.gemfirexd.jdbc;
 
+import java.math.BigDecimal;
 import java.sql.*;
 import java.util.Arrays;
 import java.util.Properties;
@@ -78,6 +79,8 @@ import io.snappydata.test.dunit.VM;
 import junit.framework.TestSuite;
 import junit.textui.TestRunner;
 import org.apache.derbyTesting.functionTests.tests.derbynet.SqlExceptionTest;
+import org.apache.derbyTesting.junit.JDBC;
+import udtexamples.UDTPrice;
 
 @SuppressWarnings("serial")
 public class CreateTableTest extends JdbcTestBase {
@@ -197,7 +200,121 @@ public class CreateTableTest extends JdbcTestBase {
     createTables(conn);
     populateData(conn, false, false);
   }
-  
+
+  public void testLOBUDTKey_GEMXD18() throws SQLException {
+    Connection conn = getConnection();
+    Statement stmt = conn.createStatement();
+    stmt.execute("create schema bob");
+    try {
+      stmt.execute("CREATE TABLE USERS_ROLES(USERID string NOT NULL, "
+          + "ROLEID bigint NOT NULL, PRIMARY KEY (USERID,ROLEID))");
+      fail("Expected exception for LOB type as primary key");
+    } catch (SQLException sqle) {
+      if (!"42832".equals(sqle.getSQLState())) {
+        throw sqle;
+      }
+    }
+    try {
+      stmt.execute("CREATE TABLE USERS_ROLES(USERID string NOT NULL UNIQUE, "
+          + "ROLEID bigint NOT NULL)");
+      fail("Expected exception for LOB type as unique key");
+    } catch (SQLException sqle) {
+      if (!"42832".equals(sqle.getSQLState())) {
+        throw sqle;
+      }
+    }
+    // check UDT disallowed as key
+    stmt.execute("CREATE TYPE UDTPrice " +
+        "EXTERNAL NAME 'udtexamples.UDTPrice' LANGUAGE JAVA");
+    try {
+      stmt.execute("CREATE TABLE USERS_TICKETS(USERID string, "
+          + "ROLEID bigint NOT NULL, TICKETPRICE UDTPrice UNIQUE)");
+      fail("Expected exception for UDT type as unique key");
+    } catch (SQLException sqle) {
+      if (!"42832".equals(sqle.getSQLState())) {
+        throw sqle;
+      }
+    }
+    stmt.execute("CREATE TABLE USERS_TICKETS(USERID string NOT NULL, "
+        + "ROLEID bigint NOT NULL, TICKETPRICE UDTPrice)");
+    try {
+      stmt.execute(
+          "CREATE INDEX USERS_TICKETS_PRICE ON USERS_TICKETS(TICKETPRICE)");
+      fail("Expected exception for UDT type as index key");
+    } catch (SQLException sqle) {
+      if (!"X0X67".equals(sqle.getSQLState())) {
+        throw sqle;
+      }
+    }
+
+    stmt.execute("CREATE TABLE USERS_ROLES(USERID string NOT NULL, "
+        + "ROLEID bigint NOT NULL) PARTITION BY COLUMN(USERID,ROLEID)");
+    try {
+      stmt.execute("CREATE INDEX USERS_ROLES_ID ON USERS_ROLES(USERID)");
+      fail("Expected exception for LOB type as index key");
+    } catch (SQLException sqle) {
+      if (!"42832".equals(sqle.getSQLState())) {
+        throw sqle;
+      }
+    }
+
+    stmt.execute("CREATE INDEX USERS_ROLES_ROLE ON USERS_ROLES(ROLEID)");
+
+    stmt.execute("insert into users_roles values('two', 3), ('four', 5)");
+
+    ResultSet rs;
+    String[][] expected = new String[][]{
+        new String[]{"two", "3"},
+        new String[]{"four", "5"}
+    };
+    String[][] expected2 = new String[][]{
+        new String[]{"two", "3"}
+    };
+    rs = stmt.executeQuery("select * from users_roles");
+    JDBC.assertUnorderedResultSet(rs, expected);
+    rs = stmt.executeQuery("select * from users_roles where roleId > 2");
+    JDBC.assertUnorderedResultSet(rs, expected);
+    rs = stmt.executeQuery(
+        "select * from users_roles where roleId > 1 and roleId < 4");
+    JDBC.assertUnorderedResultSet(rs, expected2);
+    rs = stmt.executeQuery("select * from users_roles where roleId != 4");
+    JDBC.assertUnorderedResultSet(rs, expected);
+    rs = stmt.executeQuery("select * from users_roles where roleId != 5");
+    JDBC.assertUnorderedResultSet(rs, expected2);
+
+    // next for table having UDT type
+    stmt.execute("CREATE INDEX USERS_TICKETS_ROLES ON USERS_TICKETS(ROLEID)");
+    PreparedStatement pstmt = conn.prepareStatement(
+        "insert into USERS_TICKETS values(?, ?, ?)");
+    pstmt.setString(1, "two");
+    pstmt.setInt(2, 3);
+    pstmt.setObject(3, new UDTPrice(new BigDecimal("1.1"), new BigDecimal("2.2")));
+    pstmt.execute();
+    pstmt.setString(1, "four");
+    pstmt.setInt(2, 5);
+    pstmt.setObject(3, new UDTPrice(new BigDecimal("0.1"), new BigDecimal("3.2")));
+    pstmt.execute();
+
+    expected = new String[][]{
+        new String[]{"two", "3", "highPrice is 2.2 low price is 1.1"},
+        new String[]{"four", "5", "highPrice is 3.2 low price is 0.1"}
+    };
+    expected2 = new String[][]{
+        new String[]{"two", "3", "highPrice is 2.2 low price is 1.1"},
+    };
+    rs = stmt.executeQuery("select * from users_tickets");
+    JDBC.assertUnorderedResultSet(rs, expected);
+    rs = stmt.executeQuery("select * from users_tickets where roleId > 2");
+    JDBC.assertUnorderedResultSet(rs, expected);
+    rs = stmt.executeQuery(
+        "select * from users_tickets where roleId > 1 and roleId < 4");
+    JDBC.assertUnorderedResultSet(rs, expected2);
+    rs = stmt.executeQuery("select * from users_tickets where roleId != 4");
+    JDBC.assertUnorderedResultSet(rs, expected);
+    rs = stmt.executeQuery("select * from users_tickets where roleId != 5");
+    JDBC.assertUnorderedResultSet(rs, expected2);
+  }
+
   public void testNPE_43664() throws SQLException {
     Connection conn = getConnection();
     Statement stmt = conn.createStatement();


### PR DESCRIPTION
## Changes proposed in this pull request

Explicitly check for LOB/XML/UDT columns for primary/unique keys and indexed columns since CLOBs have now been made orderable but we cannot still support those columns as keys due to various complications as mentioned in [GEMXD-18](https://snappydata.atlassian.net/browse/GEMXD-18)

These columns are allowed as part of partitioning.
## Patch testing

Added a unit test CreateTableTest.testLOBUDTKey_GEMXD18 to check for failure/success with various combinations.

Running store precheckin.
## Other PRs

N/A
