### PR TITLE
[SNAP-976] Honour LRUMEMSIZE when no localMaxMemory is set

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegion.java
@@ -1789,11 +1789,8 @@ public abstract class AbstractRegion implements Region, RegionAttributes,
     this.evictionAttributes = new EvictionAttributesImpl((EvictionAttributesImpl)attrs
         .getEvictionAttributes());
     if (this.partitionAttributes != null) {
-      ((PartitionAttributesImpl) this.partitionAttributes).computeLocalMaxMemory();
-      
-      if (this.evictionAttributes != null
-          && this.evictionAttributes.getAlgorithm().isLRUMemory()
-          && this.partitionAttributes.getLocalMaxMemory() != 0
+      if (this.evictionAttributes.getAlgorithm().isLRUMemory()
+          && this.partitionAttributes.getLocalMaxMemory() > 0
           && this.evictionAttributes.getMaximum() != this.partitionAttributes.getLocalMaxMemory()) {
         
         getCache().getLoggerI18n().warning(LocalizedStrings.Mem_LRU_Eviction_Attribute_Reset,
@@ -1801,6 +1798,8 @@ public abstract class AbstractRegion implements Region, RegionAttributes,
             this.partitionAttributes.getLocalMaxMemory() });
         this.evictionAttributes.setMaximum(this.partitionAttributes.getLocalMaxMemory());
       }
+      ((PartitionAttributesImpl)this.partitionAttributes)
+          .computeLocalMaxMemory();
     }
     //final boolean isNotPartitionedRegion = !(attrs.getPartitionAttributes() != null || attrs
     //            .getDataPolicy().withPartitioning());

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/xmlcache/RegionCreation.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/xmlcache/RegionCreation.java
@@ -336,11 +336,9 @@ public class RegionCreation implements Region {
       this.attrs.setRefid(getRefid());
     }
     if (attrs.getPartitionAttributes() != null) {
-      ((PartitionAttributesImpl) attrs.getPartitionAttributes()).computeLocalMaxMemory();
-        
       if (attrs.getEvictionAttributes() != null
           && attrs.getEvictionAttributes().getAlgorithm().isLRUMemory()
-          && attrs.getPartitionAttributes().getLocalMaxMemory() != 0
+          && attrs.getPartitionAttributes().getLocalMaxMemory() > 0
           && attrs.getEvictionAttributes().getMaximum() != attrs.getPartitionAttributes().getLocalMaxMemory()) {
         
         getCache().getLoggerI18n().warning(
@@ -353,6 +351,9 @@ public class RegionCreation implements Region {
             attrs.getEvictionAttributes().getObjectSizer(),
             attrs.getEvictionAttributes().getAction()));
       }
+
+      ((PartitionAttributesImpl)attrs.getPartitionAttributes())
+          .computeLocalMaxMemory();
     }
   }
 


### PR DESCRIPTION
## Changes proposed in this pull request

This change does minimal change to avoid overwriting configured LRUMEMSIZE
when no localMaxMemory has been set.

The whole concept of localMaxMemory vs LRUMEMSIZE is a broken design and needs
to be fixed.

Continuing discussion in https://github.com/SnappyDataInc/snappy-store/pull/97
and https://jira.snappydata.io/browse/SNAP-976
## Patch testing

precheckin -Pstore
## ReleaseNotes changes

NA
## Other PRs

Previous PR with discussion: https://github.com/SnappyDataInc/snappy-store/pull/97
