### PR TITLE
In GenericStatement#prepMinion instead of skipping cancellation of st…

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/AlterTableNode.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/AlterTableNode.java
@@ -215,6 +215,11 @@ public class AlterTableNode extends DDLStatementNode
 			return "ALTER TABLE";
 	}
 
+	public boolean isTruncateTable()
+	{
+		return truncateTable;
+	}
+
 	public	int	getChangeType() { return changeType; }
 
 	// We inherit the generate() method from DDLStatementNode.


### PR DESCRIPTION
## Changes proposed in this pull request

In GenericStatement#prepMinion, instead of skipping cancellation of statements based regex/patterns, using querytree when available.

Incorporating the only remaining review comment in https://github.com/SnappyDataInc/snappy-store/pull/44.  (the original PR was already merged) 
## Patch testing

Ran store junit/dunit tests
## Other PRs
