### PR TITLE
Snap 828

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
@@ -50,6 +50,13 @@ public abstract class CallbackFactoryProvider {
       throw new UnsupportedOperationException("unexpected invocation for "
           + toString());
     }
+
+    @Override
+    public Boolean haveRegisteredExternalStore(String tableName) {
+      throw new UnsupportedOperationException("unexpected invocation for "
+          + toString());
+    }
+
   };
 
   public static void setStoreCallbacks(StoreCallbacks cb) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
@@ -52,7 +52,7 @@ public abstract class CallbackFactoryProvider {
     }
 
     @Override
-    public Boolean haveRegisteredExternalStore(String tableName) {
+    public boolean haveRegisteredExternalStore(String tableName) {
       throw new UnsupportedOperationException("unexpected invocation for "
           + toString());
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
@@ -32,4 +32,5 @@ public interface StoreCallbacks {
   List<String> getInternalTableSchemas();
   public int getHashCodeSnappy(Object dvd);
   public int getHashCodeSnappy(Object dvds[]);
+  public Boolean haveRegisteredExternalStore(String tableName);
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
@@ -32,5 +32,5 @@ public interface StoreCallbacks {
   List<String> getInternalTableSchemas();
   public int getHashCodeSnappy(Object dvd);
   public int getHashCodeSnappy(Object dvds[]);
-  public Boolean haveRegisteredExternalStore(String tableName);
+  public boolean haveRegisteredExternalStore(String tableName);
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/RegionSizeCalculatorFunction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/RegionSizeCalculatorFunction.java
@@ -49,8 +49,8 @@ public class RegionSizeCalculatorFunction implements Function , Declarable {
     Set<PartitionedRegion> partitionedRegions = Misc.getGemFireCache().getPartitionedRegions();
     for (PartitionedRegion pr : partitionedRegions) {
       long valueSizeOfRegion = getSizeForAllPrimaryBucketsOfRegion(pr);
-      String regionName = pr.getFullPath().replaceFirst("/", "").replaceAll("/", ".");
-      regionSizeInfo.put(regionName, valueSizeOfRegion);
+      String qualifiedTableName = Misc.getFullTableNameFromRegionPath(pr.getFullPath());
+      regionSizeInfo.put(qualifiedTableName, valueSizeOfRegion);
     }
     context.getResultSender().lastResult(regionSizeInfo);
   }

--- a/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
+++ b/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
@@ -427,12 +427,12 @@ public class SQLParser
 	    afact.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
 	    distributionNode.setPersistence(true);
 	    // [sjigyasu] Create versioned region entries for persistent partitioned tables
-      if (callback.haveRegisteredExternalStore(tableName.getFullTableName())){
-        afact.setConcurrencyChecksEnabled(false);
-       }
-       else if (concChecksFlag) {
-         afact.setConcurrencyChecksEnabled(true);
-       }
+           if (callback.haveRegisteredExternalStore(tableName.getFullTableName())){
+              afact.setConcurrencyChecksEnabled(false);
+           }
+           else if (concChecksFlag) {
+              afact.setConcurrencyChecksEnabled(true);
+           }
 	  }
         if (repPartPersFlags[0]) {
           if (repPartPersFlags[2]) {

--- a/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
+++ b/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
@@ -233,6 +233,9 @@ import com.pivotal.gemfirexd.internal.engine.procedure.coordinate.DistributedPro
 import com.pivotal.gemfirexd.internal.engine.procedure.coordinate.ProcedureProcessorNode;
 import com.pivotal.gemfirexd.internal.impl.jdbc.Util;
 import com.pivotal.gemfirexd.internal.engine.store.ServerGroupUtils;
+import com.gemstone.gemfire.internal.snappy.CallbackFactoryProvider;
+import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
+
 // GemStone changes END
 
 public class SQLParser
@@ -417,13 +420,19 @@ public class SQLParser
 	    repPartPersFlags[2] = true;
 		  afact.setDiskStoreName(GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME);
 	  }
+
+	  StoreCallbacks callback = CallbackFactoryProvider.getStoreCallbacks();
+
 	  if (repPartPersFlags[1] && repPartPersFlags[2]) {
 	    afact.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
 	    distributionNode.setPersistence(true);
 	    // [sjigyasu] Create versioned region entries for persistent partitioned tables
-	    if(concChecksFlag) {	      	
-		afact.setConcurrencyChecksEnabled(true);
-	    }
+      if (callback.haveRegisteredExternalStore(tableName.getFullTableName())){
+        afact.setConcurrencyChecksEnabled(false);
+       }
+       else if (concChecksFlag) {
+         afact.setConcurrencyChecksEnabled(true);
+       }
 	  }
         if (repPartPersFlags[0]) {
           if (repPartPersFlags[2]) {
@@ -510,7 +519,10 @@ public class SQLParser
 			afact.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
 			distributionNode.setPersistence(true);
 		    // [sjigyasu] Create versioned region entries for persistent partitioned tables
-		    if (concChecksFlag) {
+		    if (callback.haveRegisteredExternalStore(tableName.getFullTableName())){
+		        afact.setConcurrencyChecksEnabled(false);
+		    }
+		    else if (concChecksFlag) {
     	  		afact.setConcurrencyChecksEnabled(true);
     	  	}
 	      }


### PR DESCRIPTION
## Changes proposed in this pull request

disable concurrency checks for the row buffer table to avoid tombstone creation.
(Fill in the changes here)
## Patch testing

precheckin and by running  streaming app
(Fill in the details that how was this patch tested)
## Other PRs

Yes. 
(Does this change required changes in other projects- snappyData, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
