### PR TITLE
Suspect entries should check for EEE

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
@@ -2201,7 +2201,6 @@ RETRY_LOOP:
 
     final LocalRegion owner = _getOwner();
 
-    owner.getLogWriterI18n().fine("SKSK comign here for key " , new Exception("SKSK"));
     final boolean isRegionReady = !inTokenMode;
     boolean cbEventInPending = false;
     LogWriterI18n log = owner.getLogWriterI18n();

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DistributedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DistributedRegion.java
@@ -343,7 +343,7 @@ public class DistributedRegion extends LocalRegion implements
     if (event.getVersionTag() != null && event.getVersionTag().getRegionVersion() > 0) {
       return false;
     }
-    if (isTX()) {
+    if (event.getTXState() != null) {
       return false;
     }
     // if we're not allowed to generate a version tag we need to send it to someone who can

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/GfxdIndexManager.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/GfxdIndexManager.java
@@ -51,30 +51,8 @@ import com.gemstone.gemfire.distributed.internal.DistributionManager;
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
 import com.gemstone.gemfire.distributed.internal.membership.MembershipManager;
 import com.gemstone.gemfire.internal.Assert;
-import com.gemstone.gemfire.internal.cache.AbstractRegionEntry;
-import com.gemstone.gemfire.internal.cache.BucketAdvisor;
-import com.gemstone.gemfire.internal.cache.BucketRegion;
-import com.gemstone.gemfire.internal.cache.DiskStoreImpl;
-import com.gemstone.gemfire.internal.cache.DistributedRegion;
-import com.gemstone.gemfire.internal.cache.EntryEventImpl;
-import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
-import com.gemstone.gemfire.internal.cache.InitialImageOperation;
-import com.gemstone.gemfire.internal.cache.KeyInfo;
-import com.gemstone.gemfire.internal.cache.LocalRegion;
-import com.gemstone.gemfire.internal.cache.OperationReattemptException;
-import com.gemstone.gemfire.internal.cache.Oplog;
+import com.gemstone.gemfire.internal.cache.*;
 import com.gemstone.gemfire.internal.cache.Oplog.DiskRegionInfo;
-import com.gemstone.gemfire.internal.cache.PartitionedRegion;
-import com.gemstone.gemfire.internal.cache.PartitionedRegionHelper;
-import com.gemstone.gemfire.internal.cache.RegionEntry;
-import com.gemstone.gemfire.internal.cache.SortedIndexContainer;
-import com.gemstone.gemfire.internal.cache.SortedIndexRecoveryJob;
-import com.gemstone.gemfire.internal.cache.TXEntryState;
-import com.gemstone.gemfire.internal.cache.TXManagerImpl;
-import com.gemstone.gemfire.internal.cache.TXStateInterface;
-import com.gemstone.gemfire.internal.cache.TXStateProxy;
-import com.gemstone.gemfire.internal.cache.Token;
-import com.gemstone.gemfire.internal.cache.TransactionMessage;
 import com.gemstone.gemfire.internal.cache.delta.Delta;
 import com.gemstone.gemfire.internal.cache.locks.LockingPolicy;
 import com.gemstone.gemfire.internal.cache.wan.GatewaySenderEventCallbackArgument;
@@ -438,8 +416,15 @@ public final class GfxdIndexManager implements Dependent, IndexUpdater,
               owner.getFullPath());
         }
 
+        boolean isRecovered = false;
+        if (!owner.isInitialized()) {
+          DiskRegion dr = owner.getDiskRegion();
+          if (dr != null) {
+            isRecovered = dr.testIsRecovered(entry, false);
+          }
+        }
         boolean throwEEE = false;
-        if (!posDup && owner.isInitialized()) {
+        if (!posDup && (owner.isInitialized() || (!owner.isInitialized() && !isRecovered))) {
           if (lastModifiedFromOrigin == -1
               || lastModifiedFromOrigin != entry.getLastModified()) {
             throwEEE = true;
@@ -516,8 +501,7 @@ public final class GfxdIndexManager implements Dependent, IndexUpdater,
             }
             throw new EntryExistsException(event.getKey().toString(), OffHeapHelper.getHeapForm(oldValue));
           }
-        }
-        else {
+        } else {
           // for the case of posDup or dup during GII just ignore and return
           if (this.logFineEnabled) {
             traceIndex("GfxdIndexManager#onEvent: ignored "

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/GfxdIndexManager.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/GfxdIndexManager.java
@@ -424,7 +424,8 @@ public final class GfxdIndexManager implements Dependent, IndexUpdater,
           }
         }
         boolean throwEEE = false;
-        if (!posDup && (owner.isInitialized() || (!owner.isInitialized() && !isRecovered))) {
+        if (!posDup && (owner.isInitialized() || (!this.isPartitionedRegion && !owner.isInitialized()
+            && !isRecovered))) {
           if (lastModifiedFromOrigin == -1
               || lastModifiedFromOrigin != entry.getLastModified()) {
             throwEEE = true;


### PR DESCRIPTION
## Changes proposed in this pull request SNAP-838

Suspect entries were not checking for EntryExistsException in case entry was already present in RegionMap and suspect entry was getting processed while GII was on.

In the fix, we are going to check for EEE if region is not initilized and entry is not recovered.
## Patch testing

(Fill in the details that how was this patch tested)
## Other PRs

(Does this change required changes in other projects- snappyData, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
