### PR TITLE
changes for bug 761

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/resolver/GfxdListPartitionResolver.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/resolver/GfxdListPartitionResolver.java
@@ -40,6 +40,7 @@ import com.pivotal.gemfirexd.internal.engine.sql.catalog.ExtraTableInfo;
 import com.pivotal.gemfirexd.internal.engine.store.CompactCompositeRegionKey;
 import com.pivotal.gemfirexd.internal.engine.store.GemFireContainer.SerializableDelta;
 import com.pivotal.gemfirexd.internal.engine.store.offheap.OffHeapByteSource;
+import com.pivotal.gemfirexd.internal.engine.store.offheap.OffHeapRow;
 import com.pivotal.gemfirexd.internal.engine.store.offheap.OffHeapRowWithLobs;
 import com.pivotal.gemfirexd.internal.engine.store.RegionEntryUtils;
 import com.pivotal.gemfirexd.internal.engine.store.RegionKey;
@@ -417,7 +418,7 @@ public final class GfxdListPartitionResolver extends GfxdPartitionResolver {
         final Class<?> vclass = val.getClass();
         if (vclass == byte[].class) {
           if (cd.isLob) {
-            vbytes = null;
+            vbytes = cd.columnDefaultBytes;
           } else {
             vbytes = (byte[])val;
           }
@@ -435,9 +436,9 @@ public final class GfxdListPartitionResolver extends GfxdPartitionResolver {
           }
         } else {
           if (cd.isLob) {
-            vbytes = null;
+            vbytes = cd.columnDefaultBytes;
           } else {
-            vbytes = ((OffHeapRowWithLobs)val).getRowBytes(); // OFFHEAP: optimize; no need to read all the bytes
+            vbytes = ((OffHeapByteSource)val).getRowBytes(); // OFFHEAP: optimize; no need to read all the bytes
           }
         }
         final long offsetAndWidth = rf.getOffsetAndWidth(

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/resolver/GfxdListPartitionResolver.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/resolver/GfxdListPartitionResolver.java
@@ -40,7 +40,6 @@ import com.pivotal.gemfirexd.internal.engine.sql.catalog.ExtraTableInfo;
 import com.pivotal.gemfirexd.internal.engine.store.CompactCompositeRegionKey;
 import com.pivotal.gemfirexd.internal.engine.store.GemFireContainer.SerializableDelta;
 import com.pivotal.gemfirexd.internal.engine.store.offheap.OffHeapByteSource;
-import com.pivotal.gemfirexd.internal.engine.store.offheap.OffHeapRow;
 import com.pivotal.gemfirexd.internal.engine.store.offheap.OffHeapRowWithLobs;
 import com.pivotal.gemfirexd.internal.engine.store.RegionEntryUtils;
 import com.pivotal.gemfirexd.internal.engine.store.RegionKey;


### PR DESCRIPTION
## Changes proposed in this pull request

Incorporated the review comments in https://github.com/SnappyDataInc/snappy-store/commit/0d038d642c32ec079994b14353782d9f10ac149b
Also in ProjectionRow.toData moved common common code to serialize column into a function called for both "if (this.lobColumns == null)" and "else" part. 

@sumwale please review.
## Patch testing

Ran all store junit/dunit tests and randomPartitionTablesProcedureIndexWithAccessors.conf.
## Other PRs

(Does this change required changes in other projects- snappyData, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

…aInc/snappy-store/commit/0d038d642c32ec079994b14353782d9f10ac149b
