### PR TITLE
Read the required snappy Jar versions at runtime in hydra

### DIFF
--- a/tests/core/src/main/java/bin/sample-runbt.sh
+++ b/tests/core/src/main/java/bin/sample-runbt.sh
@@ -78,11 +78,20 @@ list=`ls $GEMFIRE/lib/gemfirexd-client-*`
 filename=`tr "/" "\n" <<< $list | tail -1`
 
 export releaseVersion=`echo "${filename%*.*}"| cut -d'-' -f3-4`
-export CLASSPATH=$JTESTS:$EXTRA_JTESTS:$GEMFIRE/lib/gemfirexd-${releaseVersion}.jar:$GEMFIRE/lib/gemfirexd-client-${releaseVersion}.jar:$JTESTS/../../libs/gemfirexd-hydra-tests-${releaseVersion}-all.jar:$GEMFIRE/lib/gemfirexd-tools-${releaseVersion}.jar
+
+assemblyJarName=`ls $GEMFIRE/../snappy/lib/snappydata-assembly*`
+assemblyJarFilename=`tr "/" "\n" <<< $assemblyJarName | tail -1`
+export assemblyJarVersion=`echo "${assemblyJarFilename%*.*}"| cut -d'_' -f2`
+
+snappyTestsJarName=`ls $SNAPPYDATADIR/dtests/build-artifacts/scala-2.10/libs/gemfirexd-scala-tests*`
+snappyTestsJarFilename=`tr "/" "\n" <<< $snappyTestsJarName | tail -1`
+export snappyTestsJarVersion=`echo "${snappyTestsJarFilename%*.*}"| cut -d'-' -f4-6`
+
+export CLASSPATH=$JTESTS:$EXTRA_JTESTS:$GEMFIRE/lib/gemfirexd-${releaseVersion}.jar:$GEMFIRE/lib/gemfirexd-client-${releaseVersion}.jar:$JTESTS/../../libs/gemfirexd-hydra-tests-${releaseVersion}-all.jar:$GEMFIRE/lib/gemfirexd-tools-${releaseVersion}.jar:$SNAPPYDATADIR/dtests/build-artifacts/scala-2.10/libs/gemfirexd-scala-tests-${snappyTestsJarVersion}.jar:$GEMFIRE/../snappy/lib/snappydata-assembly_${assemblyJarVersion}.jar
 export EXTRA_JTESTS=$SNAPPYDATADIR/store/tests/core/build-artifacts/linux/classes/main
 #export JTESTS_RESOURCES=$SNAPPYDATADIR/store/tests/core/src/main/java
 
 # This is the command to run the test, make sure the correct release version of jar used or change the jar path to use correctly. Also change the jar name in sql/snappy.local.conf if incorrect
 
-echo $SNAPPYDATADIR/store/tests/core/src/main/java/bin/run-snappy-store-bt.sh --osbuild $GEMFIRE $OUTPUT_DIR -Dproduct=snappystore -DtestJVM=$TEST_JVM/bin/java -DEXTRA_JTESTS=$EXTRA_JTESTS  -Dbt.grepLogs=true -DremovePassedTest=true  -DnumTimesToRun=$runIters -DlocalConf=$localconfpath ${bts}
-$SNAPPYDATADIR/store/tests/core/src/main/java/bin/run-snappy-store-bt.sh --osbuild $GEMFIRE $OUTPUT_DIR -Dproduct=snappystore -DtestJVM=$TEST_JVM/bin/java -DEXTRA_JTESTS=$EXTRA_JTESTS  -Dbt.grepLogs=true -DremovePassedTest=true -DnumTimesToRun=$runIters -DlocalConf=$localconfpath ${bts}
+echo $SNAPPYDATADIR/store/tests/core/src/main/java/bin/run-snappy-store-bt.sh --osbuild $GEMFIRE $OUTPUT_DIR -Dproduct=snappystore -DtestJVM=$TEST_JVM/bin/java -DEXTRA_JTESTS=$EXTRA_JTESTS  -Dbt.grepLogs=true -DnumTimesToRun=$runIters -DlocalConf=$localconfpath ${bts}
+$SNAPPYDATADIR/store/tests/core/src/main/java/bin/run-snappy-store-bt.sh --osbuild $GEMFIRE $OUTPUT_DIR -Dproduct=snappystore -DtestJVM=$TEST_JVM/bin/java -DEXTRA_JTESTS=$EXTRA_JTESTS  -Dbt.grepLogs=true -DnumTimesToRun=$runIters -DlocalConf=$localconfpath ${bts}

--- a/tests/core/src/main/java/bin/sample-runbt.sh
+++ b/tests/core/src/main/java/bin/sample-runbt.sh
@@ -93,5 +93,5 @@ export EXTRA_JTESTS=$SNAPPYDATADIR/store/tests/core/build-artifacts/linux/classe
 
 # This is the command to run the test, make sure the correct release version of jar used or change the jar path to use correctly. Also change the jar name in sql/snappy.local.conf if incorrect
 
