### PR TITLE
SNAP-905

### DIFF
--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/SystemProperties.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/SystemProperties.java
@@ -229,6 +229,8 @@ public final class SystemProperties {
           || "com.pivotal.gemfirexd.tools.GfxdSystemAdmin"
                .equals(frameCls)
           || "com.pivotal.gemfirexd.internal.GemFireXDVersion"
+              .equals(frameCls)
+          || "io.snappydata.gemxd.SnappyDataVersion$"
               .equals(frameCls)) {
         return true;
       }

--- a/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/internal/impl/tools/ij/utilMain.java
+++ b/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/internal/impl/tools/ij/utilMain.java
@@ -41,6 +41,7 @@
 package com.pivotal.gemfirexd.internal.impl.tools.ij;
                 
 
+import com.gemstone.gemfire.internal.GemFireVersion;
 import com.pivotal.gemfirexd.internal.GemFireXDVersion;
 import com.pivotal.gemfirexd.internal.iapi.services.info.ProductGenusNames;
 import com.pivotal.gemfirexd.internal.iapi.tools.i18n.*;
@@ -267,8 +268,9 @@ public class utilMain implements java.security.PrivilegedAction {
 				version = "?";
 			}
 			*/
-//			out.println(convertGfxdMessageToSnappy(langUtil.getTextMessage("IJ_IjVers30C199", GemFireXDVersion.getGemFireXDVersion())));
-			out.println(GemFireXDVersion.getProductName() + " " + GemFireXDVersion.getGemFireXDVersion() + " " + GemFireXDVersion.getGemFireXDReleaseStage());
+			out.println(convertGfxdMessageToSnappy(
+					langUtil.getTextMessage("IJ_IjVers30C199", GemFireVersion.getProductVersion() + " " +
+							GemFireVersion.getProductReleaseStage())));
 			// GemStone changes END
 			for (int i = connEnv.length - 1; i >= 0; i--) { // print out any initial warnings...
 				Connection c = connEnv[i].getConnection();

--- a/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/internal/impl/tools/ij/utilMain.java
+++ b/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/internal/impl/tools/ij/utilMain.java
@@ -42,7 +42,6 @@ package com.pivotal.gemfirexd.internal.impl.tools.ij;
                 
 
 import com.gemstone.gemfire.internal.GemFireVersion;
-import com.pivotal.gemfirexd.internal.GemFireXDVersion;
 import com.pivotal.gemfirexd.internal.iapi.services.info.ProductGenusNames;
 import com.pivotal.gemfirexd.internal.iapi.tools.i18n.*;
 import com.pivotal.gemfirexd.internal.shared.common.SharedUtils;


### PR DESCRIPTION
## Changes proposed in this pull request

 Printing the product version from GemFireVersion instead of GemFireXDVersion so that default set version for SnappyData will be printed on snappy shell instead of rowstore version
## Patch testing
## ReleaseNotes changes
## Other PRs

https://github.com/SnappyDataInc/snappydata/pull/321
