### PR TITLE
[SNAP-930] remove bucket RW lock when moving data from row buffer to column table

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/partitioned/PutAllPRMessage.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/partitioned/PutAllPRMessage.java
@@ -460,7 +460,7 @@ public final class PutAllPRMessage extends PartitionMessageWithDirectReply {
       }
     }
     if (!notificationOnly) {
-      bucketRegion.putAllLock.readLock().lock();
+      //bucketRegion.columnBatchFlushLock.readLock().lock();
       try {
         if (putAllPRData.length > 0) {
           if (this.posDup && bucketRegion.getConcurrencyChecksEnabled()) {
@@ -647,7 +647,7 @@ public final class PutAllPRMessage extends PartitionMessageWithDirectReply {
           if (tx == null) {
             bucketRegion.removeAndNotifyKeys(keys);
           }
-          bucketRegion.putAllLock.readLock().unlock();
+          //bucketRegion.columnBatchFlushLock.readLock().unlock();
           // TODO: For tx it may change.
           // TODO: For concurrent putALLs, this will club other putall as well
           // the putAlls in worst case so cachedbatchsize may be large?


### PR DESCRIPTION
## Changes proposed in this pull request

The lock is now only for multiple threads trying to move data from row buffer to
column table.

Once a thread has started moving data, other threads that find
the overflow condition still satisfied will just continue after finding the lock
already being held by some thread.

Any concurrent puts will otherwise continue unabated. Since our underlying maps are
thread-safe, hence additions to the map while another thread is iterating it for
removals later does not present any thread-safety issues.

However, it does present a logical problem of threads reading duplicate data.
Note that this is already a problem with current code since pure readers do not
take any lock. A proper fix for this issue will require snapshots using RVVs.
## Patch testing

SnappyData with store precheckin
## ReleaseNotes changes

NA
## Other PRs

NA
