### PR TITLE
Snap 853

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLMessage.java
@@ -155,7 +155,7 @@ public final class GfxdDDLMessage extends GfxdMessage implements
     // With the new logic of not allowing new ddls to be fired when replay is
     // going on the skipping logic is removed and instead an assertion is put
     // that ddl replay should not be in progress when ddl is received.
-    if (memStore.initialDDLReplayInProgress()) {
+    if (!memStore.initialDDLReplayDone()) {
       throw new GfxdDDLReplayInProgressException("Received ddl " + ddl +
           " from sender " + getSender() + " while ddl replay is still in progress");
     }

--- a/tests/core/src/main/java/hydra/RemoteTestModule.java
+++ b/tests/core/src/main/java/hydra/RemoteTestModule.java
@@ -138,7 +138,19 @@ private static Class c = RMIHydraSocketFactory.class;
       // if parent thread has owner set properly, all children will follow
       for ( int i = 0; i < MyNumThreads; i++ ) {
 
-        RemoteTestModule mod = new RemoteTestModule();
+        RemoteTestModule mod = null;
+        int retryCnt = 0;
+        while(retryCnt < 20) {
+          try {
+            mod = new RemoteTestModule();
+          } catch (RemoteException re) {
+            MasterController.sleepForMs(500);
+            if (retryCnt == 19) {
+              throw re;
+            }
+            retryCnt++;
+          }
+        }
         MasterController.sleepForMs(300);
 
         int tid = MyBaseThreadId + i;

--- a/tests/core/src/main/java/hydra/RemoteTestModule.java
+++ b/tests/core/src/main/java/hydra/RemoteTestModule.java
@@ -143,6 +143,7 @@ private static Class c = RMIHydraSocketFactory.class;
         while(retryCnt < 20) {
           try {
             mod = new RemoteTestModule();
+            break;
           } catch (RemoteException re) {
             MasterController.sleepForMs(500);
             if (retryCnt == 19) {


### PR DESCRIPTION
## Changes proposed in this pull request

Failing ddls which come when a node is coming up based on ddlReplayNotDone flag rather than ddlInProgress status
## Patch testing

precheckin and targeted regression
## Other PRs

(Does this change required changes in other projects- snappyData, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
