### PR TITLE
Fixes tx delete isse (SNAP-736)

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DistributedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DistributedRegion.java
@@ -343,6 +343,9 @@ public class DistributedRegion extends LocalRegion implements
     if (event.getVersionTag() != null && event.getVersionTag().getRegionVersion() > 0) {
       return false;
     }
+    if (isTX()) {
+      return false;
+    }
     // if we're not allowed to generate a version tag we need to send it to someone who can
     if (this.concurrencyChecksEnabled && !this.generateVersionTag) {
       return true;


### PR DESCRIPTION
## Changes proposed in this pull request

Avoid extra hop which in case of tx delete was causing region not to be added in affected list
## Patch testing

Added new tests for the issue.
## Other PRs

(Does this change required changes in other projects- snappyData, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

```
Fixes an issue where tx delete ops were not committed
```
