### PR TITLE
[GEMXD-39] Add stats for file descriptors

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -103,6 +103,7 @@ Bug Fixes
              totalFileDescriptors - total number of open file handles in this machine
              fileDescriptorsSystemMax - OS limit of maximum number of open file handles
              totalThreads - total number of threads in this machine
-             threadsSessionMax - OS limit of maximum number of threads+processes in current session
-             threadsSystemMax - OS limit of maximum number of threads+processes in this machine
+             threadsSessionMax - OS limit of maximum number of threads+processes
+               for current login session
+             threadsSystemMax - OS limit of maximum number of threads+processes on this machine
 

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -98,3 +98,11 @@ Bug Fixes
 * GEMXD-19 - Cleaning the index corresponding to rows in previously hosted bucket but discarded
              on restart. This was resulting on wrong counts when where clause contained indexes 
              and the query plan picked indexes instead of table scan.
+
+* GEMXD-39 - Added few more items to LinuxSystemStats:
+             totalFileDescriptors - total number of open file handles in this machine
+             fileDescriptorsSystemMax - OS limit of maximum number of open file handles
+             totalThreads - total number of threads in this machine
+             threadsSessionMax - OS limit of maximum number of threads+processes in current session
+             threadsSystemMax - OS limit of maximum number of threads+processes in this machine
+

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/LinuxSystemStats.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/LinuxSystemStats.java
@@ -64,8 +64,6 @@ public class LinuxSystemStats
   final static int cachedMemoryINT = 16;
   final static int dirtyMemoryINT = 17;
   final static int cpuNonUserINT = 18;
-  final static int threadsINT = 19;
-  final static int threadsSystemMaxINT = 20;
 
   final static int loopbackPacketsLONG = 0;
   final static int loopbackBytesLONG = 1;
@@ -95,7 +93,11 @@ public class LinuxSystemStats
   final static int iosInProgressLONG = 25;
   final static int timeIosInProgressLONG = 26;
   final static int ioTimeLONG = 27;
-  final static int threadsMaxLONG = 28;
+  final static int totalFileDescriptorsLONG = 28;
+  final static int fileDescriptorsSystemMaxLONG = 29;
+  final static int totalThreadsLONG = 30;
+  final static int threadsSessionMaxLONG = 31;
+  final static int threadsSystemMaxLONG = 32;
 
   final static int loadAverage1DOUBLE = 0;
   final static int loadAverage15DOUBLE = 1;
@@ -170,13 +172,24 @@ public class LinuxSystemStats
                             f.createIntGauge("cpuNonUser",
                                                 "The percentage of total available time that has been used to execute non-user code.(includes system, iowait, irq, softirq etc.)",
                                                 "%"),
