### PR TITLE
Fixes Delta GII issue when tx ops are in progress

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/cache/CacheFactory.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/cache/CacheFactory.java
@@ -258,7 +258,8 @@ public class CacheFactory {
     // deadlock when messaging returns to this VM
     final int initReq = LocalRegion.threadInitLevelRequirement();
     if (initReq == LocalRegion.ANY_INIT
-        || initReq == LocalRegion.BEFORE_INITIAL_IMAGE || (InitialImageOperation.anyTestHookInstalled())) { // fix bug 33471
+        || initReq == LocalRegion.BEFORE_INITIAL_IMAGE  // fix bug 33471
+        || (InitialImageOperation.anyTestHookInstalled())) {
       return basicGetInstancePart2(system, closeOk);
     } else {
       synchronized (CacheFactory.class) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/cache/CacheFactory.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/cache/CacheFactory.java
@@ -24,6 +24,7 @@ import com.gemstone.gemfire.distributed.internal.InternalDistributedSystem;
 import com.gemstone.gemfire.internal.GemFireVersion;
 import com.gemstone.gemfire.internal.cache.CacheConfig;
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
+import com.gemstone.gemfire.internal.cache.InitialImageOperation;
 import com.gemstone.gemfire.internal.cache.LocalRegion;
 import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import com.gemstone.gemfire.internal.jndi.JNDIInvoker;
@@ -257,7 +258,7 @@ public class CacheFactory {
     // deadlock when messaging returns to this VM
     final int initReq = LocalRegion.threadInitLevelRequirement();
     if (initReq == LocalRegion.ANY_INIT
-        || initReq == LocalRegion.BEFORE_INITIAL_IMAGE) { // fix bug 33471
+        || initReq == LocalRegion.BEFORE_INITIAL_IMAGE || (InitialImageOperation.anyTestHookInstalled())) { // fix bug 33471
       return basicGetInstancePart2(system, closeOk);
     } else {
       synchronized (CacheFactory.class) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
@@ -19,15 +19,7 @@ package com.gemstone.gemfire.internal.cache;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -47,9 +39,12 @@ import com.gemstone.gemfire.cache.query.QueryException;
 import com.gemstone.gemfire.cache.query.internal.IndexUpdater;
 import com.gemstone.gemfire.cache.query.internal.index.IndexManager;
 import com.gemstone.gemfire.cache.query.internal.index.IndexProtocol;
+import com.gemstone.gemfire.distributed.internal.DM;
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
 import com.gemstone.gemfire.i18n.LogWriterI18n;
 import com.gemstone.gemfire.internal.Assert;
+import com.gemstone.gemfire.internal.ByteArrayDataInput;
+import com.gemstone.gemfire.internal.HeapDataOutputStream;
 import com.gemstone.gemfire.internal.cache.DiskInitFile.DiskRegionFlag;
 import com.gemstone.gemfire.internal.cache.FilterRoutingInfo.FilterInfo;
 import com.gemstone.gemfire.internal.cache.delta.Delta;
@@ -73,6 +68,7 @@ import com.gemstone.gemfire.internal.concurrent.CustomEntryConcurrentHashMap.Has
 import com.gemstone.gemfire.internal.concurrent.MapCallbackAdapter;
 import com.gemstone.gemfire.internal.concurrent.MapResult;
 import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
+import com.gemstone.gemfire.internal.offheap.ByteSource;
 import com.gemstone.gemfire.internal.offheap.OffHeapHelper;
 import com.gemstone.gemfire.internal.offheap.OffHeapRegionEntryHelper;
 import com.gemstone.gemfire.internal.offheap.SimpleMemoryAllocatorImpl;
@@ -82,7 +78,9 @@ import com.gemstone.gemfire.internal.offheap.annotations.Retained;
 import com.gemstone.gemfire.internal.offheap.annotations.Unretained;
 import com.gemstone.gemfire.internal.sequencelog.EntryLogger;
 import com.gemstone.gemfire.internal.shared.SystemProperties;
+import com.gemstone.gemfire.internal.shared.Version;
 import com.gemstone.gemfire.internal.size.SingleObjectSizer;
+import com.gemstone.gemfire.internal.util.ArrayUtils;
 import com.gemstone.gemfire.pdx.PdxInstance;
 import com.gemstone.gemfire.pdx.PdxSerializationException;
 import com.gemstone.gemfire.pdx.internal.ConvertableToBytes;
@@ -2253,7 +2251,17 @@ RETRY_LOOP:
         txRemoveOldIndexEntry(Operation.DESTROY, re);
         boolean clearOccured = false;
         try {
-          processAndGenerateTXVersionTag(owner, cbEvent, re, txr);
+          EntryEventImpl txEvent = null;
+          if (!isRegionReady) {
+            if (re.isTombstone() || re.isDestroyedOrRemoved()) {
+              // creating the event just to process the version tag.
+              txEvent = createCBEvent(owner, localOp ? Operation.LOCAL_DESTROY
+                      : Operation.DESTROY, key, null, txState, eventId,
+                  aCallbackArgument, filterRoutingInfo, bridgeContext,
+                  versionTag, tailKey, cbEvent);
+            }
+          }
+          processAndGenerateTXVersionTag(owner, (txEvent != null) ? txEvent : cbEvent, re, txr);
           if (inTokenMode) {
             re.setValue(owner, Token.DESTROYED);
           }
@@ -2308,7 +2316,17 @@ RETRY_LOOP:
         }
 
         try {
-          processAndGenerateTXVersionTag(owner, cbEvent, re, txr);
+          EntryEventImpl txEvent = null;
+          if (!isRegionReady) {
+            if (re.isTombstone() || re.isDestroyedOrRemoved()) {
+              // creating the event just to process the version tag.
+              txEvent = createCBEvent(owner, localOp ? Operation.LOCAL_DESTROY
+                      : Operation.DESTROY, key, null, txState, eventId,
+                  aCallbackArgument, filterRoutingInfo, bridgeContext,
+                  versionTag, tailKey, cbEvent);
+            }
+          }
+          processAndGenerateTXVersionTag(owner, (txEvent != null) ? txEvent : cbEvent, re, txr);
           int oldSize = 0;
           if (cbEvent != null && owner.getConcurrencyChecksEnabled()
               && (versionTag = cbEvent.getVersionTag()) != null) {
@@ -4429,7 +4447,21 @@ RETRY_LOOP:
         OffHeapHelper.releaseWithNoTracking(oldValue);
       }
       }
-      processAndGenerateTXVersionTag(owner, cbEvent, re, txr);
+      boolean flag = false;
+      EntryEventImpl txEvent = null;
+      if (!isRegionReady && owner.getConcurrencyChecksEnabled()) {
+        InitialImageOperation.Entry tmplEntry = new InitialImageOperation.Entry();
+
+        flag = checkIfEqualValue(owner, re, tmplEntry, newValue);
+
+        // creating the event just to process the version tag.
+        txEvent = createCBEvent(owner, putOp, key, newValue, txState, eventId,
+            aCallbackArgument, filterRoutingInfo, bridgeContext, versionTag,
+            tailKey, cbEvent);
+      }
+      if (!flag) {
+        processAndGenerateTXVersionTag(owner, !isRegionReady ? txEvent : cbEvent, re, txr);
+      }
       txRemoveOldIndexEntry(putOp, re);
       if (didDestroy) {
         re.txDidDestroy(lastMod);
@@ -4564,6 +4596,87 @@ RETRY_LOOP:
       if (!cbEventInPending && cbEvent != null) cbEvent.release();
     }
   }
+
+  private boolean checkIfEqualValue(LocalRegion region, RegionEntry re, InitialImageOperation.Entry tmplEntry,
+      Object tmpValue) {
+    final DM dm = region.getDistributionManager();
+    final ByteArrayDataInput in = new ByteArrayDataInput();
+    final HeapDataOutputStream out = new HeapDataOutputStream(
+        Version.CURRENT);
+
+    if (re.fillInValue(region, tmplEntry, in, dm, null)) {
+      try {
+        if (tmplEntry.value != null) {
+          final byte[] valueInCache;
+          boolean areEqual = true;
+          final Class<?> vclass = tmplEntry.value.getClass();
+          if (vclass == byte[].class) {
+            valueInCache = (byte[])tmplEntry.value;
+            return Arrays.equals(valueInCache, (byte[])tmpValue);
+          } else if (vclass == byte[][].class) {
+            if (tmpValue instanceof byte[][]) {
+              final byte[][] v1 = (byte[][])tmplEntry.value;
+              final byte[][] v2 = (byte[][])tmpValue;
+              areEqual = ArrayUtils.areByteArrayArrayEquals(v1,
+                  v2);
+              if (areEqual) {
+                return true;
+              } else {
+                valueInCache = null;
+              }
+            } else {
+              valueInCache = EntryEventImpl
+                  .serialize(tmplEntry.value, out);
+            }
+          } else if (ByteSource.class.isAssignableFrom(vclass)) {
+            ByteSource bs = (ByteSource)tmplEntry.value;
+            // TODO: PERF: Asif: optimize ByteSource to allow
+            // comparison without reading byte[][] into memory
+            Object storedObject = bs
+                .getValueAsDeserializedHeapObject();
+            final Class<?> cls;
+            if (storedObject == null) {
+              valueInCache = null;
+            } else if ((cls = storedObject.getClass()) == byte[].class) {
+              valueInCache = (byte[])storedObject;
+            } else if (cls == byte[][].class
+                && tmpValue instanceof byte[][]) {
+              final byte[][] v1 = (byte[][])storedObject;
+              final byte[][] v2 = (byte[][])tmpValue;
+              areEqual = ArrayUtils.areByteArrayArrayEquals(v1,
+                  v2);
+              if (areEqual) {
+                return true;
+              } else {
+                valueInCache = null;
+              }
+            } else {
+              valueInCache = EntryEventImpl
+                  .serialize(storedObject, out);
+            }
+          } else if (HeapDataOutputStream.class
+              .isAssignableFrom(vclass)) {
+            valueInCache = ((HeapDataOutputStream)tmplEntry.value)
+                .toByteArray();
+          } else {
+            valueInCache = EntryEventImpl
+                .serialize(tmplEntry.value, out);
+          }
+          // compare byte arrays
+          if (areEqual) {
+            byte[] tmpBytes = EntryEventImpl.serialize(tmpValue, out);
+            if (Arrays.equals(valueInCache, tmpBytes)) {
+              return true;
+            }
+          }
+        }
+      } finally {
+        OffHeapHelper.release(tmplEntry.value);
+      }
+    }
+    return false;
+  }
+
 
   /**
    * called from txApply* methods to process and generate versionTags.

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
@@ -2201,6 +2201,7 @@ RETRY_LOOP:
 
     final LocalRegion owner = _getOwner();
 
+    owner.getLogWriterI18n().fine("SKSK comign here for key " , new Exception("SKSK"));
     final boolean isRegionReady = !inTokenMode;
     boolean cbEventInPending = false;
     LogWriterI18n log = owner.getLogWriterI18n();
@@ -2251,17 +2252,7 @@ RETRY_LOOP:
         txRemoveOldIndexEntry(Operation.DESTROY, re);
         boolean clearOccured = false;
         try {
-          EntryEventImpl txEvent = null;
-          if (!isRegionReady) {
-            if (re.isTombstone() || re.isDestroyedOrRemoved()) {
-              // creating the event just to process the version tag.
-              txEvent = createCBEvent(owner, localOp ? Operation.LOCAL_DESTROY
-                      : Operation.DESTROY, key, null, txState, eventId,
-                  aCallbackArgument, filterRoutingInfo, bridgeContext,
-                  versionTag, tailKey, cbEvent);
-            }
-          }
-          processAndGenerateTXVersionTag(owner, (txEvent != null) ? txEvent : cbEvent, re, txr);
+          processAndGenerateTXVersionTag(owner, cbEvent, re, txr);
           if (inTokenMode) {
             re.setValue(owner, Token.DESTROYED);
           }
@@ -2299,6 +2290,7 @@ RETRY_LOOP:
         }
       }
       else if (inTokenMode || owner.concurrencyChecksEnabled) {
+
         if (shouldCreateCBEvent(owner,
             false /* isInvalidate */, isRegionReady || inRI)) {
           cbEvent = createCBEvent(owner, localOp ? Operation.LOCAL_DESTROY
@@ -2318,15 +2310,14 @@ RETRY_LOOP:
         try {
           EntryEventImpl txEvent = null;
           if (!isRegionReady) {
-            if (re.isTombstone() || re.isDestroyedOrRemoved()) {
-              // creating the event just to process the version tag.
-              txEvent = createCBEvent(owner, localOp ? Operation.LOCAL_DESTROY
-                      : Operation.DESTROY, key, null, txState, eventId,
-                  aCallbackArgument, filterRoutingInfo, bridgeContext,
-                  versionTag, tailKey, cbEvent);
-            }
+            // creating the event just to process the version tag.
+            txEvent = createCBEvent(owner, localOp ? Operation.LOCAL_DESTROY
+                    : Operation.DESTROY, key, null, txState, eventId,
+                aCallbackArgument, filterRoutingInfo, bridgeContext,
+                versionTag, tailKey, cbEvent);
           }
           processAndGenerateTXVersionTag(owner, (txEvent != null) ? txEvent : cbEvent, re, txr);
+
           int oldSize = 0;
           if (cbEvent != null && owner.getConcurrencyChecksEnabled()
               && (versionTag = cbEvent.getVersionTag()) != null) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/InitialImageOperation.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/InitialImageOperation.java
@@ -4676,6 +4676,23 @@ public class InitialImageOperation  {
     }
   }
 
+  public static boolean anyTestHookInstalled() {
+    return (internalBeforeGetInitialImage != null ||
+    internalBeforeRequestRVV != null ||
+    internalAfterRequestRVV != null ||
+    internalAfterCalculatedUnfinishedOps != null ||
+    internalBeforeSavedReceivedRVV != null ||
+    internalAfterSavedReceivedRVV != null ||
+    internalAfterSentRequestImage != null ||
+    internalAfterReceivedRequestImage != null ||
+    internalDuringPackingImage != null ||
+    internalAfterSentImageReply != null ||
+    internalAfterReceivedImageReply != null ||
+    internalDuringApplyDelta != null ||
+    internalBeforeCleanExpiredTombstones != null ||
+    internalAfterSavedRVVEnd != null);
+  }
+
   public static void resetGIITestHook(final GIITestHookType type, final boolean setNull) {
     switch (type) {
     case BeforeGetInitialImage: // 0

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/gii/DeltaGIIDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/gii/DeltaGIIDUnit.java
@@ -91,9 +91,6 @@ public class DeltaGIIDUnit  extends DistributedSQLTestBase {
    * @throws Exception
    */
   public void testGFXDDeltaWithDeltaGII() throws Exception {
-	  if(isTransactional) {
-		  return;
-	  }
     startVMs(0, 2);
     startVMs(1, 0);
     createDiskStore(true, 1);
@@ -203,9 +200,6 @@ public class DeltaGIIDUnit  extends DistributedSQLTestBase {
    * @throws Exception
    */
   public void testGFXDDeltaWithDeltaGII_serverExecute() throws Exception {
-	  if(isTransactional) {
-		  return;
-	  }
     startVMs(0, 2);
     startVMs(1, 0);
     createDiskStore(true, 1);
@@ -420,9 +414,6 @@ public class DeltaGIIDUnit  extends DistributedSQLTestBase {
    * @throws Exception
    */
   public void testGFXDDeleteWithDeltaGIITX() throws Exception {
-    if(isTransactional) {
-      return;
-    }
     startVMs(0, 2);
     startVMs(1, 0);
     createDiskStore(true, 1);
@@ -535,9 +526,6 @@ public class DeltaGIIDUnit  extends DistributedSQLTestBase {
    * @throws Exception
    */
   public void testGFXDDeltaWithDeltaGIITX() throws Exception {
-    if(isTransactional) {
-      return;
-    }
     startVMs(0, 2);
     startVMs(1, 0);
     createDiskStore(true, 1);

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/gii/DeltaGIIDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/gii/DeltaGIIDUnit.java
@@ -150,7 +150,7 @@ public class DeltaGIIDUnit  extends DistributedSQLTestBase {
     psUpdate.setString(1, "AfterReceivedImageReply");
     psUpdate.setInt(2, 4);
     psUpdate.execute();
-    expected.put(4,  "AfterReceivedImageReply");
+    expected.put(4, "AfterReceivedImageReply");
     
     //unblock the GII. The GII should now finish
     unblockGII(-2, GIITestHookType.AfterReceivedImageReply);
@@ -294,7 +294,354 @@ public class DeltaGIIDUnit  extends DistributedSQLTestBase {
     }
     
   }
-  
+
+  /**
+   * Test insufficient data store behaviour for distributed/update/delete/select
+   * and for primary key based select/update/delete
+   *
+   * @throws Exception
+   */
+  public void testGFXDDeltaWithDeltaGIINoAutoCommit() throws Exception {
+    startVMs(0, 2);
+    startVMs(1, 0);
+    createDiskStore(true, 1);
+    // Create a schema
+    clientSQLExecute(1, "create schema trade");
+
+    Map<Integer, String> expected = new HashMap<Integer, String>();
+    clientSQLExecute(1, "create table trade.customers (cid int not null, "
+        + "cust_name varchar(100), tid int, primary key (cid)) ENABLE CONCURRENCY CHECKS replicate "
+        + getSuffix());
+    Connection conn = TestUtil.getConnection();
+    conn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+    conn.setAutoCommit(false);
+    PreparedStatement psInsert = conn
+        .prepareStatement("insert into trade.customers values (?,?,?)");
+    for (int i = 1; i < 5; ++i) {
+      psInsert.setInt(1, i);
+      psInsert.setString(2, "unmodified");
+      psInsert.setInt(3, i);
+      psInsert.executeUpdate();
+      expected.put(i,  "unmodified");
+    }
+    conn.commit();
+    //Stop a VM, and create some modifications
+    stopVMNums(-2);
+
+    PreparedStatement psUpdate = conn
+        .prepareStatement("update trade.customers set cust_name=? where cid=?");
+    psUpdate.setString(1, "BeforeRestart");
+    psUpdate.setInt(2, 2);
+    psUpdate.execute();
+    conn.commit();
+    expected.put(2,  "BeforeRestart");
+
+    blockGII(-2, GIITestHookType.BeforeRequestRVV);
+    blockGII(-2, GIITestHookType.AfterReceivedImageReply);
+
+    AsyncVM async2 = restartServerVMAsync(2, 0, null, null);
+
+    waitForGIICallbackStarted(-2, GIITestHookType.BeforeRequestRVV);
+
+    //Do an update before requesting the RVV. If we apply this update
+    //to the RVV On the recipient, it will cause us to fail to fetch the base
+    //value for the row
+    psUpdate.setString(1, "BeforeRequestRVV");
+    psUpdate.setInt(2, 3);
+    psUpdate.execute();
+    conn.commit();
+    expected.put(3,  "BeforeRequestRVV");
+
+    //Let the GII proceeed until after we receive the initial image reply
+    //(but before we process it)
+    unblockGII(-2, GIITestHookType.BeforeRequestRVV);
+
+    waitForGIICallbackStarted(-2, GIITestHookType.AfterReceivedImageReply);
+
+    //Do an update. If this is not applied to the RVV at some point
+    //the RVV will not match the region contents.
+    psUpdate.setString(1, "AfterReceivedImageReply");
+    psUpdate.setInt(2, 4);
+    psUpdate.execute();
+    conn.commit();
+    expected.put(4,  "AfterReceivedImageReply");
+
+    //unblock the GII. The GII should now finish
+    unblockGII(-2, GIITestHookType.AfterReceivedImageReply);
+
+    System.out.println("SKSK unblockGII AfterReceivedImageReply");
+    joinVM(false, async2);
+
+
+
+    RegionVersionVector rvv1 = getRVV(-1);
+    RegionVersionVector rvv2 = getRVV(-2);
+    if(!rvv1.logicallySameAs(rvv2)) {
+      fail("RVVS don't match. provider=" +rvv1.fullToString() + ", recipient=" + rvv2.fullToString());
+    }
+
+    {
+      //Make sure vm2 has the correct contents.
+      //Now we want to validate the region contents and RVVs...
+      Statement s = conn.createStatement();
+      s.execute("select * from trade.customers");
+      ResultSet rs = s.getResultSet();
+
+      Map<Integer, String> received = new HashMap();
+      while(rs.next()) {
+        received.put(rs.getInt("cid"), rs.getString("cust_name"));
+      }
+
+      assertEquals(expected,received);
+    }
+
+    stopVMNums(-1);
+
+    //Make sure vm2 has the correct contents.
+    //Now we want to validate the region contents and RVVs...
+    {
+      Statement s = conn.createStatement();
+      s.execute("select * from trade.customers");
+      ResultSet rs = s.getResultSet();
+
+      Map<Integer, String> received = new HashMap();
+      while(rs.next()) {
+        received.put(rs.getInt("cid"), rs.getString("cust_name"));
+      }
+      assertEquals(expected,received);
+    }
+    conn.commit();
+  }
+
+  /**
+   * Test insufficient data store behaviour for distributed/update/delete/select
+   * and for primary key based select/update/delete
+   *
+   * @throws Exception
+   */
+  public void testGFXDDeleteWithDeltaGIITX() throws Exception {
+    if(isTransactional) {
+      return;
+    }
+    startVMs(0, 2);
+    startVMs(1, 0);
+    createDiskStore(true, 1);
+    // Create a schema
+    clientSQLExecute(1, "create schema trade");
+
+    Map<Integer, String> expected = new HashMap<Integer, String>();
+    clientSQLExecute(1, "create table trade.customers (cid int not null, "
+        + "cust_name varchar(100), tid int, primary key (cid)) ENABLE CONCURRENCY CHECKS replicate "
+        + getSuffix());
+    Connection conn = TestUtil.getConnection();
+    conn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+    conn.setAutoCommit(true);
+    PreparedStatement psInsert = conn
+        .prepareStatement("insert into trade.customers values (?,?,?)");
+    for (int i = 1; i < 5; ++i) {
+      psInsert.setInt(1, i);
+      psInsert.setString(2, "unmodified");
+      psInsert.setInt(3, i);
+      psInsert.executeUpdate();
+      expected.put(i,  "unmodified");
+    }
+    //Stop a VM, and create some modifications
+    stopVMNums(-2);
+
+    PreparedStatement psUpdate = conn
+        .prepareStatement("update trade.customers set cust_name=? where cid=?");
+    psUpdate.setString(1, "BeforeRestart");
+    psUpdate.setInt(2, 2);
+    psUpdate.execute();
+    expected.put(2,  "BeforeRestart");
+
+    blockGII(-2, GIITestHookType.BeforeRequestRVV);
+    blockGII(-2, GIITestHookType.AfterReceivedImageReply);
+
+    AsyncVM async2 = restartServerVMAsync(2, 0, null, null);
+
+    waitForGIICallbackStarted(-2, GIITestHookType.BeforeRequestRVV);
+
+    //Do an update before requesting the RVV. If we apply this update
+    //to the RVV On the recipient, it will cause us to fail to fetch the base
+    //value for the row
+    psUpdate.setString(1, "BeforeRequestRVV");
+    psUpdate.setInt(2, 3);
+    psUpdate.execute();
+
+    expected.put(3,  "BeforeRequestRVV");
+
+    //Let the GII proceeed until after we receive the initial image reply
+    //(but before we process it)
+    unblockGII(-2, GIITestHookType.BeforeRequestRVV);
+
+    waitForGIICallbackStarted(-2, GIITestHookType.AfterReceivedImageReply);
+
+    //Do a delete. If this is not applied to the RVV at some point
+    //the RVV will not match the region contents.
+
+    Statement st = conn.createStatement();
+    boolean b = st.execute("delete from trade.customers where cid = 4");
+    expected.remove(4);
+
+    //unblock the GII. The GII should now finish
+    unblockGII(-2, GIITestHookType.AfterReceivedImageReply);
+
+    joinVM(false, async2);
+
+    RegionVersionVector rvv1 = getRVV(-1);
+    RegionVersionVector rvv2 = getRVV(-2);
+    if(!rvv1.logicallySameAs(rvv2)) {
+      fail("RVVS don't match. provider=" +rvv1.fullToString() + ", recipient=" + rvv2.fullToString());
+    }
+
+    {
+      //Make sure vm2 has the correct contents.
+      //Now we want to validate the region contents and RVVs...
+      Statement s = conn.createStatement();
+      s.execute("select * from trade.customers");
+      ResultSet rs = s.getResultSet();
+
+      Map<Integer, String> received = new HashMap();
+      while(rs.next()) {
+        received.put(rs.getInt("cid"), rs.getString("cust_name"));
+      }
+      assertEquals(expected,received);
+    }
+
+    stopVMNums(-1);
+
+    //Make sure vm2 has the correct contents.
+    //Now we want to validate the region contents and RVVs...
+    {
+      Statement s = conn.createStatement();
+      s.execute("select * from trade.customers");
+      ResultSet rs = s.getResultSet();
+
+      Map<Integer, String> received = new HashMap();
+      while(rs.next()) {
+        received.put(rs.getInt("cid"), rs.getString("cust_name"));
+      }
+      assertEquals(expected,received);
+    }
+  }
+
+
+
+  /**
+   * Test insufficient data store behaviour for distributed/update/delete/select
+   * and for primary key based select/update/delete
+   *
+   * @throws Exception
+   */
+  public void testGFXDDeltaWithDeltaGIITX() throws Exception {
+    if(isTransactional) {
+      return;
+    }
+    startVMs(0, 2);
+    startVMs(1, 0);
+    createDiskStore(true, 1);
+    // Create a schema
+    clientSQLExecute(1, "create schema trade");
+
+    Map<Integer, String> expected = new HashMap<Integer, String>();
+    clientSQLExecute(1, "create table trade.customers (cid int not null, "
+        + "cust_name varchar(100), tid int, primary key (cid)) ENABLE CONCURRENCY CHECKS replicate "
+        + getSuffix());
+    Connection conn = TestUtil.getConnection();
+    conn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+    conn.setAutoCommit(true);
+    PreparedStatement psInsert = conn
+        .prepareStatement("insert into trade.customers values (?,?,?)");
+    for (int i = 1; i < 5; ++i) {
+      psInsert.setInt(1, i);
+      psInsert.setString(2, "unmodified");
+      psInsert.setInt(3, i);
+      psInsert.executeUpdate();
+      expected.put(i,  "unmodified");
+    }
+    //Stop a VM, and create some modifications
+    stopVMNums(-2);
+
+    PreparedStatement psUpdate = conn
+        .prepareStatement("update trade.customers set cust_name=? where cid=?");
+    psUpdate.setString(1, "BeforeRestart");
+    psUpdate.setInt(2, 2);
+    psUpdate.execute();
+    expected.put(2,  "BeforeRestart");
+
+    blockGII(-2, GIITestHookType.BeforeRequestRVV);
+    blockGII(-2, GIITestHookType.AfterReceivedImageReply);
+
+    AsyncVM async2 = restartServerVMAsync(2, 0, null, null);
+
+    waitForGIICallbackStarted(-2, GIITestHookType.BeforeRequestRVV);
+
+    //Do an update before requesting the RVV. If we apply this update
+    //to the RVV On the recipient, it will cause us to fail to fetch the base
+    //value for the row
+    psUpdate.setString(1, "BeforeRequestRVV");
+    psUpdate.setInt(2, 3);
+    psUpdate.execute();
+
+    expected.put(3,  "BeforeRequestRVV");
+
+    //Let the GII proceeed until after we receive the initial image reply
+    //(but before we process it)
+    unblockGII(-2, GIITestHookType.BeforeRequestRVV);
+
+    waitForGIICallbackStarted(-2, GIITestHookType.AfterReceivedImageReply);
+
+    //Do an update. If this is not applied to the RVV at some point
+    //the RVV will not match the region contents.
+    psUpdate.setString(1, "AfterReceivedImageReply");
+    psUpdate.setInt(2, 4);
+    psUpdate.execute();
+    expected.put(4,  "AfterReceivedImageReply");
+
+    //unblock the GII. The GII should now finish
+    unblockGII(-2, GIITestHookType.AfterReceivedImageReply);
+
+    joinVM(false, async2);
+
+    RegionVersionVector rvv1 = getRVV(-1);
+    RegionVersionVector rvv2 = getRVV(-2);
+    if(!rvv1.logicallySameAs(rvv2)) {
+      fail("RVVS don't match. provider=" +rvv1.fullToString() + ", recipient=" + rvv2.fullToString());
+    }
+
+    {
+      //Make sure vm2 has the correct contents.
+      //Now we want to validate the region contents and RVVs...
+      Statement s = conn.createStatement();
+      s.execute("select * from trade.customers");
+      ResultSet rs = s.getResultSet();
+
+      Map<Integer, String> received = new HashMap();
+      while(rs.next()) {
+        received.put(rs.getInt("cid"), rs.getString("cust_name"));
+      }
+
+      assertEquals(expected,received);
+    }
+
+    stopVMNums(-1);
+
+    //Make sure vm2 has the correct contents.
+    //Now we want to validate the region contents and RVVs...
+    {
+      Statement s = conn.createStatement();
+      s.execute("select * from trade.customers");
+      ResultSet rs = s.getResultSet();
+
+      Map<Integer, String> received = new HashMap();
+      while(rs.next()) {
+        received.put(rs.getInt("cid"), rs.getString("cust_name"));
+      }
+      assertEquals(expected,received);
+    }
+  }
+
   public void blockGII(int vmNum, GIITestHookType type) throws Exception {
     serverExecute(-vmNum, new BlockGII(type));
   }


### PR DESCRIPTION
## Changes proposed in this pull request

Check for values in txApplyPut before processing versionTag
Check if the entry is already destroyed in txApplyDestroy before processing versionTag
## Patch testing

Added new tests
## Other PRs

(Does this change required changes in other projects- snappyData, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

  As a workaround check for the value and if the value are same, don't increment
  the RVV
  The value check is done only for entries that are pending ops so there is not much
  perf issue
