### PR TITLE
[SNAP-757] Use CLOBs as return values for relevant system procedures

### DIFF
--- a/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/am/SingleHopPreparedStatement.java
+++ b/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/am/SingleHopPreparedStatement.java
@@ -534,7 +534,7 @@ public abstract class SingleHopPreparedStatement extends PreparedStatement {
 
       getBktLocationProc
           .setString(1, this.singleHopInformation.getRegionName());
-      getBktLocationProc.registerOutParameter(2, java.sql.Types.LONGVARCHAR);
+      getBktLocationProc.registerOutParameter(2, java.sql.Types.CLOB);
       getBktLocationProc.execute();
       String bucketToServerMappingStr = getBktLocationProc.getString(2);
       if (SanityManager.TraceSingleHop) {

--- a/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/net/NetConnection.java
+++ b/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/net/NetConnection.java
@@ -1341,7 +1341,7 @@ public class NetConnection extends com.pivotal.gemfirexd.internal.client.am.Conn
     public java.sql.CallableStatement getBucketToServerDetails_;
 
     public static final String BUCKET_AND_SERVER_PROC_QUERY =
-      "call SYS.GET_BUCKET_TO_SERVER_MAPPING(?, ?)";
+      "call SYS.GET_BUCKET_TO_SERVER_MAPPING2(?, ?)";
 
     /** array of SQLState strings that denote failover should be done */
     public static final String[] failoverSQLStateArray = new String[] { "08001",
@@ -1441,7 +1441,7 @@ public class NetConnection extends com.pivotal.gemfirexd.internal.client.am.Conn
       assert Thread.holdsLock(staticSync_);
 
       final String qAllAndPreferredServer =
-        "call SYS.GET_ALLSERVERS_AND_PREFSERVER(?, ?, ?, ?)";
+        "call SYS.GET_ALLSERVERS_AND_PREFSERVER2(?, ?, ?, ?)";
       final String qPreferredServer = "call SYS.GET_PREFSERVER(?, ?, ?)";
       final String qAllServersOnly = "select NETSERVERS, KIND from SYS." +
         "MEMBERS where LENGTH(NETSERVERS) > 0 order by LENGTH(LOCATOR) desc";
@@ -1532,7 +1532,7 @@ public class NetConnection extends com.pivotal.gemfirexd.internal.client.am.Conn
             if (cstmt == null) {
               cstmt = conn.prepareCall(qAllAndPreferredServer);
             }
-            cstmt.registerOutParameter(4, java.sql.Types.LONGVARCHAR);
+            cstmt.registerOutParameter(4, java.sql.Types.CLOB);
           }
           else {
             if (cstmt == null) {
@@ -3511,7 +3511,7 @@ public class NetConnection extends com.pivotal.gemfirexd.internal.client.am.Conn
 
   /**
    * The pattern to extract addresses from the result of
-   * GET_ALLSERVERS_AND_PREFSERVER procedure; format is:
+   * GET_ALLSERVERS_AND_PREFSERVER2 procedure; format is:
    * 
    * host1/addr1[port1]{kind1},host2/addr2[port2]{kind2},...
    */
@@ -3558,7 +3558,7 @@ public class NetConnection extends com.pivotal.gemfirexd.internal.client.am.Conn
     NetConnection locateConn_;
 
     /**
-     * Cached callable statement for GET_ALLSERVERS_AND_PREFSERVER procedure
+     * Cached callable statement for GET_ALLSERVERS_AND_PREFSERVER2 procedure
      * call on the {@link #locateConn_} connection.
      */
     java.sql.CallableStatement allStmt_;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/Misc.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/Misc.java
@@ -1090,7 +1090,6 @@ public abstract class Misc {
 
   public static boolean parseBoolean(String s) {
     if (s != null) {
-      s = s.trim();
       if (s.length() == 1) {
         return Integer.parseInt(s) != 0;
       } else {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -18,6 +18,7 @@
 package com.pivotal.gemfirexd.internal.engine.ddl.catalog;
 
 import java.sql.Blob;
+import java.sql.Clob;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -77,6 +78,7 @@ import com.pivotal.gemfirexd.internal.iapi.sql.dictionary.SchemaDescriptor;
 import com.pivotal.gemfirexd.internal.iapi.sql.dictionary.StatementRoutinePermission;
 import com.pivotal.gemfirexd.internal.iapi.store.access.TransactionController;
 import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor;
+import com.pivotal.gemfirexd.internal.iapi.types.HarmonySerialClob;
 import com.pivotal.gemfirexd.internal.iapi.types.TypeId;
 import com.pivotal.gemfirexd.internal.iapi.util.IdUtil;
 import com.pivotal.gemfirexd.internal.iapi.util.StringUtil;
@@ -927,6 +929,44 @@ public class GfxdSystemProcedures extends SystemProcedures {
   }
 
   /**
+   * Get two results: a CLOB containing all the network servers available in
+   * the distributed system; other the preferred server w.r.t. load-balancing to
+   * connect to from a JDBC client as out parameter. A set of servers to be
+   * excluded from consideration can be passed as a comma-separated string (e.g.
+   * to ignore the failed server during failover).
+   *
+   * The format of network server list is:
+   *
+   * host1[port1]{kind1},host2[port2]{kind2},...
+   *
+   * i.e. comma-separated list of each network server followed by the
+   * <code>VMKind</code> of the VM in curly braces. The network servers on
+   * stand-alone locators are given preference and appear at the front. If the
+   * output column exceeds the max size of LONGVARCHAR column
+   * {@link TypeId#LONGVARCHAR_MAXWIDTH} then null is returned for this result
+   * in which case the client is supposed to get the list from the SYS.MEMBERS
+   * VTI table in a separate call.
+   *
+   * This is primarily to avoid making two calls to the servers from the clients
+   * during connection creation or failover.
+   * <p>
+   * This differs from GET_ALLSERVERS_AND_PREFSERVER in returning
+   * "allNetServers" as a CLOB rather than a LONGVARCHAR for the rare case
+   * when it exceeds 32K.
+   */
+  public static void GET_ALLSERVERS_AND_PREFSERVER2(String excludedServers,
+      String[] prefServerName, int[] prefServerPort, Clob[] allNetServers)
+      throws SQLException {
+    final String[] allServers = new String[1];
+    GET_ALLSERVERS_AND_PREFSERVER(excludedServers, prefServerName, prefServerPort, allServers);
+    if (allServers[0] != null) {
+      allNetServers[0] = new HarmonySerialClob(allServers[0]);
+    } else {
+      allNetServers[0] = null;
+    }
+  }
+
+  /**
    * Get the preferred server to which the next connection should be made. A set
    * of servers to be excluded from consideration can be passed as a
    * comma-separated string (e.g. to ignore the failed server during failover).
@@ -1434,13 +1474,41 @@ public class GfxdSystemProcedures extends SystemProcedures {
     bktToServerMapping[0] = bucketInfo.toString();
   }
 
+
+  /**
+   * Get all buckets location information network server addr wise. This
+   * updated version uses CLOBs for results so works with large number of
+   * buckets that can exceed 32K limit of VARCHARs.
+   *
+   * @param fqtn
+   *          the fully qualified table name
+   * @param bktToServerMapping
+   *          0th index will contain the information in the below format
+   *          "numbuckets:redundancy:bucketid1:primarybucketserver;
+   *          secondary1bucketserver;...|bucketid2...."
+   *          "113:2:0;pc25.pune.gemstone.com/10.112.204.14[25005]{datastore};
+   *          null;null|2;pc25.pune.gemstone.com/10.112.204.14[25005]
+   *          {datastore};null;null"
+   * @throws SQLException
+   */
+  public static void GET_BUCKET_TO_SERVER_MAPPING2(String fqtn,
+      Clob[] bktToServerMapping) throws SQLException {
+    String[] mapping = new String[1];
+    GET_BUCKET_TO_SERVER_MAPPING(fqtn, mapping);
+    if (mapping[0] != null) {
+      bktToServerMapping[0] = new HarmonySerialClob(mapping[0]);
+    } else {
+      bktToServerMapping[0] = null;
+    }
+  }
+
   /**
    * Message is published to everybody (including locators) and added to the DDL
    * queue for persistent purposes.
-   * 
+   *
    * Any new member joining will also see the execution of the procedures like
    * statistics enabling/disabling.
-   * 
+   *
    * @param args
    *          arguments of the procedure.
    * @param lastArgServerGroups
@@ -1448,7 +1516,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
    *          serverGroup where the publish will be restricted.
    * @param systemProcedure
    *          procedure method that is remotely invoked.
-   * @param persistent whether to include in the DDL queue and replay 
+   * @param persistent whether to include in the DDL queue and replay
    * @param includeLocators should this message published to locator VMs too.
    * @throws SQLException wrapping any StandardExceptions if is raised.
    */
@@ -2173,7 +2241,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
    * @throws SQLException if table is not found or is not a column table
    */
   public static void GET_COLUMN_TABLE_SCHEMA(String table,
-      String[] schemaAsJson) throws SQLException {
+      Clob[] schemaAsJson) throws SQLException {
 
     String schemaString = Misc.getMemStoreBooting().getExternalCatalog()
         .getColumnTableSchemaAsJson(table, true);
@@ -2185,8 +2253,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
           "GET_COLUMN_TABLE_SCHEMA table=" + table + " schema=" + schemaString);
     }
-    //schemaAsJson[0] = new HarmonySerialClob(schemaString);
-    schemaAsJson[0] = schemaString;
+    schemaAsJson[0] = new HarmonySerialClob(schemaString);
   }
 
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -1433,6 +1433,20 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
           sysUUID, arg_names, arg_types, 3, 0, RoutineAliasInfo.READS_SQL_DATA,
           null, newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
 
+      // GET_ALLSERVERS_AND_PREFSERVER2(String excludedServers,
+      // String[] allNetServers, String[] prefServerName, int[] prefServerPort,
+      // Clob[] allNetServers)
+      arg_names = new String[] { "EXCLUDED_SERVERS",
+          "PREFERRED_SERVER_NAME", "PREFERRED_SERVER_PORT", "ALL_NETSERVERS" };
+      arg_types = new TypeDescriptor[] {
+          DataTypeDescriptor.getCatalogType(Types.LONGVARCHAR),
+          DataTypeDescriptor.getCatalogType(Types.VARCHAR, 256),
+          DataTypeDescriptor.getCatalogType(Types.INTEGER),
+          DataTypeDescriptor.getCatalogType(Types.CLOB) };
+      super.createSystemProcedureOrFunction("GET_ALLSERVERS_AND_PREFSERVER2",
+          sysUUID, arg_names, arg_types, 3, 0, RoutineAliasInfo.READS_SQL_DATA,
+          null, newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
+
       // GET_PREFSERVER(String excludedServers, String[] preferredServerName,
       // int[] preferredServerPort)
       arg_names = new String[] { "EXCLUDED_SERVERS", "PREFERRED_SERVER_NAME",
@@ -1614,7 +1628,7 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
     }
 
     {
-      // GET_BUCKET_TO_SERVERS_MAPPING
+      // GET_BUCKET_TO_SERVER_MAPPING
       String[] arg_names = new String[] { "FQTN", "BKT_TO_SERVER_MAPPING" };
       TypeDescriptor[] arg_types = new TypeDescriptor[] { DataTypeDescriptor
           .getCatalogType(Types.VARCHAR), DataTypeDescriptor
@@ -1622,7 +1636,17 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
       super.createSystemProcedureOrFunction("GET_BUCKET_TO_SERVER_MAPPING", sysUUID,
           arg_names, arg_types, 1, 0, RoutineAliasInfo.READS_SQL_DATA, null,
           newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
+    }
 
+    {
+      // GET_BUCKET_TO_SERVER_MAPPING2
+      String[] arg_names = new String[] { "FQTN", "BKT_TO_SERVER_MAPPING" };
+      TypeDescriptor[] arg_types = new TypeDescriptor[] { DataTypeDescriptor
+          .getCatalogType(Types.VARCHAR), DataTypeDescriptor
+          .getCatalogType(Types.CLOB) };
+      super.createSystemProcedureOrFunction("GET_BUCKET_TO_SERVER_MAPPING2", sysUUID,
+          arg_names, arg_types, 1, 0, RoutineAliasInfo.READS_SQL_DATA, null,
+          newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
     }
 
     TypeDescriptor varchar32672Type = DataTypeDescriptor.getCatalogType(
@@ -1793,7 +1817,7 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
       String[] arg_names = new String[]{"TABLE", "SCHEMA_AS_JSON"};
       TypeDescriptor[] arg_types = new TypeDescriptor[]{
           DataTypeDescriptor.getCatalogType(Types.VARCHAR),
-          DataTypeDescriptor.getCatalogType(Types.LONGVARCHAR)
+          DataTypeDescriptor.getCatalogType(Types.CLOB)
       };
       super.createSystemProcedureOrFunction("GET_COLUMN_TABLE_SCHEMA", sysUUID,
           arg_names, arg_types, 1, 0, RoutineAliasInfo.READS_SQL_DATA, null,


### PR DESCRIPTION
## Changes proposed in this pull request
- added SYS.GET_ALLSERVERS_AND_PREFSERVER2 and SYS.GET_BUCKET_TO_SERVER_MAPPING2 that use Clob[] as return parameter instead of *VARCHAR
- update SYS.GET_COLUMN_TABLE_SCHEMA to use Clob[] as return parameter instead of LONGVARCHAR
- updated NetConnection/SingleHopPreparedStatement call points to use the new procedures with updated signature; the corresponding update to SYS.GET_COLUMN_TABLE_SCHEMA call point will be done in snappydata PR
- fix the ClassCastException in EmbedCallableStatement.getClob to explicitly create Clobs
  as required (similar to handling in EmbedResultSet.getClob)
## Patch testing

Single hop and client-server dunits
## Other PRs

https://github.com/SnappyDataInc/snappydata/pull/237
