### PR TITLE
Snap 735: Supporting VARCHAR with size and processing STRING as VARCHAR(32762), by default.

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionManager.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionManager.java
@@ -162,7 +162,7 @@ public final class DistributionManager
   public static final String NAME = "GemFire";
 
   /** Should we log operations related to distribution? */
-  public static boolean VERBOSE = Boolean.getBoolean("DistributionManager.VERBOSE");
+  public static boolean VERBOSE = true; //Boolean.getBoolean("DistributionManager.VERBOSE");
   
   /** The number of milliseconds to wait for distribution-related
    * things to happen */

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionManager.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionManager.java
@@ -162,7 +162,7 @@ public final class DistributionManager
   public static final String NAME = "GemFire";
 
   /** Should we log operations related to distribution? */
-  public static boolean VERBOSE = true; //Boolean.getBoolean("DistributionManager.VERBOSE");
+  public static boolean VERBOSE = Boolean.getBoolean("DistributionManager.VERBOSE");
   
   /** The number of milliseconds to wait for distribution-related
    * things to happen */

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
@@ -113,6 +113,9 @@ public final class SnappyResultHolder extends GfxdDataSerializable {
           // read the precision and the scale
           precisions[i] = (int)InternalDataSerializer.readSignedVL(dis);
           scales[i] = (int)InternalDataSerializer.readSignedVL(dis);
+        } else if (columnType == StoredFormatIds.SQL_VARCHAR_ID) {
+          precisions[i] = (int)InternalDataSerializer.readSignedVL(dis);
+          scales[i] = -1;
         } else {
           precisions[i] = -1;
           scales[i] = -1;
@@ -243,10 +246,15 @@ public final class SnappyResultHolder extends GfxdDataSerializable {
         break;
 
       case StoredFormatIds.SQL_CLOB_ID:
-      case StoredFormatIds.SQL_VARCHAR_ID:
         dvd = new SQLClob();
         jdbcTypeId = Types.CLOB;
         dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(jdbcTypeId, nullable);
+        break;
+
+      case StoredFormatIds.SQL_VARCHAR_ID:
+        dvd = new SQLVarchar();
+        jdbcTypeId = Types.VARCHAR;
+        dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(jdbcTypeId, nullable, precision);
         break;
 
       case StoredFormatIds.SQL_BLOB_ID:

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
@@ -259,6 +259,7 @@ public final class SnappyResultHolder extends GfxdDataSerializable {
         break;
 
       case StoredFormatIds.SQL_CHAR_ID:
+        System.out.println("ABS SnappyResultHolder case CHAR");
         dvd = new SQLChar();
         jdbcTypeId = Types.CHAR;
         dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(jdbcTypeId, nullable, precision);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
@@ -113,7 +113,8 @@ public final class SnappyResultHolder extends GfxdDataSerializable {
           // read the precision and the scale
           precisions[i] = (int)InternalDataSerializer.readSignedVL(dis);
           scales[i] = (int)InternalDataSerializer.readSignedVL(dis);
-        } else if (columnType == StoredFormatIds.SQL_VARCHAR_ID) {
+        } else if (columnType == StoredFormatIds.SQL_VARCHAR_ID ||
+            columnType == StoredFormatIds.SQL_CHAR_ID) {
           precisions[i] = (int)InternalDataSerializer.readSignedVL(dis);
           scales[i] = -1;
         } else {
@@ -254,6 +255,12 @@ public final class SnappyResultHolder extends GfxdDataSerializable {
       case StoredFormatIds.SQL_VARCHAR_ID:
         dvd = new SQLVarchar();
         jdbcTypeId = Types.VARCHAR;
+        dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(jdbcTypeId, nullable, precision);
+        break;
+
+      case StoredFormatIds.SQL_CHAR_ID:
+        dvd = new SQLChar();
+        jdbcTypeId = Types.CHAR;
         dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(jdbcTypeId, nullable, precision);
         break;
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
@@ -259,7 +259,6 @@ public final class SnappyResultHolder extends GfxdDataSerializable {
         break;
 
       case StoredFormatIds.SQL_CHAR_ID:
-        System.out.println("ABS SnappyResultHolder case CHAR");
         dvd = new SQLChar();
         jdbcTypeId = Types.CHAR;
         dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(jdbcTypeId, nullable, precision);
@@ -270,6 +269,13 @@ public final class SnappyResultHolder extends GfxdDataSerializable {
         jdbcTypeId = Types.BLOB;
         dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(
             jdbcTypeId, nullable);
+        break;
+
+      // indicator for complex type as clob
+      case StoredFormatIds.REF_TYPE_ID:
+        dvd = new SQLClob();
+        jdbcTypeId = Types.CLOB;
+        dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(jdbcTypeId, nullable);
         break;
 
       default :


### PR DESCRIPTION
## Changes proposed in this pull request
- Provide/Read metadata size as precision for VARCHAR type.
  See the other PR.
## Patch testing

Started precheckin
## ReleaseNotes changes

NA
## Other PRs

https://github.com/SnappyDataInc/snappydata/pull/353