-echo $SNAPPYDATADIR/store/tests/core/src/main/java/bin/run-snappy-store-bt.sh --osbuild $GEMFIRE $OUTPUT_DIR -Dproduct=snappystore -DtestJVM=$TEST_JVM/bin/java -DEXTRA_JTESTS=$EXTRA_JTESTS  -Dbt.grepLogs=true -DnumTimesToRun=$runIters -DlocalConf=$localconfpath ${bts}
-$SNAPPYDATADIR/store/tests/core/src/main/java/bin/run-snappy-store-bt.sh --osbuild $GEMFIRE $OUTPUT_DIR -Dproduct=snappystore -DtestJVM=$TEST_JVM/bin/java -DEXTRA_JTESTS=$EXTRA_JTESTS  -Dbt.grepLogs=true -DnumTimesToRun=$runIters -DlocalConf=$localconfpath ${bts}
+echo $SNAPPYDATADIR/store/tests/core/src/main/java/bin/run-snappy-store-bt.sh --osbuild $GEMFIRE $OUTPUT_DIR -Dproduct=snappystore -DtestJVM=$TEST_JVM/bin/java -DEXTRA_JTESTS=$EXTRA_JTESTS  -Dbt.grepLogs=true -DremovePassedTest=true -DnumTimesToRun=$runIters -DlocalConf=$localconfpath ${bts}
+$SNAPPYDATADIR/store/tests/core/src/main/java/bin/run-snappy-store-bt.sh --osbuild $GEMFIRE $OUTPUT_DIR -Dproduct=snappystore -DtestJVM=$TEST_JVM/bin/java -DEXTRA_JTESTS=$EXTRA_JTESTS  -Dbt.grepLogs=true -DremovePassedTest=true -DnumTimesToRun=$runIters -DlocalConf=$localconfpath ${bts}

--- a/tests/core/src/main/java/hydra/VmDescription.java
+++ b/tests/core/src/main/java/hydra/VmDescription.java
@@ -17,6 +17,8 @@
 
 package hydra;
 
+import java.io.File;
+import java.io.FilenameFilter;
 import java.io.Serializable;
 import java.util.*;
 
@@ -150,6 +152,22 @@ implements Serializable {
     return map;
   }
 
+  protected static String getSnappyJarPath(String jarPath, final String jarName) {
+    String snappyJar = null;
+    File parent = new File(jarPath);
+    File[] files = parent.listFiles(new FilenameFilter() {
+      @Override
+      public boolean accept(File dir, String name) {
+        if (name.startsWith(jarName))
+          return true;
+        else return false;
+      }
+    });
+    File snappyAssembly = files[0];
+    snappyJar = snappyAssembly.getAbsolutePath();
+    return snappyJar;
+  }
+
   //////////////////////////////////////////////////////////////////////////////
   ////    CONFIGURATION                                                     ////
   //////////////////////////////////////////////////////////////////////////////
@@ -234,11 +252,14 @@ implements Serializable {
         classPath.add(hd.getGemFireHome() + hd.getFileSep() + "lib"
                 + hd.getFileSep() + "gemfirexd-tools-" +
                 ProductVersionHelper.getInfo().getProperty(ProductVersionHelper.SNAPPYRELEASEVERSION) + ".jar");
+        classPath.add(getSnappyJarPath(hd.getGemFireHome() + hd.getFileSep() + ".." + hd.getFileSep() + "snappy" + hd.getFileSep() + "lib", "snappydata-assembly"));
       }
 
       // classPath -- test jars
       classPath.add(hd.getTestDir() + hd.getFileSep() + ".." + hd.getFileSep() + ".." + hd.getFileSep() + "libs" + hd.getFileSep() + "gemfirexd-hydra-tests-" +
               ProductVersionHelper.getInfo().getProperty(ProductVersionHelper.SNAPPYRELEASEVERSION) + "-all.jar");
+      classPath.add(getSnappyJarPath(hd.getGemFireHome() + hd.getFileSep() + ".." + hd.getFileSep() + ".." + hd.getFileSep() + ".." + hd.getFileSep() + "dtests" + hd.getFileSep() +
+              "build-artifacts" + hd.getFileSep() + "scala-2.10" + hd.getFileSep() + "libs", "gemfirexd-scala-tests"));
 
       // classPath -- set at last
       vmd.setClassPath(EnvHelper.asPath(classPath, hd));


### PR DESCRIPTION
## Changes proposed in this pull request

Removed hard coding for jar versions for all required jars while running the snappy hydra tests.
## Patch testing

Ran the sample.bt under dtests in SNAP-581 branch
## Other PRs

No
