### PR TITLE
Fix in SkipListMap for index issue

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/ConcurrentSkipListMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/ConcurrentSkipListMap.java
@@ -797,6 +797,11 @@ public class ConcurrentSkipListMap<K, V> extends AbstractMap<K, V> implements
         return null;
       }
     }
+
+    @Override
+    public final void clear() {
+      // nothing to be done since the entire node object will be discarded
+    }
   }
 
   // GemStoneAddition
@@ -1294,8 +1299,10 @@ public class ConcurrentSkipListMap<K, V> extends AbstractMap<K, V> implements
         }
 
         final SkipListNode<K, V> z = this.nodeFactory.newNode(key, value, n);
-        if (!b.casNext(n, z))
+        if (!b.casNext(n, z)) {
+          z.clear();
           break; // restart if lost race to append to b
+        }
         final int level = randomLevel();
         if (level > 0)
           insertIndex(z, level, numNodesCompared /* GemStoneAddition */);
@@ -1386,6 +1393,7 @@ public class ConcurrentSkipListMap<K, V> extends AbstractMap<K, V> implements
         final SkipListNode<K, V> z = this.nodeFactory.newNode(key,
             creator.newValue(key, context, params, null), n);
         if (!b.casNext(n, z)) {
+          z.clear();
           break; // restart if lost race to append to b
         }
         final int level = randomLevel();

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/SkipListNode.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/SkipListNode.java
@@ -128,4 +128,9 @@ public interface SkipListNode<K, V> {
    * @return new entry or null
    */
   public AbstractMap.SimpleImmutableEntry<K, V> createSnapshot();
+
+  /**
+   * Invoked when a node fails to get inserted in the map.
+   */
+  public void clear();
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/CompactCompositeIndexKey.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/CompactCompositeIndexKey.java
@@ -452,7 +452,7 @@ public class CompactCompositeIndexKey extends CompactCompositeKey implements
    * {@inheritDoc}
    */
   @Override
-  public boolean appendMarker(SkipListNode<Object, Object> f) {
+  public final boolean appendMarker(SkipListNode<Object, Object> f) {
     return casNext(f, new CompactCompositeIndexKey(f));
   }
 
@@ -460,7 +460,7 @@ public class CompactCompositeIndexKey extends CompactCompositeKey implements
    * {@inheritDoc}
    */
   @Override
-  public void helpDelete(SkipListNode<Object, Object> bi,
+  public final void helpDelete(SkipListNode<Object, Object> bi,
       SkipListNode<Object, Object> fi) {
     final CompactCompositeIndexKey b = (CompactCompositeIndexKey)bi;
     final CompactCompositeIndexKey f = (CompactCompositeIndexKey)fi;
@@ -483,7 +483,7 @@ public class CompactCompositeIndexKey extends CompactCompositeKey implements
    * {@inheritDoc}
    */
   @Override
-  public SimpleImmutableEntry<Object, Object> createSnapshot() {
+  public final SimpleImmutableEntry<Object, Object> createSnapshot() {
     final Object v = getValidValue();
     if (v != null) {
       // [sumedh] the next link can keep a large region of map alive via the key
@@ -500,7 +500,16 @@ public class CompactCompositeIndexKey extends CompactCompositeKey implements
    * {@inheritDoc}
    */
   @Override
-  public void setTransientValue(Object value) {
+  public final void clear() {
+    // clear mapValue to indicate that the key is no longer a node
+    this.mapValue = null;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public final void setTransientValue(Object value) {
     this.mapValue = value;
   }
 
@@ -508,7 +517,7 @@ public class CompactCompositeIndexKey extends CompactCompositeKey implements
    * {@inheritDoc}
    */
   @Override
-  public Object getTransientValue() {
+  public final Object getTransientValue() {
     return this.mapValue;
   }
 
@@ -533,7 +542,7 @@ public class CompactCompositeIndexKey extends CompactCompositeKey implements
         ccik = (CompactCompositeIndexKey)key;
       }
       else {
-        ccik = new CompactCompositeIndexKey((Object)null, (ExtraIndexInfo)null);
+        ccik = new CompactCompositeIndexKey((Object)null, null);
       }
       ccik.mapValue = value;
       ccik.next = (CompactCompositeIndexKey)next;


### PR DESCRIPTION
## Changes proposed in this pull request

Fix for SNAP-619

Key objects in snappy indexes themselves can become node in the index's SkipListMap. However, there is race condition whereby a key may lose the race to become the node to another key but may still remain marked as a node. This patch unmarks the key as node if it fails to become a node in the index map.
## Patch testing

Ran precheckin and tests in SNAP-619
## Other PRs

(Does this change required changes in other projects- snappyData, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

  patch provided by Sumedh