-                            f.createIntGauge("threads",
+                            f.createLongGauge("totalFileDescriptors",
+                                "The total number of open file handles in this computer " +
+                                    "at the time of data collection. Notice that this is an " +
+                                    "instantaneous count, not an average over the time interval.",
+                                "fds"),
+                            f.createLongGauge("fileDescriptorsSystemMax",
+                                "The OS limit of maximum number of open file handles in this computer.",
+                                "fds"),
+                            f.createLongGauge("totalThreads",
                                 "The total number of threads in the computer at the time of " +
                                     "data collection. Notice that this is an instantaneous " +
                                     "count, not an average over the time interval.",
                                 "threads"),
-                            f.createIntGauge("threadsSystemMax",
-                                "The OS limit of maximum number of threads in this computer.",
+                            f.createLongGauge("threadsSessionMax",
+                                "The OS limit of maximum number of threads+processes in current session.",
+                                "threads"),
+                            f.createLongGauge("threadsSystemMax",
+                                "The OS limit of maximum number of threads+processes in this computer.",
                                 "threads"),
 
                             f.createLongCounter("loopbackPackets",
@@ -298,8 +311,6 @@ public class LinuxSystemStats
     checkOffset("cachedMemory", cachedMemoryINT);
     checkOffset("dirtyMemory", dirtyMemoryINT);
     checkOffset("cpuNonUser", cpuNonUserINT);
-    checkOffset("threads", threadsINT);
-    checkOffset("threadsSystemMax", threadsSystemMaxINT);
 
     checkOffset("loopbackPackets", loopbackPacketsLONG);
     checkOffset("loopbackBytes", loopbackBytesLONG);
@@ -329,7 +340,11 @@ public class LinuxSystemStats
     checkOffset("diskOpsInProgress", iosInProgressLONG);
     checkOffset("diskTimeInProgress", timeIosInProgressLONG);
     checkOffset("diskTime", ioTimeLONG);
-    checkOffset("threadsMax", threadsMaxLONG);
+    checkOffset("totalFileDescriptors", totalFileDescriptorsLONG);
+    checkOffset("fileDescriptorsSystemMax", fileDescriptorsSystemMaxLONG);
+    checkOffset("totalThreads", totalThreadsLONG);
+    checkOffset("threadsSessionMax", threadsSessionMaxLONG);
+    checkOffset("threadsSystemMax", threadsSystemMaxLONG);
 
     checkOffset("loadAverage1", loadAverage1DOUBLE);
     checkOffset("loadAverage15", loadAverage15DOUBLE);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/LinuxSystemStats.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/LinuxSystemStats.java
@@ -271,7 +271,7 @@ public class LinuxSystemStats
                                     "count, not an average over the time interval.",
                                 "threads"),
                             f.createLongGauge("threadsSessionMax",
-                                "The OS limit of maximum number of threads+processes in current session.",
+                                "The OS limit of maximum number of threads+processes in current login session.",
                                 "threads"),
                             f.createLongGauge("threadsSystemMax",
                                 "The OS limit of maximum number of threads+processes in this computer.",

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/LinuxSystemStats.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/LinuxSystemStats.java
@@ -172,25 +172,6 @@ public class LinuxSystemStats
                             f.createIntGauge("cpuNonUser",
                                                 "The percentage of total available time that has been used to execute non-user code.(includes system, iowait, irq, softirq etc.)",
                                                 "%"),
-                            f.createLongGauge("totalFileDescriptors",
-                                "The total number of open file handles in this computer " +
-                                    "at the time of data collection. Notice that this is an " +
-                                    "instantaneous count, not an average over the time interval.",
-                                "fds"),
-                            f.createLongGauge("fileDescriptorsSystemMax",
-                                "The OS limit of maximum number of open file handles in this computer.",
-                                "fds"),
-                            f.createLongGauge("totalThreads",
-                                "The total number of threads in the computer at the time of " +
-                                    "data collection. Notice that this is an instantaneous " +
-                                    "count, not an average over the time interval.",
-                                "threads"),
-                            f.createLongGauge("threadsSessionMax",
-                                "The OS limit of maximum number of threads+processes in current session.",
-                                "threads"),
-                            f.createLongGauge("threadsSystemMax",
-                                "The OS limit of maximum number of threads+processes in this computer.",
-                                "threads"),
 
                             f.createLongCounter("loopbackPackets",
                                              "The number of network packets sent (or received) on the loopback interface",
@@ -276,10 +257,25 @@ public class LinuxSystemStats
                             f.createLongCounter("diskTime",
                                                 "The total number of milliseconds that measures both completed disk operations and any accumulating backlog of in progress ops.",
                                                 "milliseconds"),
-                            f.createLongGauge("threadsMax",
-                                "The OS limit of maximum number of threads in current session",
+                            f.createLongGauge("totalFileDescriptors",
+                                "The total number of open file handles in this computer " +
+                                    "at the time of data collection. Notice that this is an " +
+                                    "instantaneous count, not an average over the time interval.",
+                                "fds"),
+                            f.createLongGauge("fileDescriptorsSystemMax",
+                                "The OS limit of maximum number of open file handles in this computer.",
+                                "fds"),
+                            f.createLongGauge("totalThreads",
+                                "The total number of threads in the computer at the time of " +
+                                    "data collection. Notice that this is an instantaneous " +
+                                    "count, not an average over the time interval.",
                                 "threads"),
-
+                            f.createLongGauge("threadsSessionMax",
+                                "The OS limit of maximum number of threads+processes in current session.",
+                                "threads"),
+                            f.createLongGauge("threadsSystemMax",
+                                "The OS limit of maximum number of threads+processes in this computer.",
+                                "threads"),
 
                             f.createDoubleGauge("loadAverage1",
                                                 "The average number of threads in the run queue or waiting for disk I/O over the last minute.",

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/NativeCalls.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/NativeCalls.java
@@ -545,8 +545,8 @@ public abstract class NativeCalls {
     return false;
   }
 
-  public long getMaxAllowedThreads() {
-    return 0;
+  public long getSessionThreadLimit() {
+    return 0L;
   }
 
   /**

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/jna/FreeBSDNativeCalls.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/jna/FreeBSDNativeCalls.java
@@ -80,6 +80,7 @@ final class FreeBSDNativeCalls extends POSIXNativeCalls {
     return (errno == ENOPROTOOPT);
   }
 
+  @Override
   protected int getRLimitNProcResourceId() {
     return RLIMIT_NPROC;
   }

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/jna/LinuxNativeCalls.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/jna/LinuxNativeCalls.java
@@ -502,6 +502,7 @@ final class LinuxNativeCalls extends POSIXNativeCalls {
     }
   }
 
+  @Override
   protected int getRLimitNProcResourceId() {
     return RLIMIT_NPROC;
   }

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/jna/MacOSXNativeCalls.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/jna/MacOSXNativeCalls.java
@@ -77,6 +77,7 @@ final class MacOSXNativeCalls extends POSIXNativeCalls {
     return (errno == ENOPROTOOPT);
   }
 
+  @Override
   protected int getRLimitNProcResourceId() {
     return RLIMIT_NPROC;
   }

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/jna/POSIXNativeCalls.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/jna/POSIXNativeCalls.java
@@ -154,6 +154,8 @@ class POSIXNativeCalls extends NativeCalls {
    */
   private SignalHandler hupHandler;
 
+  protected final RLimit rlimit = new RLimit();
+
   /**
    * the <code>RehashServerOnSIGHUP</code> instance provided to
    * {@link #daemonize}
@@ -448,13 +450,14 @@ class POSIXNativeCalls extends NativeCalls {
   }
 
   @Override
-  public long getMaxAllowedThreads() {
-    RLimit rlim = new RLimit();
+  public synchronized long getSessionThreadLimit() {
     int nProcResourceId = getRLimitNProcResourceId();
     if (nProcResourceId >= 0) {
       try {
-        if (getrlimit(nProcResourceId, rlim) == 0) {
-          return rlim.rlim_cur;
+        rlimit.rlim_cur = 0;
+        rlimit.rlim_max = 0;
+        if (getrlimit(nProcResourceId, rlimit) == 0) {
+          return rlimit.rlim_cur;
         }
       } catch (LastErrorException ignored) {
       }


### PR DESCRIPTION
## Changes proposed in this pull request

Continuing with previous checkin that added more details thread stats (85a89e14dc9c6ac73c43622d7357982cb74224d2), this adds FD stats on similar lines.
- added stats for max system file descriptors and currently open count on machine
  (stats for open fds by this process and "ulimit -n" are already present in VMStats)
- reuse the RLimit object since creation has some significant overhead which has shown up
  in mission control etc
- changed some thread stats added previously as longs instead of ints to make it consistent
- some renaming to make it cleaner
## Patch testing

store precheckin (ongoing)
## ReleaseNotes changes

Added to ReleaseNotes. However, the new thread/fd stats should go into VSD docs but those currently don't go into such details and don't have any system/OS stats sections (http://rowstore.docs.snappydata.io/docs/manage_guide/Topics/vsd_overview.html).
## Other PRs

NA
