### PR TITLE
correct row count is calculated for column table

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/MemoryAnalyticsVTI.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/MemoryAnalyticsVTI.java
@@ -243,7 +243,11 @@ public class MemoryAnalyticsVTI extends GfxdVTITemplate implements
       res = formatSizeValue(totalsize, new StringBuilder());
     }
     else if (NUM_ROWS.equals(columnName)) {
-      res = currVal[5];
+      if (currVal.length >9 && currVal[9] > 0 ) {
+        res = currVal[9];
+      } else {
+        res = currVal[5];
+      }
     }
     else if (NUM_KEYS_MEMORY.equals(columnName)) {
       res = currVal[6];


### PR DESCRIPTION
## Changes proposed in this pull request

changed the memoryanalytics to show the correct row count for column table. 
existing count variable is not changed as it may be used for actual row count purpose in store
## Patch testing

store precheckin
## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)
## Other PRs

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

existing count variable is not changed as it may
be used for actual rowcount purpose in store
