### PR TITLE
[SNAP-1036] multiple performance optimizations for raw store access

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
@@ -96,6 +96,10 @@ public abstract class AbstractOplogDiskRegionEntry
     return Helper.getValueInVMOrDiskWithoutFaultIn(this, owner);
   }
   @Retained
+  public final Object getHeapValueInVMOrDiskWithoutFaultIn(LocalRegion owner) {
+    return Helper.getValueHeapOrDiskWithoutFaultIn(this, owner);
+  }
+  @Retained
   @Override
   public Object getValueOffHeapOrDiskWithoutFaultIn(LocalRegion owner) {
     return Helper.getValueOffHeapOrDiskWithoutFaultIn(this, owner);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegion.java
@@ -2155,7 +2155,7 @@ public abstract class AbstractRegion implements Region, RegionAttributes,
     return new RegionSnapshotServiceImpl(this);
   }
   
-  public Compressor getCompressor() {
+  public final Compressor getCompressor() {
     return this.compressor;
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
@@ -547,13 +547,11 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
     final Object v;
     if (owner.compressor == null) {
       v = _getValue();
+      // null should only be possible if disk entry
+      return v != null ? v : Token.NOT_AVAILABLE;
     } else {
       v = decompress(owner, _getValue());
-    }
-    if (v != null) { // should only be possible if disk entry
-      return v;
-    } else {
-      return Token.NOT_AVAILABLE;
+      return v != null ? v : Token.NOT_AVAILABLE;
     }
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
@@ -995,12 +995,16 @@ public interface DiskEntry extends RegionEntry {
       Object v;
       if (region.compressor == null) {
         v = entry._getValue();
+        if (v != null && !Token.isRemovedFromDisk(v)) {
+          return v;
+        }
       } else {
         v = AbstractRegionEntry.decompress(region, entry._getValue());
+        if (v != null && !Token.isRemovedFromDisk(v)) {
+          return v;
+        }
       }
-      if (v != null && !Token.isRemovedFromDisk(v)) {
-        return v;
-      } else if (!region.isIndexCreationThread()) {
+      if (!region.isIndexCreationThread()) {
         synchronized (entry) {
           if (region.compressor == null) {
             v = entry._getValue();

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
@@ -963,7 +963,8 @@ public interface DiskEntry extends RegionEntry {
     @Retained
     public static Object getValueOffHeapOrDiskWithoutFaultIn(DiskEntry entry, LocalRegion region) {
       @Retained Object v = entry._getValueRetain(region, true); // TODO:KIRK:OK Object v = entry.getValueWithContext(region);
-      if (v == null || Token.isRemovedFromDisk(v)
+      final boolean isRemovedFromDisk = Token.isRemovedFromDisk(v);
+      if ((v == null || isRemovedFromDisk)
           && !region.isIndexCreationThread()) {
         synchronized (entry) {
           v = entry._getValueRetain(region, true); // TODO:KIRK:OK v = entry.getValueWithContext(region);
@@ -973,7 +974,7 @@ public interface DiskEntry extends RegionEntry {
           }
         }
       }
-      if (Token.isRemovedFromDisk(v)) {
+      if (isRemovedFromDisk) {
         // fix for bug 31800
         v = null;
       } else if (v instanceof ByteSource) {
@@ -986,6 +987,35 @@ public interface DiskEntry extends RegionEntry {
         }
       }
       return v;
+    }
+
+    @Retained
+    public static Object getValueHeapOrDiskWithoutFaultIn(DiskEntry entry,
+        LocalRegion region) {
+      Object v;
+      if (region.compressor == null) {
+        v = entry._getValue();
+      } else {
+        v = AbstractRegionEntry.decompress(region, entry._getValue());
+      }
+      if (v != null && !Token.isRemovedFromDisk(v)) {
+        return v;
+      } else if (!region.isIndexCreationThread()) {
+        synchronized (entry) {
+          if (region.compressor == null) {
+            v = entry._getValue();
+          } else {
+            v = AbstractRegionEntry.decompress(region, entry._getValue());
+          }
+          if (v == null) {
+            v = Helper.getOffHeapValueOnDiskOrBuffer(entry,
+                region.getDiskRegion(), region, false);
+          }
+        }
+        return v;
+      } else {
+        return null;
+      }
     }
 
     @Retained

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
@@ -613,9 +613,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
 
   @Override
   public boolean isMarkedForEviction() {
-    throw new UnsupportedOperationException(LocalizedStrings
-        .PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
-            .toLocalizedString());
+    return false;
   }
   @Override
   public void setMarkedForEviction() {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/pdx/internal/unsafe/UnsafeWrapper.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/pdx/internal/unsafe/UnsafeWrapper.java
@@ -33,7 +33,7 @@ public final class UnsafeWrapper {
 
   private static final Unsafe unsafe = UnsafeHolder.getUnsafe();
 
-  public final Unsafe getUnsafe() {
+  public static Unsafe getUnsafe() {
     return unsafe;
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/heap/MemHeapScanController.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/heap/MemHeapScanController.java
@@ -99,7 +99,6 @@ import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
 import com.pivotal.gemfirexd.internal.iapi.reference.SQLState;
 import com.pivotal.gemfirexd.internal.iapi.services.i18n.MessageService;
 import com.pivotal.gemfirexd.internal.iapi.services.io.FormatableBitSet;
-import com.pivotal.gemfirexd.internal.iapi.services.sanity.SanityManager;
 import com.pivotal.gemfirexd.internal.iapi.sql.Activation;
 import com.pivotal.gemfirexd.internal.iapi.sql.conn.LanguageConnectionContext;
 import com.pivotal.gemfirexd.internal.iapi.sql.execute.ExecRow;
@@ -117,6 +116,7 @@ import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor;
 import com.pivotal.gemfirexd.internal.iapi.types.DataValueFactory;
 import com.pivotal.gemfirexd.internal.iapi.types.RowLocation;
 import com.pivotal.gemfirexd.internal.impl.sql.execute.ValueRow;
+import com.pivotal.gemfirexd.internal.shared.common.sanity.SanityManager;
 
 /**
  * DOCUMENT ME!
@@ -186,6 +186,8 @@ public class MemHeapScanController implements MemScanController, RowCountable,
   protected int forUpdate;
 
   protected GemFireContainer gfContainer;
+
+  protected boolean isOffHeap;
 
   private boolean addRegionAndKey = false;
 
@@ -263,6 +265,7 @@ public class MemHeapScanController implements MemScanController, RowCountable,
       throws StandardException {
     this.gfContainer = conglomerate.getGemFireContainer();
     assert this.gfContainer != null;
+    this.isOffHeap = this.gfContainer.isOffHeap();
     conglomerate.openContainer(tran, openMode, lockLevel, locking);
     this.tran = tran;
     this.openMode = openMode;
@@ -952,7 +955,7 @@ public class MemHeapScanController implements MemScanController, RowCountable,
           }
         }
         else {
-          if (this.gfContainer.isOffHeap()) {
+          if (this.isOffHeap) {
             final OffHeapResourceHolder offheapOwner = this.offheapOwner != null
                 ? this.offheapOwner : this.tran;
             if (this.currentExecRow != null) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/GemFireXDUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/GemFireXDUtils.java
@@ -2269,6 +2269,15 @@ public final class GemFireXDUtils {
     return null;
   }
 
+  /**
+   * Get the {@link GemFireContainer} for given table name.
+   */
+  public static GemFireContainer getGemFireContainer(String tableName,
+      boolean throwIfNotFound) {
+    return (GemFireContainer)Misc.getRegionForTable(tableName,
+        throwIfNotFound).getUserAttribute();
+  }
+
   public static int[] getPrimaryKeyColumns(TableDescriptor td)
       throws StandardException {
     if (td != null) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/AbstractCompactExecRow.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/AbstractCompactExecRow.java
@@ -1043,9 +1043,8 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
     }
     if (!dvd.isNull()) {
       return dvd.getDouble();
-    }
-    else {
-      wasNull.setWasNull();
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
       return 0.0;
     }
   }
@@ -1061,9 +1060,8 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
     final String result = dvd.getString();
     if (result != null) {
       return result;
-    }
-    else {
-      wasNull.setWasNull();
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
       return null;
     }
   }
@@ -1078,9 +1076,8 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
     final Object result = dvd.getObject();
     if (result != null) {
       return result;
-    }
-    else {
-      wasNull.setWasNull();
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
       return null;
     }
   }
@@ -1092,10 +1089,12 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
         || (dvd = this.deserializedCache[position - 1]) == null) {
       return getBoolean(position, wasNull);
     }
-    if (dvd.isNull()) {
-      wasNull.setWasNull();
+    if (!dvd.isNull()) {
+      return dvd.getBoolean();
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
+      return false;
     }
-    return dvd.getBoolean();
   }
 
   public final byte getAsByte(int position, ResultWasNull wasNull)
@@ -1105,10 +1104,12 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
         || (dvd = this.deserializedCache[position - 1]) == null) {
       return getByte(position, wasNull);
     }
-    if (dvd.isNull()) {
-      wasNull.setWasNull();
+    if (!dvd.isNull()) {
+      return dvd.getByte();
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
+      return 0;
     }
-    return dvd.getByte();
   }
 
   public final short getAsShort(int position, ResultWasNull wasNull)
@@ -1118,10 +1119,12 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
         || (dvd = this.deserializedCache[position - 1]) == null) {
       return getShort(position, wasNull);
     }
-    if (dvd.isNull()) {
-      wasNull.setWasNull();
+    if (!dvd.isNull()) {
+      return dvd.getShort();
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
+      return 0;
     }
-    return dvd.getShort();
   }
 
   public final int getAsInt(int position, ResultWasNull wasNull)
@@ -1131,10 +1134,12 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
         || (dvd = this.deserializedCache[position - 1]) == null) {
       return getInt(position, wasNull);
     }
-    if (dvd.isNull()) {
-      wasNull.setWasNull();
+    if (!dvd.isNull()) {
+      return dvd.getInt();
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
+      return 0;
     }
-    return dvd.getInt();
   }
 
   public final long getAsLong(int position, ResultWasNull wasNull)
@@ -1144,10 +1149,12 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
         || (dvd = this.deserializedCache[position - 1]) == null) {
       return getLong(position, wasNull);
     }
-    if (dvd.isNull()) {
-      wasNull.setWasNull();
+    if (!dvd.isNull()) {
+      return dvd.getLong();
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
+      return 0L;
     }
-    return dvd.getLong();
   }
 
   public final float getAsFloat(int position, ResultWasNull wasNull)
@@ -1157,10 +1164,12 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
         || (dvd = this.deserializedCache[position - 1]) == null) {
       return getFloat(position, wasNull);
     }
-    if (dvd.isNull()) {
-      wasNull.setWasNull();
+    if (!dvd.isNull()) {
+      return dvd.getFloat();
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
+      return 0.0f;
     }
-    return dvd.getFloat();
   }
 
   public final BigDecimal getAsBigDecimal(int position, ResultWasNull wasNull)
@@ -1170,10 +1179,12 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
         || (dvd = this.deserializedCache[position - 1]) == null) {
       return getBigDecimal(position, wasNull);
     }
-    if (dvd.isNull()) {
-      wasNull.setWasNull();
+    if (!dvd.isNull()) {
+      return SQLDecimal.getBigDecimal(dvd);
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
+      return null;
     }
-    return SQLDecimal.getBigDecimal(dvd);
   }
 
   public final byte[] getAsBytes(int position, ResultWasNull wasNull)
@@ -1183,10 +1194,13 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
         || (dvd = this.deserializedCache[position - 1]) == null) {
       return getBytes(position, wasNull);
     }
-    if (dvd.isNull()) {
-      wasNull.setWasNull();
+    final byte[] result = dvd.getBytes();
+    if (result != null) {
+      return result;
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
+      return null;
     }
-    return dvd.getBytes();
   }
 
   public final java.sql.Date getAsDate(int position, Calendar cal,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -503,6 +503,7 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
         row.setRowArray(template);
       }
       this.templateRow = row.getNewNullRow();
+      this.hasSingleSchema = false;
     }
 
     if (this.comparator != null) {
@@ -928,20 +929,17 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
    */
   public final ExtraTableInfo getExtraTableInfo(final byte[] rawRow) {
 
-    if (rawRow == null) {
-      return this.tableInfo;
-    }
-
     // if there are no old schemas then simply return current formatter
     if (this.hasSingleSchema) {
       int rowVersion;
       assert isCurrentVersion((rowVersion = readVersion(rawRow))):
           "unexpected version in row=" + rowVersion + ", schemaVersion="
-          + this.schemaVersion;
+              + this.schemaVersion;
 
       return this.tableInfo;
-    }
-    else {
+    } else if (rawRow == null) {
+      return this.tableInfo;
+    } else {
       return getExtraTableInfoForMultiSchema(rawRow);
     }
   }
@@ -974,21 +972,17 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
    * Return the table info for this container given the first row byte array.
    */
   public final ExtraTableInfo getExtraTableInfo(final OffHeapByteSource rawRow) {
-
-    if (rawRow == null) {
-      return this.tableInfo;
-    }
-
     // if there are no old schemas then simply return current formatter
     if (this.hasSingleSchema) {
       int rowVersion;
       assert isCurrentVersion((rowVersion = readVersion(rawRow))):
           "unexpected version in row=" + rowVersion + ", schemaVersion="
-          + this.schemaVersion;
+              + this.schemaVersion;
 
       return this.tableInfo;
-    }
-    else {
+    } else if (rawRow == null) {
+      return this.tableInfo;
+    } else {
       return getExtraTableInfoForMultiSchema(rawRow);
     }
   }
@@ -998,17 +992,15 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
    */
   public final ExtraTableInfo getExtraTableInfo(final Object rawRow) {
 
-    if (rawRow == null) {
-      return this.tableInfo;
-    }
-
     // if there are no old schemas then simply return current formatter
     if (this.hasSingleSchema) {
       int rowVersion;
       assert isCurrentVersion((rowVersion = readVersion_(rawRow))):
           "unexpected version in row=" + rowVersion + ", schemaVersion="
-          + this.schemaVersion;
+              + this.schemaVersion;
 
+      return this.tableInfo;
+    } else if (rawRow == null) {
       return this.tableInfo;
     }
 
@@ -1048,6 +1040,7 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
 
   @Unretained
   private final int readVersion_(@Unretained final Object rawRow) {
+    if (rawRow == null) return this.schemaVersion;
     final Class<?> cls = rawRow.getClass();
     if (cls == byte[].class) {
       return readVersion((byte[])rawRow);
@@ -1395,45 +1388,37 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
   }
 
   public final RowFormatter getRowFormatter(final byte[] rawRow) {
-    if (!isByteArrayStore()) {
-      return null;
-    }
-
-    if (rawRow == null) {
-      return this.tableInfo.getRowFormatter();
-    }
     // if there are no old schemas then simply return current formatter
     if (this.hasSingleSchema) {
       int rowVersion;
-      assert isCurrentVersion(rowVersion = readVersion(rawRow)):
+      assert isCurrentVersion(rowVersion = readVersion(rawRow)) :
           "unexpected version in row=" + rowVersion + ", schemaVersion="
-          + this.schemaVersion;
+              + this.schemaVersion;
 
       return this.tableInfo.getRowFormatter();
-    }
-    else {
+    } else if (!isByteArrayStore()) {
+      return null;
+    } else if (rawRow == null) {
+      return this.tableInfo.getRowFormatter();
+    } else {
       return getRowFormatterForMultiSchema(rawRow);
     }
   }
 
   public final RowFormatter getRowFormatter(final byte[][] rawRow) {
-    if (!isByteArrayStore()) {
-      return null;
-    }
-
-    if (rawRow == null || rawRow.length == 0) {
-      return this.tableInfo.getRowFormatter();
-    }
     // if there are no old schemas then simply return current formatter
     if (this.hasSingleSchema) {
       int rowVersion;
-      assert isCurrentVersion(rowVersion = readVersion(rawRow[0])):
+      assert isCurrentVersion(rowVersion = readVersion(rawRow[0])) :
           "unexpected version in row=" + rowVersion + ", schemaVersion="
-          + this.schemaVersion;
+              + this.schemaVersion;
 
       return this.tableInfo.getRowFormatter();
-    }
-    else {
+    } else if (!isByteArrayStore()) {
+      return null;
+    } else if (rawRow == null || rawRow.length == 0) {
+      return this.tableInfo.getRowFormatter();
+    } else {
       return getRowFormatterForMultiSchema(rawRow[0]);
     }
   }
@@ -1460,23 +1445,19 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
 
   public final RowFormatter getRowFormatter(
       @Unretained final OffHeapByteSource rawRow) {
-    if (!isByteArrayStore()) {
-      return null;
-    }
-
-    if (rawRow == null) {
-      return this.tableInfo.getRowFormatter();
-    }
     // if there are no old schemas then simply return current formatter
     if (this.hasSingleSchema) {
       int rowVersion;
       assert isCurrentVersion(rowVersion = readVersion(rawRow)):
           "unexpected version in row=" + rowVersion + ", schemaVersion="
-          + this.schemaVersion;
+              + this.schemaVersion;
 
       return this.tableInfo.getRowFormatter();
-    }
-    else {
+    } else if (!isByteArrayStore()) {
+      return null;
+    } else if (rawRow == null) {
+      return this.tableInfo.getRowFormatter();
+    } else {
       return getRowFormatterForMultiSchema(
           UnsafeMemoryChunk.getUnsafeWrapper(), rawRow.getUnsafeAddress(),
           rawRow);
@@ -1485,20 +1466,17 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
 
   public final RowFormatter getRowFormatter(final UnsafeWrapper unsafe,
       final long memAddr, @Unretained final OffHeapByteSource rawRow) {
-    if (!isByteArrayStore()) {
-      return null;
-    }
-
     // if there are no old schemas then simply return current formatter
     if (this.hasSingleSchema) {
       int rowVersion;
       assert isCurrentVersion(rowVersion = readVersion(rawRow)):
           "unexpected version in row=" + rowVersion + ", schemaVersion="
-          + this.schemaVersion;
+              + this.schemaVersion;
 
       return this.tableInfo.getRowFormatter();
-    }
-    else {
+    } else if (!isByteArrayStore()) {
+      return null;
+    } else {
       return getRowFormatterForMultiSchema(unsafe, memAddr, rawRow);
     }
   }
@@ -1509,20 +1487,17 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
    * @return the RowFormatter, or null if this is not a byte array store table.
    */
   public final RowFormatter getRowFormatter(@Unretained final Object rawRow) {
-    if (!isByteArrayStore()) {
-      return null;
-    }
-
-    if (rawRow == null) {
-      return this.tableInfo.getRowFormatter();
-    }
     // if there are no old schemas then simply return current formatter
     if (this.hasSingleSchema) {
       int rowVersion;
       assert isCurrentVersion(rowVersion = readVersion_(rawRow)):
           "unexpected version in row=" + rowVersion + ", schemaVersion="
-          + this.schemaVersion;
+              + this.schemaVersion;
 
+      return this.tableInfo.getRowFormatter();
+    } else if (!isByteArrayStore()) {
+      return null;
+    } else if (rawRow == null) {
       return this.tableInfo.getRowFormatter();
     }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/OffHeapCompactExecRowWithLobs.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/OffHeapCompactExecRowWithLobs.java
@@ -17,8 +17,6 @@
 
 package com.pivotal.gemfirexd.internal.engine.store;
 
-import static com.gemstone.gemfire.internal.offheap.annotations.OffHeapIdentifier.OFFHEAP_COMPACT_EXEC_ROW_WITH_LOBS_SOURCE;
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -34,7 +32,6 @@ import com.gemstone.gemfire.internal.offheap.UnsafeMemoryChunk;
 import com.gemstone.gemfire.internal.offheap.annotations.Released;
 import com.gemstone.gemfire.internal.offheap.annotations.Unretained;
 import com.gemstone.gemfire.internal.util.ArrayUtils;
-import com.gemstone.gemfire.pdx.internal.unsafe.UnsafeWrapper;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
 import com.pivotal.gemfirexd.internal.engine.GfxdDataSerializable;
 import com.pivotal.gemfirexd.internal.engine.distributed.metadata.RegionAndKey;
@@ -48,6 +45,8 @@ import com.pivotal.gemfirexd.internal.iapi.sql.dictionary.ColumnDescriptor;
 import com.pivotal.gemfirexd.internal.iapi.sql.execute.ExecRow;
 import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor;
 import com.pivotal.gemfirexd.internal.shared.common.ResolverUtils;
+
+import static com.gemstone.gemfire.internal.offheap.annotations.OffHeapIdentifier.OFFHEAP_COMPACT_EXEC_ROW_WITH_LOBS_SOURCE;
 
 /**
  * A compact implementation of Row that contains one or more LOBs (i.e. BLOBs or
@@ -608,11 +607,8 @@ public final class OffHeapCompactExecRowWithLobs extends AbstractCompactExecRow 
       else {
         return this.formatter.getAsBlob(position, (OffHeapRow)source, wasNull);
       }
-    }
-    else {
-      if (wasNull != null) {
-        wasNull.setWasNull();
-      }
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
       return null;
     }
   }
@@ -633,11 +629,8 @@ public final class OffHeapCompactExecRowWithLobs extends AbstractCompactExecRow 
       else {
         return this.formatter.getAsClob(position, (OffHeapRow)source, wasNull);
       }
-    }
-    else {
-      if (wasNull != null) {
-        wasNull.setWasNull();
-      }
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
       return null;
     }
   }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
@@ -121,10 +121,11 @@ public final class RegionEntryUtils {
   }
 
   private static final boolean isValueToken(Object value) {
-    if (Misc.getMemStoreBooting().isHadoopGfxdLonerMode())
-      return Token.isInvalidOrRemoved(value);
-    else
+    if (!Misc.getMemStoreBooting().isHadoopGfxdLonerMode()) {
       return Token.isInvalidOrRemoved(value) || value == Token.NOT_AVAILABLE;
+    } else {
+      return Token.isInvalidOrRemoved(value);
+    }
   }
 
   /**
@@ -1561,9 +1562,8 @@ public final class RegionEntryUtils {
     }
 
     // assumes val to be non null
-    public int getBucketIdFromRegionEntry(RegionEntry val) {
-      RowLocation rl = (RowLocation) val;
-      return rl.getBucketID();
+    public final int getBucketIdFromRegionEntry(RegionEntry val) {
+      return ((RowLocation)val).getBucketID();
     }
 
     @Override

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
@@ -625,7 +625,7 @@ public final class RegionEntryUtils {
     }
   }
 
-  private static AbstractCompactExecRow fillRowUsingAddress(
+  public static AbstractCompactExecRow fillRowUsingAddress(
       final GemFireContainer baseContainer, final LocalRegion region,
       final OffHeapRegionEntry entry, final AbstractCompactExecRow row,
       boolean faultIn) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RowFormatter.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RowFormatter.java
@@ -8303,7 +8303,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsString(bytes, offset, columnWidth,
-          cd.columnType, wasNull);
+          cd.columnType);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -8312,18 +8312,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getString();
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -8349,12 +8343,9 @@ public final class RowFormatter implements Serializable {
           : cd.columnDefaultBytes;
       if (bytes != null) {
         return DataTypeUtilities.getAsString(bytes, 0, bytes.length,
-            cd.columnType, wasNull);
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+            cd.columnType);
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -8371,7 +8362,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsString(unsafe, memAddr + offset,
-          columnWidth, bs, cd.columnType, wasNull);
+          columnWidth, bs, cd.columnType);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -8380,18 +8371,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getString();
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -8430,7 +8415,7 @@ public final class RowFormatter implements Serializable {
         if (lob instanceof byte[]) {
           final byte[] bytes = (byte[])lob;
           return DataTypeUtilities.getAsString(bytes, 0, bytes.length,
-              cd.columnType, wasNull);
+              cd.columnType);
         }
         else {
           final OffHeapByteSource bs = (OffHeapByteSource)lob;
@@ -8438,13 +8423,10 @@ public final class RowFormatter implements Serializable {
           final int bytesLen = bs.getLength();
           final long memAddr = bs.getUnsafeAddress(0, bytesLen);
           return DataTypeUtilities.getAsString(unsafe, memAddr, bytesLen, bs,
-              cd.columnType, wasNull);
+              cd.columnType);
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -8459,7 +8441,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsObject(bytes, offset, columnWidth,
-          cd.columnType, wasNull);
+          cd.columnType);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -8468,18 +8450,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getObject();
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -8505,12 +8481,9 @@ public final class RowFormatter implements Serializable {
           : cd.columnDefaultBytes;
       if (bytes != null) {
         return DataTypeUtilities.getAsObject(bytes, 0, bytes.length,
-            cd.columnType, wasNull);
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+            cd.columnType);
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -8527,7 +8500,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsObject(unsafe, memAddr + offset,
-          columnWidth, bs, cd.columnType, wasNull);
+          columnWidth, bs, cd.columnType);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -8536,18 +8509,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getObject();
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -8586,7 +8553,7 @@ public final class RowFormatter implements Serializable {
         if (lob instanceof byte[]) {
           final byte[] bytes = (byte[])lob;
           return DataTypeUtilities.getAsObject(bytes, 0, bytes.length,
-              cd.columnType, wasNull);
+              cd.columnType);
         }
         else {
           final OffHeapByteSource bs = (OffHeapByteSource)lob;
@@ -8594,13 +8561,10 @@ public final class RowFormatter implements Serializable {
           final int bytesLen = bs.getLength();
           final long memAddr = bs.getUnsafeAddress(0, bytesLen);
           return DataTypeUtilities.getAsObject(unsafe, memAddr, bytesLen, bs,
-              cd.columnType, wasNull);
+              cd.columnType);
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -8614,18 +8578,16 @@ public final class RowFormatter implements Serializable {
     final long offsetAndWidth;
     if (offsetFromMap >= this.nVersionBytes) {
       return DataTypeUtilities.getAsBoolean(bytes, offsetFromMap,
-          cd.fixedWidth, cd.columnType, wasNull);
+          cd.fixedWidth, cd.columnType);
     } else if ((offsetAndWidth = getVarOffsetAndWidth(bytes,
         offsetFromMap, cd, false)) >= 0) {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsBoolean(bytes, offset, columnWidth,
-          cd.columnType, wasNull);
+          cd.columnType);
     } else {
       if (offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL) {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+        if (wasNull != null) wasNull.setWasNull();
         return false;
       } else {
         assert offsetAndWidth == OFFSET_AND_WIDTH_IS_DEFAULT : offsetAndWidth;
@@ -8633,9 +8595,7 @@ public final class RowFormatter implements Serializable {
         if (dvd != null && !dvd.isNull()) {
           return dvd.getBoolean();
         } else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+          if (wasNull != null) wasNull.setWasNull();
           return false;
         }
       }
@@ -8666,7 +8626,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsBoolean(unsafe, memAddr + offset,
-          columnWidth, bs, cd.columnType, wasNull);
+          columnWidth, bs, cd.columnType);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -8675,18 +8635,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getBoolean();
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return false;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return false;
       }
     }
@@ -8731,18 +8685,15 @@ public final class RowFormatter implements Serializable {
     final long offsetAndWidth;
     if (offsetFromMap >= this.nVersionBytes) {
       return DataTypeUtilities.getAsByte(bytes, offsetFromMap,
-          cd.fixedWidth, cd, wasNull);
+          cd.fixedWidth, cd);
     } else if ((offsetAndWidth = getVarOffsetAndWidth(bytes,
         offsetFromMap, cd, false)) >= 0) {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
-      return DataTypeUtilities.getAsByte(bytes, offset, columnWidth,
-          cd, wasNull);
+      return DataTypeUtilities.getAsByte(bytes, offset, columnWidth, cd);
     } else {
       if (offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL) {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+        if (wasNull != null) wasNull.setWasNull();
         return 0;
       } else {
         assert offsetAndWidth == OFFSET_AND_WIDTH_IS_DEFAULT : offsetAndWidth;
@@ -8750,9 +8701,7 @@ public final class RowFormatter implements Serializable {
         if (dvd != null && !dvd.isNull()) {
           return dvd.getByte();
         } else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+          if (wasNull != null) wasNull.setWasNull();
           return 0;
         }
       }
@@ -8783,7 +8732,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsByte(unsafe, memAddr + offset,
-          columnWidth, bs, cd, wasNull);
+          columnWidth, bs, cd);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -8792,18 +8741,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getByte();
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return 0;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return 0;
       }
     }
@@ -8848,18 +8791,15 @@ public final class RowFormatter implements Serializable {
     final long offsetAndWidth;
     if (offsetFromMap >= this.nVersionBytes) {
       return DataTypeUtilities.getAsShort(bytes, offsetFromMap,
-          cd.fixedWidth, cd, wasNull);
+          cd.fixedWidth, cd);
     } else if ((offsetAndWidth = getVarOffsetAndWidth(bytes,
         offsetFromMap, cd, false)) >= 0) {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
-      return DataTypeUtilities.getAsShort(bytes, offset, columnWidth,
-          cd, wasNull);
+      return DataTypeUtilities.getAsShort(bytes, offset, columnWidth, cd);
     } else {
       if (offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL) {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+        if (wasNull != null) wasNull.setWasNull();
         return 0;
       } else {
         assert offsetAndWidth == OFFSET_AND_WIDTH_IS_DEFAULT : offsetAndWidth;
@@ -8867,9 +8807,7 @@ public final class RowFormatter implements Serializable {
         if (dvd != null && !dvd.isNull()) {
           return dvd.getShort();
         } else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+          if (wasNull != null) wasNull.setWasNull();
           return 0;
         }
       }
@@ -8900,7 +8838,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsShort(unsafe, memAddr + offset,
-          columnWidth, bs, cd, wasNull);
+          columnWidth, bs, cd);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -8909,18 +8847,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getShort();
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return 0;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return 0;
       }
     }
@@ -8957,7 +8889,7 @@ public final class RowFormatter implements Serializable {
     }
   }
 
-  final int getAsInt(final int logicalPosition, byte[] bytes,
+  public final int getAsInt(final int logicalPosition, byte[] bytes,
       final ResultWasNull wasNull) throws StandardException {
     final int index = logicalPosition - 1;
     final ColumnDescriptor cd = this.columns[index];
@@ -8965,18 +8897,15 @@ public final class RowFormatter implements Serializable {
     final long offsetAndWidth;
     if (offsetFromMap >= this.nVersionBytes) {
       return DataTypeUtilities.getAsInt(bytes, offsetFromMap,
-          cd.fixedWidth, cd, wasNull);
+          cd.fixedWidth, cd);
     } else if ((offsetAndWidth = getVarOffsetAndWidth(bytes,
         offsetFromMap, cd, false)) >= 0) {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
-      return DataTypeUtilities.getAsInt(bytes, offset, columnWidth,
-          cd, wasNull);
+      return DataTypeUtilities.getAsInt(bytes, offset, columnWidth, cd);
     } else {
       if (offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL) {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+        if (wasNull != null) wasNull.setWasNull();
         return 0;
       } else {
         assert offsetAndWidth == OFFSET_AND_WIDTH_IS_DEFAULT : offsetAndWidth;
@@ -8984,16 +8913,14 @@ public final class RowFormatter implements Serializable {
         if (dvd != null && !dvd.isNull()) {
           return dvd.getInt();
         } else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+          if (wasNull != null) wasNull.setWasNull();
           return 0;
         }
       }
     }
   }
 
-  final int getAsInt(final int logicalPosition,
+  public final int getAsInt(final int logicalPosition,
       final byte[][] byteArrays, final ResultWasNull wasNull)
       throws StandardException {
     final ColumnDescriptor cd = this.columns[logicalPosition - 1];
@@ -9017,7 +8944,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsInt(unsafe, memAddr + offset,
-          columnWidth, bs, cd, wasNull);
+          columnWidth, bs, cd);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9026,24 +8953,18 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getInt();
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return 0;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return 0;
       }
     }
   }
 
-  final int getAsInt(final int logicalPosition,
+  public final int getAsInt(final int logicalPosition,
       @Unretained final OffHeapRow bytes, final ResultWasNull wasNull)
       throws StandardException {
     final UnsafeWrapper unsafe = UnsafeMemoryChunk.getUnsafeWrapper();
@@ -9055,7 +8976,7 @@ public final class RowFormatter implements Serializable {
         bytes, wasNull);
   }
 
-  final int getAsInt(final int logicalPosition,
+  public final int getAsInt(final int logicalPosition,
       @Unretained final OffHeapRowWithLobs byteArrays,
       final ResultWasNull wasNull) throws StandardException {
     final int index = logicalPosition - 1;
@@ -9082,18 +9003,15 @@ public final class RowFormatter implements Serializable {
     final long offsetAndWidth;
     if (offsetFromMap >= this.nVersionBytes) {
       return DataTypeUtilities.getAsLong(bytes, offsetFromMap,
-          cd.fixedWidth, cd, wasNull);
+          cd.fixedWidth, cd);
     } else if ((offsetAndWidth = getVarOffsetAndWidth(bytes,
         offsetFromMap, cd, false)) >= 0) {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
-      return DataTypeUtilities.getAsLong(bytes, offset, columnWidth,
-          cd, wasNull);
+      return DataTypeUtilities.getAsLong(bytes, offset, columnWidth, cd);
     } else {
       if (offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL) {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+        if (wasNull != null) wasNull.setWasNull();
         return 0L;
       } else {
         assert offsetAndWidth == OFFSET_AND_WIDTH_IS_DEFAULT : offsetAndWidth;
@@ -9101,9 +9019,7 @@ public final class RowFormatter implements Serializable {
         if (dvd != null && !dvd.isNull()) {
           return dvd.getLong();
         } else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+          if (wasNull != null) wasNull.setWasNull();
           return 0L;
         }
       }
@@ -9134,7 +9050,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsLong(unsafe, memAddr + offset,
-          columnWidth, bs, cd, wasNull);
+          columnWidth, bs, cd);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9143,18 +9059,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getLong();
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return 0;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return 0;
       }
     }
@@ -9199,18 +9109,15 @@ public final class RowFormatter implements Serializable {
     final long offsetAndWidth;
     if (offsetFromMap >= this.nVersionBytes) {
       return DataTypeUtilities.getAsFloat(bytes, offsetFromMap,
-          cd.fixedWidth, cd, wasNull);
+          cd.fixedWidth, cd);
     } else if ((offsetAndWidth = getVarOffsetAndWidth(bytes,
         offsetFromMap, cd, false)) >= 0) {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
-      return DataTypeUtilities.getAsFloat(bytes, offset, columnWidth,
-          cd, wasNull);
+      return DataTypeUtilities.getAsFloat(bytes, offset, columnWidth, cd);
     } else {
       if (offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL) {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+        if (wasNull != null) wasNull.setWasNull();
         return 0.0f;
       } else {
         assert offsetAndWidth == OFFSET_AND_WIDTH_IS_DEFAULT : offsetAndWidth;
@@ -9218,9 +9125,7 @@ public final class RowFormatter implements Serializable {
         if (dvd != null && !dvd.isNull()) {
           return dvd.getFloat();
         } else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+          if (wasNull != null) wasNull.setWasNull();
           return 0.0f;
         }
       }
@@ -9251,7 +9156,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsFloat(unsafe, memAddr + offset,
-          columnWidth, bs, cd, wasNull);
+          columnWidth, bs, cd);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9260,18 +9165,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getFloat();
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return 0.0f;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return 0.0f;
       }
     }
@@ -9316,18 +9215,15 @@ public final class RowFormatter implements Serializable {
     final long offsetAndWidth;
     if (offsetFromMap >= this.nVersionBytes) {
       return DataTypeUtilities.getAsDouble(bytes, offsetFromMap,
-          cd.fixedWidth, cd, wasNull);
+          cd.fixedWidth, cd);
     } else if ((offsetAndWidth = getVarOffsetAndWidth(bytes,
         offsetFromMap, cd, false)) >= 0) {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
-      return DataTypeUtilities.getAsDouble(bytes, offset, columnWidth,
-          cd, wasNull);
+      return DataTypeUtilities.getAsDouble(bytes, offset, columnWidth, cd);
     } else {
       if (offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL) {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+        if (wasNull != null) wasNull.setWasNull();
         return 0.0;
       } else {
         assert offsetAndWidth == OFFSET_AND_WIDTH_IS_DEFAULT : offsetAndWidth;
@@ -9335,9 +9231,7 @@ public final class RowFormatter implements Serializable {
         if (dvd != null && !dvd.isNull()) {
           return dvd.getDouble();
         } else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+          if (wasNull != null) wasNull.setWasNull();
           return 0.0;
         }
       }
@@ -9368,7 +9262,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsDouble(unsafe, memAddr + offset,
-          columnWidth, bs, cd, wasNull);
+          columnWidth, bs, cd);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9377,18 +9271,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getDouble();
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return 0.0;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return 0.0;
       }
     }
@@ -9433,8 +9321,7 @@ public final class RowFormatter implements Serializable {
     if (offsetAndWidth >= 0) {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
-      return DataTypeUtilities.getAsBigDecimal(bytes, offset, columnWidth,
-          cd, wasNull);
+      return DataTypeUtilities.getAsBigDecimal(bytes, offset, columnWidth, cd);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9443,18 +9330,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return SQLDecimal.getBigDecimal(dvd);
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -9492,7 +9373,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsBigDecimal(unsafe, memAddr + offset,
-          columnWidth, bs, cd, wasNull);
+          columnWidth, bs, cd);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9501,18 +9382,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return SQLDecimal.getBigDecimal(dvd);
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -9558,7 +9433,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsBytes(bytes, offset, columnWidth,
-          cd.columnType, wasNull);
+          cd.columnType);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9567,18 +9442,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getBytes();
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -9604,12 +9473,9 @@ public final class RowFormatter implements Serializable {
           : cd.columnDefaultBytes;
       if (bytes != null) {
         return DataTypeUtilities.getAsBytes(bytes, 0, bytes.length,
-            cd.columnType, wasNull);
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+            cd.columnType);
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -9626,7 +9492,7 @@ public final class RowFormatter implements Serializable {
       final int columnWidth = (int)offsetAndWidth;
       final int offset = (int)(offsetAndWidth >>> Integer.SIZE);
       return DataTypeUtilities.getAsBytes(unsafe, memAddr, offset, columnWidth,
-          bs, cd.columnType, wasNull);
+          bs, cd.columnType);
     }
     else {
       assert offsetAndWidth == OFFSET_AND_WIDTH_IS_NULL
@@ -9635,18 +9501,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getBytes();
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -9685,7 +9545,7 @@ public final class RowFormatter implements Serializable {
         if (lob instanceof byte[]) {
           final byte[] bytes = (byte[])lob;
           return DataTypeUtilities.getAsBytes(bytes, 0, bytes.length,
-              cd.columnType, wasNull);
+              cd.columnType);
         }
         else {
           final OffHeapByteSource bs = (OffHeapByteSource)lob;
@@ -9693,13 +9553,10 @@ public final class RowFormatter implements Serializable {
           final int bytesLen = bs.getLength();
           final long memAddr = bs.getUnsafeAddress(0, bytesLen);
           return DataTypeUtilities.getAsBytes(unsafe, memAddr, 0, bytesLen, bs,
-              cd.columnType, wasNull);
+              cd.columnType);
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -9718,11 +9575,8 @@ public final class RowFormatter implements Serializable {
           columnWidth, cal, cd.columnType);
       if (v != null) {
         return v;
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -9733,18 +9587,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getDate(cal);
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -9785,11 +9633,8 @@ public final class RowFormatter implements Serializable {
           + offset, columnWidth, bs, cal, cd.columnType);
       if (v != null) {
         return v;
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -9800,18 +9645,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getDate(cal);
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -9861,11 +9700,8 @@ public final class RowFormatter implements Serializable {
           columnWidth, cal, cd.columnType);
       if (v != null) {
         return v;
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -9876,18 +9712,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getTime(cal);
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -9928,11 +9758,8 @@ public final class RowFormatter implements Serializable {
           + offset, columnWidth, bs, cal, cd.columnType);
       if (v != null) {
         return v;
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -9943,18 +9770,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getTime(cal);
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -10004,11 +9825,8 @@ public final class RowFormatter implements Serializable {
           offset, columnWidth, cal, cd.columnType);
       if (v != null) {
         return v;
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -10019,18 +9837,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getTimestamp(cal);
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -10072,11 +9884,8 @@ public final class RowFormatter implements Serializable {
           memAddr + offset, columnWidth, bs, cal, cd.columnType);
       if (v != null) {
         return v;
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -10087,18 +9896,12 @@ public final class RowFormatter implements Serializable {
         final DataValueDescriptor dvd = cd.columnDefault;
         if (dvd != null && !dvd.isNull()) {
           return dvd.getTimestamp(cal);
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
+        } else {
+          if (wasNull != null) wasNull.setWasNull();
           return null;
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -10146,11 +9949,8 @@ public final class RowFormatter implements Serializable {
           : cd.columnDefaultBytes;
       if (bytes != null) {
         return new HarmonySerialBlob(bytes);
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -10177,11 +9977,8 @@ public final class RowFormatter implements Serializable {
         else {
           return new HarmonySerialBlob((OffHeapByteSource)lob);
         }
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -10207,11 +10004,8 @@ public final class RowFormatter implements Serializable {
         final int strlen = SQLChar.readIntoCharsFromByteArray(bytes, 0, size,
             chars);
         return new HarmonySerialClob(chars, strlen);
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }
@@ -10249,11 +10043,8 @@ public final class RowFormatter implements Serializable {
               bs.getUnsafeAddress(0, bytesLen), bytesLen, bs, chars);
         }
         return new HarmonySerialClob(chars, strlen);
-      }
-      else {
-        if (wasNull != null) {
-          wasNull.setWasNull();
-        }
+      } else {
+        if (wasNull != null) wasNull.setWasNull();
         return null;
       }
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationStatsDiskLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationStatsDiskLRURegionEntryHeap.java
@@ -567,7 +567,7 @@ public class VMBucketRowLocationStatsDiskLRURegionEntryHeap extends RowLocationS
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationStatsDiskRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationStatsDiskRegionEntryHeap.java
@@ -439,7 +439,7 @@ public class VMBucketRowLocationStatsDiskRegionEntryHeap extends RowLocationStat
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationStatsLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationStatsLRURegionEntryHeap.java
@@ -489,7 +489,7 @@ public class VMBucketRowLocationStatsLRURegionEntryHeap extends RowLocationStats
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationStatsRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationStatsRegionEntryHeap.java
@@ -402,7 +402,7 @@ public class VMBucketRowLocationStatsRegionEntryHeap extends RowLocationStatsReg
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationThinDiskLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationThinDiskLRURegionEntryHeap.java
@@ -501,7 +501,7 @@ public class VMBucketRowLocationThinDiskLRURegionEntryHeap extends RowLocationTh
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationThinDiskRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationThinDiskRegionEntryHeap.java
@@ -374,7 +374,7 @@ public class VMBucketRowLocationThinDiskRegionEntryHeap extends RowLocationThinD
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationThinLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationThinLRURegionEntryHeap.java
@@ -423,7 +423,7 @@ public class VMBucketRowLocationThinLRURegionEntryHeap extends RowLocationThinLR
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationThinRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMBucketRowLocationThinRegionEntryHeap.java
@@ -337,7 +337,7 @@ public class VMBucketRowLocationThinRegionEntryHeap extends RowLocationThinRegio
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationStatsDiskLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationStatsDiskLRURegionEntryHeap.java
@@ -566,7 +566,7 @@ public class VMLocalRowLocationStatsDiskLRURegionEntryHeap extends RowLocationSt
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationStatsDiskRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationStatsDiskRegionEntryHeap.java
@@ -438,7 +438,7 @@ public class VMLocalRowLocationStatsDiskRegionEntryHeap extends RowLocationStats
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationStatsLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationStatsLRURegionEntryHeap.java
@@ -488,7 +488,7 @@ public class VMLocalRowLocationStatsLRURegionEntryHeap extends RowLocationStatsL
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationStatsRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationStatsRegionEntryHeap.java
@@ -401,7 +401,7 @@ public class VMLocalRowLocationStatsRegionEntryHeap extends RowLocationStatsRegi
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationThinDiskLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationThinDiskLRURegionEntryHeap.java
@@ -500,7 +500,7 @@ public class VMLocalRowLocationThinDiskLRURegionEntryHeap extends RowLocationThi
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationThinDiskRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationThinDiskRegionEntryHeap.java
@@ -373,7 +373,7 @@ public class VMLocalRowLocationThinDiskRegionEntryHeap extends RowLocationThinDi
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationThinLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationThinLRURegionEntryHeap.java
@@ -422,7 +422,7 @@ public class VMLocalRowLocationThinLRURegionEntryHeap extends RowLocationThinLRU
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationThinRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VMLocalRowLocationThinRegionEntryHeap.java
@@ -336,7 +336,7 @@ public class VMLocalRowLocationThinRegionEntryHeap extends RowLocationThinRegion
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationStatsDiskLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationStatsDiskLRURegionEntryHeap.java
@@ -676,7 +676,7 @@ public class VersionedBucketRowLocationStatsDiskLRURegionEntryHeap extends RowLo
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationStatsDiskRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationStatsDiskRegionEntryHeap.java
@@ -538,7 +538,7 @@ public class VersionedBucketRowLocationStatsDiskRegionEntryHeap extends RowLocat
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationStatsLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationStatsLRURegionEntryHeap.java
@@ -600,7 +600,7 @@ public class VersionedBucketRowLocationStatsLRURegionEntryHeap extends RowLocati
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationStatsRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationStatsRegionEntryHeap.java
@@ -495,7 +495,7 @@ public class VersionedBucketRowLocationStatsRegionEntryHeap extends RowLocationS
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationThinDiskLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationThinDiskLRURegionEntryHeap.java
@@ -612,7 +612,7 @@ public class VersionedBucketRowLocationThinDiskLRURegionEntryHeap extends RowLoc
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationThinDiskRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationThinDiskRegionEntryHeap.java
@@ -471,7 +471,7 @@ public class VersionedBucketRowLocationThinDiskRegionEntryHeap extends RowLocati
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationThinLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationThinLRURegionEntryHeap.java
@@ -518,7 +518,7 @@ public class VersionedBucketRowLocationThinLRURegionEntryHeap extends RowLocatio
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationThinRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedBucketRowLocationThinRegionEntryHeap.java
@@ -430,7 +430,7 @@ public class VersionedBucketRowLocationThinRegionEntryHeap extends RowLocationTh
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationStatsDiskLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationStatsDiskLRURegionEntryHeap.java
@@ -675,7 +675,7 @@ public class VersionedLocalRowLocationStatsDiskLRURegionEntryHeap extends RowLoc
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationStatsDiskRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationStatsDiskRegionEntryHeap.java
@@ -537,7 +537,7 @@ public class VersionedLocalRowLocationStatsDiskRegionEntryHeap extends RowLocati
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationStatsLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationStatsLRURegionEntryHeap.java
@@ -599,7 +599,7 @@ public class VersionedLocalRowLocationStatsLRURegionEntryHeap extends RowLocatio
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationStatsRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationStatsRegionEntryHeap.java
@@ -494,7 +494,7 @@ public class VersionedLocalRowLocationStatsRegionEntryHeap extends RowLocationSt
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationThinDiskLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationThinDiskLRURegionEntryHeap.java
@@ -611,7 +611,7 @@ public class VersionedLocalRowLocationThinDiskLRURegionEntryHeap extends RowLoca
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationThinDiskRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationThinDiskRegionEntryHeap.java
@@ -470,7 +470,7 @@ public class VersionedLocalRowLocationThinDiskRegionEntryHeap extends RowLocatio
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationThinLRURegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationThinLRURegionEntryHeap.java
@@ -517,7 +517,7 @@ public class VersionedLocalRowLocationThinLRURegionEntryHeap extends RowLocation
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationThinRegionEntryHeap.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/VersionedLocalRowLocationThinRegionEntryHeap.java
@@ -429,7 +429,7 @@ public class VersionedLocalRowLocationThinRegionEntryHeap extends RowLocationThi
   }
   @Override
   public Object getValueWithoutFaultInOrOffHeapEntry(LocalRegion owner) {
-    return this.getValueInVMOrDiskWithoutFaultIn(owner);
+    return this.getHeapValueInVMOrDiskWithoutFaultIn(owner);
   }
   @Override
   public Object getValueOrOffHeapEntry(LocalRegion owner) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/DataTypeUtilities.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/DataTypeUtilities.java
@@ -61,7 +61,6 @@ import com.pivotal.gemfirexd.internal.shared.common.StoredFormatIds;
 import java.math.BigDecimal;
 import java.sql.Types;
 import java.sql.ResultSetMetaData;
-import java.util.Arrays;
 import java.util.Calendar;
 
 /**
@@ -1112,8 +1111,7 @@ public abstract class DataTypeUtilities {
             columnWidth);
         if (bd != null) {
           return SQLDecimal.getBoolean(bd);
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return false;
         }
@@ -1133,34 +1131,21 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          return !(str.equals("0") || str.equals("false"));
-        }
-        else {
-          wasNull.setWasNull();
-          return false;
-        }
+        return !(str.equals("0") || str.equals("false"));
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
       case StoredFormatIds.VARCHAR_TYPE_ID:
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          return !(str.equals("0") || str.equals("false"));
-        }
-        else {
-          wasNull.setWasNull();
-          return false;
-        }
+        return !(str.equals("0") || str.equals("false"));
       }
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(inBytes, offset, columnWidth);
         if (!dvd.isNull()) {
           return dvd.getBoolean();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return false;
         }
@@ -1191,8 +1176,7 @@ public abstract class DataTypeUtilities {
             columnWidth);
         if (bd != null) {
           return SQLDecimal.getBoolean(bd);
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return false;
         }
@@ -1212,34 +1196,21 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(unsafe, memOffset, columnWidth,
             bs, dtd).trim();
-        if (str != null) {
-          return !(str.equals("0") || str.equals("false"));
-        }
-        else {
-          wasNull.setWasNull();
-          return false;
-        }
+        return !(str.equals("0") || str.equals("false"));
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
       case StoredFormatIds.VARCHAR_TYPE_ID:
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(unsafe, memOffset,
             columnWidth, bs, dtd).trim();
-        if (str != null) {
-          return !(str.equals("0") || str.equals("false"));
-        }
-        else {
-          wasNull.setWasNull();
-          return false;
-        }
+        return !(str.equals("0") || str.equals("false"));
       }
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
         if (!dvd.isNull()) {
           return dvd.getBoolean();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return false;
         }
@@ -1285,8 +1256,7 @@ public abstract class DataTypeUtilities {
                 SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
                 cd.getColumnName());
           }
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return (byte)0;
         }
@@ -1321,18 +1291,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          try {
-            return Byte.parseByte(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "TINYINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Byte.parseByte(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "TINYINT",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
@@ -1340,18 +1304,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          try {
-            return Byte.parseByte(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "TINYINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Byte.parseByte(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "TINYINT",
+              cd.getColumnName());
         }
       }
       default: {
@@ -1359,8 +1317,7 @@ public abstract class DataTypeUtilities {
         dvd.readBytes(inBytes, offset, columnWidth);
         if (!dvd.isNull()) {
           return dvd.getByte();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return (byte)0;
         }
@@ -1407,8 +1364,7 @@ public abstract class DataTypeUtilities {
                 SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
                 cd.getColumnName());
           }
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return (byte)0;
         }
@@ -1443,18 +1399,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(unsafe, memOffset, columnWidth,
             bs, dtd).trim();
-        if (str != null) {
-          try {
-            return Byte.parseByte(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "TINYINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Byte.parseByte(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "TINYINT",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
@@ -1462,18 +1412,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(unsafe, memOffset,
             columnWidth, bs, dtd).trim();
-        if (str != null) {
-          try {
-            return Byte.parseByte(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "TINYINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Byte.parseByte(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "TINYINT",
+              cd.getColumnName());
         }
       }
       default: {
@@ -1481,8 +1425,7 @@ public abstract class DataTypeUtilities {
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
         if (!dvd.isNull()) {
           return dvd.getByte();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return (byte)0;
         }
@@ -1531,8 +1474,7 @@ public abstract class DataTypeUtilities {
                 SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
                 cd.getColumnName());
           }
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return (short)0;
         }
@@ -1559,18 +1501,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          try {
-            return Short.parseShort(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Short.parseShort(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
@@ -1578,18 +1514,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          try {
-            return Short.parseShort(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Short.parseShort(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT",
+              cd.getColumnName());
         }
       }
       default: {
@@ -1597,8 +1527,7 @@ public abstract class DataTypeUtilities {
         dvd.readBytes(inBytes, offset, columnWidth);
         if (!dvd.isNull()) {
           return dvd.getShort();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return (short)0;
         }
@@ -1646,8 +1575,7 @@ public abstract class DataTypeUtilities {
                 SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
                 cd.getColumnName());
           }
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return (short)0;
         }
@@ -1674,18 +1602,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(unsafe, memOffset, columnWidth,
             bs, dtd).trim();
-        if (str != null) {
-          try {
-            return Short.parseShort(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Short.parseShort(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
@@ -1693,18 +1615,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(unsafe, memOffset,
             columnWidth, bs, dtd).trim();
-        if (str != null) {
-          try {
-            return Short.parseShort(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Short.parseShort(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "SMALLINT",
+              cd.getColumnName());
         }
       }
       default: {
@@ -1712,8 +1628,7 @@ public abstract class DataTypeUtilities {
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
         if (!dvd.isNull()) {
           return dvd.getShort();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return (short)0;
         }
@@ -1754,8 +1669,7 @@ public abstract class DataTypeUtilities {
                 SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
                 cd.getColumnName());
           }
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0;
         }
@@ -1782,18 +1696,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          try {
-            return Integer.parseInt(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "INTEGER",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Integer.parseInt(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "INTEGER",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
@@ -1801,18 +1709,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          try {
-            return Integer.parseInt(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "INTEGER",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Integer.parseInt(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "INTEGER",
+              cd.getColumnName());
         }
       }
       default: {
@@ -1820,8 +1722,7 @@ public abstract class DataTypeUtilities {
         dvd.readBytes(inBytes, offset, columnWidth);
         if (!dvd.isNull()) {
           return dvd.getInt();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0;
         }
@@ -1863,8 +1764,7 @@ public abstract class DataTypeUtilities {
                 SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
                 cd.getColumnName());
           }
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0;
         }
@@ -1891,18 +1791,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(unsafe, memOffset, columnWidth,
             bs, dtd).trim();
-        if (str != null) {
-          try {
-            return Integer.parseInt(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "INTEGER",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Integer.parseInt(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "INTEGER",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
@@ -1910,18 +1804,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(unsafe, memOffset,
             columnWidth, bs, dtd).trim();
-        if (str != null) {
-          try {
-            return Integer.parseInt(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "INTEGER",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Integer.parseInt(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "INTEGER",
+              cd.getColumnName());
         }
       }
       default: {
@@ -1929,8 +1817,7 @@ public abstract class DataTypeUtilities {
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
         if (!dvd.isNull()) {
           return dvd.getInt();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0;
         }
@@ -1964,8 +1851,7 @@ public abstract class DataTypeUtilities {
             columnWidth);
         if (bd != null) {
           return SQLDecimal.getLong(bd);
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0l;
         }
@@ -1987,18 +1873,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          try {
-            return Long.parseLong(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Long.parseLong(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
@@ -2006,18 +1886,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          try {
-            return Long.parseLong(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Long.parseLong(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
+              cd.getColumnName());
         }
       }
       default: {
@@ -2025,8 +1899,7 @@ public abstract class DataTypeUtilities {
         dvd.readBytes(inBytes, offset, columnWidth);
         if (!dvd.isNull()) {
           return dvd.getLong();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0;
         }
@@ -2061,8 +1934,7 @@ public abstract class DataTypeUtilities {
             columnWidth);
         if (bd != null) {
           return SQLDecimal.getLong(bd);
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0l;
         }
@@ -2084,18 +1956,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(unsafe, memOffset, columnWidth,
             bs, dtd).trim();
-        if (str != null) {
-          try {
-            return Long.parseLong(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Long.parseLong(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
@@ -2103,18 +1969,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(unsafe, memOffset,
             columnWidth, bs, dtd).trim();
-        if (str != null) {
-          try {
-            return Long.parseLong(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Long.parseLong(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
+              cd.getColumnName());
         }
       }
       default: {
@@ -2122,8 +1982,7 @@ public abstract class DataTypeUtilities {
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
         if (!dvd.isNull()) {
           return dvd.getLong();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0;
         }
@@ -2154,8 +2013,7 @@ public abstract class DataTypeUtilities {
             offset, columnWidth);
         if (localValue != null) {
           return NumberDataType.normalizeREAL(localValue.floatValue());
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0.0f;
         }
@@ -2169,18 +2027,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          try {
-            return Float.parseFloat(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Float.parseFloat(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
@@ -2188,18 +2040,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          try {
-            return Float.parseFloat(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Float.parseFloat(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, "BIGINT",
+              cd.getColumnName());
         }
       }
       default: {
@@ -2207,8 +2053,7 @@ public abstract class DataTypeUtilities {
         dvd.readBytes(inBytes, offset, columnWidth);
         if (!dvd.isNull()) {
           return dvd.getFloat();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0.0f;
         }
@@ -2240,8 +2085,7 @@ public abstract class DataTypeUtilities {
             memOffset, columnWidth);
         if (localValue != null) {
           return NumberDataType.normalizeREAL(localValue.floatValue());
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0.0f;
         }
@@ -2255,18 +2099,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(unsafe, memOffset, columnWidth,
             bs, dtd).trim();
-        if (str != null) {
-          try {
-            return Float.parseFloat(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, TypeId.REAL_NAME,
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Float.parseFloat(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, TypeId.REAL_NAME,
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
@@ -2274,18 +2112,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(unsafe, memOffset,
             columnWidth, bs, dtd).trim();
-        if (str != null) {
-          try {
-            return Float.parseFloat(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, TypeId.REAL_NAME,
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Float.parseFloat(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, TypeId.REAL_NAME,
+              cd.getColumnName());
         }
       }
       default: {
@@ -2293,8 +2125,7 @@ public abstract class DataTypeUtilities {
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
         if (!dvd.isNull()) {
           return dvd.getFloat();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0.0f;
         }
@@ -2302,7 +2133,7 @@ public abstract class DataTypeUtilities {
     }
   }
 
-  public static final double getAsDouble(final byte[] inBytes,
+  public static double getAsDouble(final byte[] inBytes,
       final int offset, final int columnWidth, final ColumnDescriptor cd,
       final ResultWasNull wasNull) throws StandardException {
 
@@ -2319,8 +2150,7 @@ public abstract class DataTypeUtilities {
             columnWidth);
         if (bd != null) {
           return SQLDecimal.getDouble(bd);
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0.0;
         }
@@ -2333,18 +2163,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          try {
-            return Double.parseDouble(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME,
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0;
+        try {
+          return Double.parseDouble(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME,
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
@@ -2352,18 +2176,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(inBytes, offset, columnWidth,
             dtd).trim();
-        if (str != null) {
-          try {
-            return Double.parseDouble(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME,
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0.0;
+        try {
+          return Double.parseDouble(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME,
+              cd.getColumnName());
         }
       }
       default:
@@ -2371,8 +2189,7 @@ public abstract class DataTypeUtilities {
         dvd.readBytes(inBytes, offset, columnWidth);
         if (!dvd.isNull()) {
           return dvd.getDouble();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0.0;
         }
@@ -2397,8 +2214,7 @@ public abstract class DataTypeUtilities {
             columnWidth);
         if (bd != null) {
           return SQLDecimal.getDouble(bd);
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0.0;
         }
@@ -2411,18 +2227,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CHAR_TYPE_ID: {
         final String str = SQLChar.getAsString(unsafe, memOffset, columnWidth,
             bs, dtd).trim();
-        if (str != null) {
-          try {
-            return Double.parseDouble(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME,
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0.0;
+        try {
+          return Double.parseDouble(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME,
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGVARCHAR_TYPE_ID:
@@ -2430,18 +2240,12 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.CLOB_TYPE_ID: {
         final String str = SQLVarchar.getAsString(unsafe, memOffset,
             columnWidth, bs, dtd).trim();
-        if (str != null) {
-          try {
-            return Double.parseDouble(str);
-          } catch (NumberFormatException nfe) {
-            throw StandardException.newException(
-                SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME,
-                cd.getColumnName());
-          }
-        }
-        else {
-          wasNull.setWasNull();
-          return 0.0;
+        try {
+          return Double.parseDouble(str);
+        } catch (NumberFormatException nfe) {
+          throw StandardException.newException(
+              SQLState.LANG_FORMAT_EXCEPTION, TypeId.DOUBLE_NAME,
+              cd.getColumnName());
         }
       }
       default:
@@ -2449,8 +2253,7 @@ public abstract class DataTypeUtilities {
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
         if (!dvd.isNull()) {
           return dvd.getDouble();
-        }
-        else {
+        } else {
           wasNull.setWasNull();
           return 0.0;
         }
@@ -2471,8 +2274,7 @@ public abstract class DataTypeUtilities {
               columnWidth);
           if (bd != null) {
             return bd;
-          }
-          else {
+          } else {
             wasNull.setWasNull();
             return null;
           }
@@ -2500,31 +2302,18 @@ public abstract class DataTypeUtilities {
         case StoredFormatIds.CHAR_TYPE_ID: {
           final String str = SQLChar.getAsString(inBytes, offset, columnWidth,
               dtd);
-          if (str != null) {
-            return new BigDecimal(str);
-          }
-          else {
-            wasNull.setWasNull();
-            return BigDecimal.ZERO;
-          }
+          return new BigDecimal(str);
         }
         case StoredFormatIds.LONGVARCHAR_TYPE_ID:
         case StoredFormatIds.VARCHAR_TYPE_ID:
           String str = SQLVarchar.getAsString(inBytes, offset, columnWidth);
-          if (str != null) {
-            return new BigDecimal(str);
-          }
-          else {
-            wasNull.setWasNull();
-            return BigDecimal.ZERO;
-          }
+          return new BigDecimal(str);
         default: {
           final DataValueDescriptor dvd = dtd.getNull();
           dvd.readBytes(inBytes, offset, columnWidth);
           if (!dvd.isNull()) {
             return SQLDecimal.getBigDecimal(dvd);
-          }
-          else {
+          } else {
             wasNull.setWasNull();
             return null;
           }
@@ -2551,8 +2340,7 @@ public abstract class DataTypeUtilities {
               columnWidth);
           if (bd != null) {
             return bd;
-          }
-          else {
+          } else {
             wasNull.setWasNull();
             return null;
           }
@@ -2580,32 +2368,19 @@ public abstract class DataTypeUtilities {
         case StoredFormatIds.CHAR_TYPE_ID: {
           final String str = SQLChar.getAsString(unsafe, memOffset,
               columnWidth, bs, dtd);
-          if (str != null) {
-            return new BigDecimal(str);
-          }
-          else {
-            wasNull.setWasNull();
-            return BigDecimal.ZERO;
-          }
+          return new BigDecimal(str);
         }
         case StoredFormatIds.LONGVARCHAR_TYPE_ID:
         case StoredFormatIds.VARCHAR_TYPE_ID:
           String str = SQLVarchar.getAsString(unsafe, memOffset, columnWidth,
               bs);
-          if (str != null) {
-            return new BigDecimal(str);
-          }
-          else {
-            wasNull.setWasNull();
-            return BigDecimal.ZERO;
-          }
+          return new BigDecimal(str);
         default: {
           final DataValueDescriptor dvd = dtd.getNull();
           dvd.readBytes(unsafe, memOffset, columnWidth, bs);
           if (!dvd.isNull()) {
             return SQLDecimal.getBigDecimal(dvd);
-          }
-          else {
+          } else {
             wasNull.setWasNull();
             return null;
           }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/DataTypeUtilities.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/DataTypeUtilities.java
@@ -40,15 +40,18 @@
 
 package com.pivotal.gemfirexd.internal.iapi.types;
 
+import java.math.BigDecimal;
+import java.sql.ResultSetMetaData;
+import java.sql.Types;
+import java.util.Calendar;
+
 import com.gemstone.gemfire.internal.offheap.UnsafeMemoryChunk;
 import com.gemstone.gemfire.internal.offheap.annotations.Unretained;
 import com.gemstone.gemfire.internal.shared.ClientSharedData;
 import com.gemstone.gemfire.internal.shared.ClientSharedUtils;
 import com.gemstone.gemfire.pdx.internal.unsafe.UnsafeWrapper;
-
 import com.pivotal.gemfirexd.internal.engine.distributed.ByteArrayDataOutput;
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
-import com.pivotal.gemfirexd.internal.engine.store.ResultWasNull;
 import com.pivotal.gemfirexd.internal.engine.store.RowFormatter;
 import com.pivotal.gemfirexd.internal.engine.store.offheap.OffHeapByteSource;
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
@@ -57,11 +60,6 @@ import com.pivotal.gemfirexd.internal.iapi.reference.JDBC40Translation;
 import com.pivotal.gemfirexd.internal.iapi.reference.SQLState;
 import com.pivotal.gemfirexd.internal.iapi.sql.dictionary.ColumnDescriptor;
 import com.pivotal.gemfirexd.internal.shared.common.StoredFormatIds;
-
-import java.math.BigDecimal;
-import java.sql.Types;
-import java.sql.ResultSetMetaData;
-import java.util.Calendar;
 
 /**
  * A set of static utility methods for data types.
@@ -270,12 +268,11 @@ public abstract class DataTypeUtilities {
 // GemStone changes BEGIN
 
   /**
-   * Extract the given column from raw bytes as a string. Parameter "wasNull"
-   * can be null unlike other "getAs*" calls.
+   * Extract the given column from raw bytes as a string.
    */
   public static final String getAsString(final byte[] inBytes,
-      final int offset, final int columnWidth, final DataTypeDescriptor dtd,
-      final ResultWasNull wasNull) throws StandardException {
+      final int offset, final int columnWidth, final DataTypeDescriptor dtd)
+      throws StandardException {
 
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -312,27 +309,17 @@ public abstract class DataTypeUtilities {
       default:
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(inBytes, offset, columnWidth);
-        final String result = dvd.getString();
-        if (result != null) {
-          return result;
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
-          return null;
-        }
+        return dvd.getString();
     }
   }
 
   /**
-   * Extract the given column from raw bytes as a string. Parameter "wasNull"
-   * can be null unlike other "getAs*" calls.
+   * Extract the given column from raw bytes as a string.
    */
   public static final String getAsString(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth,
-      @Unretained final OffHeapByteSource bs, final DataTypeDescriptor dtd,
-      final ResultWasNull wasNull) throws StandardException {
+      @Unretained final OffHeapByteSource bs, final DataTypeDescriptor dtd)
+      throws StandardException {
 
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -369,26 +356,16 @@ public abstract class DataTypeUtilities {
       default:
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
-        final String result = dvd.getString();
-        if (result != null) {
-          return result;
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
-          return null;
-        }
+        return dvd.getString();
     }
   }
 
   /**
-   * Extract the given column from raw bytes as a java object. Parameter
-   * "wasNull" can be null unlike other "getAs*" calls.
+   * Extract the given column from raw bytes as a java object.
    */
   public static final Object getAsObject(final byte[] inBytes,
-      final int offset, final int columnWidth, final DataTypeDescriptor dtd,
-      final ResultWasNull wasNull) throws StandardException {
+      final int offset, final int columnWidth, final DataTypeDescriptor dtd)
+      throws StandardException {
 
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -401,17 +378,7 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.INT_TYPE_ID:
         return Integer.valueOf(SQLInteger.getAsInteger(inBytes, offset));
       case StoredFormatIds.DECIMAL_TYPE_ID:
-        final BigDecimal bd = SQLDecimal.getAsBigDecimal(inBytes, offset,
-            columnWidth);
-        if (bd != null) {
-          return bd;
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
-          return null;
-        }
+        return SQLDecimal.getAsBigDecimal(inBytes, offset, columnWidth);
       case StoredFormatIds.LONGINT_TYPE_ID:
         return Long.valueOf(SQLLongint.getAsLong(inBytes, offset));
       case StoredFormatIds.DOUBLE_TYPE_ID:
@@ -446,27 +413,17 @@ public abstract class DataTypeUtilities {
       default:
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(inBytes, offset, columnWidth);
-        final Object result = dvd.getObject();
-        if (result != null) {
-          return result;
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
-          return null;
-        }
+        return dvd.getObject();
     }
   }
 
   /**
-   * Extract the given column from raw bytes as a java object. Parameter
-   * "wasNull" can be null unlike other "getAs*" calls.
+   * Extract the given column from raw bytes as a java object.
    */
   public static final Object getAsObject(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth,
-      @Unretained final OffHeapByteSource bs, final DataTypeDescriptor dtd,
-      final ResultWasNull wasNull) throws StandardException {
+      @Unretained final OffHeapByteSource bs, final DataTypeDescriptor dtd)
+      throws StandardException {
 
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -479,17 +436,7 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.INT_TYPE_ID:
         return Integer.valueOf(SQLInteger.getAsInteger(unsafe, memOffset));
       case StoredFormatIds.DECIMAL_TYPE_ID:
-        final BigDecimal bd = SQLDecimal.getAsBigDecimal(unsafe, memOffset,
-            columnWidth);
-        if (bd != null) {
-          return bd;
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
-          return null;
-        }
+        return SQLDecimal.getAsBigDecimal(unsafe, memOffset, columnWidth);
       case StoredFormatIds.LONGINT_TYPE_ID:
         return Long.valueOf(SQLLongint.getAsLong(unsafe, memOffset));
       case StoredFormatIds.DOUBLE_TYPE_ID:
@@ -524,16 +471,7 @@ public abstract class DataTypeUtilities {
       default:
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
-        final Object result = dvd.getObject();
-        if (result != null) {
-          return result;
-        }
-        else {
-          if (wasNull != null) {
-            wasNull.setWasNull();
-          }
-          return null;
-        }
+        return dvd.getObject();
     }
   }
 
@@ -1090,10 +1028,9 @@ public abstract class DataTypeUtilities {
   }
 
   public static final boolean getAsBoolean(final byte[] inBytes,
-      final int offset, final int columnWidth, final DataTypeDescriptor dtd,
-      final ResultWasNull wasNull) throws StandardException {
+      final int offset, final int columnWidth, final DataTypeDescriptor dtd)
+      throws StandardException {
 
-    assert wasNull != null;
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.BOOLEAN_TYPE_ID:
@@ -1109,12 +1046,7 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal bd = SQLDecimal.getAsBigDecimal(inBytes, offset,
             columnWidth);
-        if (bd != null) {
-          return SQLDecimal.getBoolean(bd);
-        } else {
-          wasNull.setWasNull();
-          return false;
-        }
+        return SQLDecimal.getBoolean(bd);
       }
       case StoredFormatIds.LONGINT_TYPE_ID: {
         final long lv = SQLLongint.getAsLong(inBytes, offset);
@@ -1143,22 +1075,16 @@ public abstract class DataTypeUtilities {
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(inBytes, offset, columnWidth);
-        if (!dvd.isNull()) {
-          return dvd.getBoolean();
-        } else {
-          wasNull.setWasNull();
-          return false;
-        }
+        return dvd.getBoolean();
       }
     }
   }
 
   public static final boolean getAsBoolean(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth,
-      @Unretained final OffHeapByteSource bs, final DataTypeDescriptor dtd,
-      final ResultWasNull wasNull) throws StandardException {
+      @Unretained final OffHeapByteSource bs, final DataTypeDescriptor dtd)
+      throws StandardException {
 
-    assert wasNull != null;
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.BOOLEAN_TYPE_ID:
@@ -1174,12 +1100,7 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal bd = SQLDecimal.getAsBigDecimal(unsafe, memOffset,
             columnWidth);
-        if (bd != null) {
-          return SQLDecimal.getBoolean(bd);
-        } else {
-          wasNull.setWasNull();
-          return false;
-        }
+        return SQLDecimal.getBoolean(bd);
       }
       case StoredFormatIds.LONGINT_TYPE_ID: {
         final long lv = SQLLongint.getAsLong(unsafe, memOffset);
@@ -1208,21 +1129,15 @@ public abstract class DataTypeUtilities {
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
-        if (!dvd.isNull()) {
-          return dvd.getBoolean();
-        } else {
-          wasNull.setWasNull();
-          return false;
-        }
+        return dvd.getBoolean();
       }
     }
   }
 
   public static final byte getAsByte(final byte[] inBytes, final int offset,
-      final int columnWidth, final ColumnDescriptor cd,
-      final ResultWasNull wasNull) throws StandardException {
+      final int columnWidth, final ColumnDescriptor cd)
+      throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -1247,18 +1162,13 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal bd = SQLDecimal.getAsBigDecimal(inBytes, offset,
             columnWidth);
-        if (bd != null) {
-          final long lv = SQLDecimal.getLong(bd);
-          if ((lv >= Byte.MIN_VALUE) && (lv <= Byte.MAX_VALUE))
-            return (byte)lv;
-          else {
-            throw StandardException.newException(
-                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
-                cd.getColumnName());
-          }
-        } else {
-          wasNull.setWasNull();
-          return (byte)0;
+        final long lv = SQLDecimal.getLong(bd);
+        if ((lv >= Byte.MIN_VALUE) && (lv <= Byte.MAX_VALUE))
+          return (byte)lv;
+        else {
+          throw StandardException.newException(
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGINT_TYPE_ID: {
@@ -1315,22 +1225,16 @@ public abstract class DataTypeUtilities {
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(inBytes, offset, columnWidth);
-        if (!dvd.isNull()) {
-          return dvd.getByte();
-        } else {
-          wasNull.setWasNull();
-          return (byte)0;
-        }
+        return dvd.getByte();
       }
     }
   }
 
   public static final byte getAsByte(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth,
-      @Unretained final OffHeapByteSource bs, final ColumnDescriptor cd,
-      final ResultWasNull wasNull) throws StandardException {
+      @Unretained final OffHeapByteSource bs, final ColumnDescriptor cd)
+      throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -1355,18 +1259,13 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal bd = SQLDecimal.getAsBigDecimal(unsafe, memOffset,
             columnWidth);
-        if (bd != null) {
-          final long lv = SQLDecimal.getLong(bd);
-          if ((lv >= Byte.MIN_VALUE) && (lv <= Byte.MAX_VALUE))
-            return (byte)lv;
-          else {
-            throw StandardException.newException(
-                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
-                cd.getColumnName());
-          }
-        } else {
-          wasNull.setWasNull();
-          return (byte)0;
+        final long lv = SQLDecimal.getLong(bd);
+        if ((lv >= Byte.MIN_VALUE) && (lv <= Byte.MAX_VALUE))
+          return (byte)lv;
+        else {
+          throw StandardException.newException(
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "TINYINT",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGINT_TYPE_ID: {
@@ -1423,12 +1322,7 @@ public abstract class DataTypeUtilities {
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
-        if (!dvd.isNull()) {
-          return dvd.getByte();
-        } else {
-          wasNull.setWasNull();
-          return (byte)0;
-        }
+        return dvd.getByte();
       }
     }
   }
@@ -1436,10 +1330,9 @@ public abstract class DataTypeUtilities {
   // TODO: SW: for both LANG_OUTSIDE_RANGE, LANG_FORMAT errors, should also
   // have the culprit value in exception message
   public static final short getAsShort(final byte[] inBytes, final int offset,
-      final int columnWidth, final ColumnDescriptor cd,
-      final ResultWasNull wasNull) throws StandardException {
+      final int columnWidth, final ColumnDescriptor cd)
+      throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -1465,18 +1358,13 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal bd = SQLDecimal.getAsBigDecimal(inBytes, offset,
             columnWidth);
-        if (bd != null) {
-          final long lv = SQLDecimal.getLong(bd);
-          if ((lv >= Short.MIN_VALUE) && (lv <= Short.MAX_VALUE))
-            return (short)lv;
-          else {
-            throw StandardException.newException(
-                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
-                cd.getColumnName());
-          }
-        } else {
-          wasNull.setWasNull();
-          return (short)0;
+        final long lv = SQLDecimal.getLong(bd);
+        if ((lv >= Short.MIN_VALUE) && (lv <= Short.MAX_VALUE))
+          return (short)lv;
+        else {
+          throw StandardException.newException(
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGINT_TYPE_ID: {
@@ -1525,22 +1413,16 @@ public abstract class DataTypeUtilities {
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(inBytes, offset, columnWidth);
-        if (!dvd.isNull()) {
-          return dvd.getShort();
-        } else {
-          wasNull.setWasNull();
-          return (short)0;
-        }
+        return dvd.getShort();
       }
     }
   }
 
   public static final short getAsShort(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth,
-      @Unretained final OffHeapByteSource bs, final ColumnDescriptor cd,
-      final ResultWasNull wasNull) throws StandardException {
+      @Unretained final OffHeapByteSource bs, final ColumnDescriptor cd)
+      throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -1566,18 +1448,13 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal bd = SQLDecimal.getAsBigDecimal(unsafe, memOffset,
             columnWidth);
-        if (bd != null) {
-          final long lv = SQLDecimal.getLong(bd);
-          if ((lv >= Short.MIN_VALUE) && (lv <= Short.MAX_VALUE))
-            return (short)lv;
-          else {
-            throw StandardException.newException(
-                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
-                cd.getColumnName());
-          }
-        } else {
-          wasNull.setWasNull();
-          return (short)0;
+        final long lv = SQLDecimal.getLong(bd);
+        if ((lv >= Short.MIN_VALUE) && (lv <= Short.MAX_VALUE))
+          return (short)lv;
+        else {
+          throw StandardException.newException(
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "SMALLINT",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGINT_TYPE_ID: {
@@ -1626,21 +1503,15 @@ public abstract class DataTypeUtilities {
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
-        if (!dvd.isNull()) {
-          return dvd.getShort();
-        } else {
-          wasNull.setWasNull();
-          return (short)0;
-        }
+        return dvd.getShort();
       }
     }
   }
 
   public static final int getAsInt(final byte[] inBytes, final int offset,
-      final int columnWidth, final ColumnDescriptor cd,
-      final ResultWasNull wasNull) throws StandardException {
+      final int columnWidth, final ColumnDescriptor cd)
+      throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -1660,18 +1531,13 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal bd = SQLDecimal.getAsBigDecimal(inBytes, offset,
             columnWidth);
-        if (bd != null) {
-          final long lv = SQLDecimal.getLong(bd);
-          if ((lv >= Integer.MIN_VALUE) && (lv <= Integer.MAX_VALUE))
-            return (int)lv;
-          else {
-            throw StandardException.newException(
-                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
-                cd.getColumnName());
-          }
-        } else {
-          wasNull.setWasNull();
-          return 0;
+        final long lv = SQLDecimal.getLong(bd);
+        if ((lv >= Integer.MIN_VALUE) && (lv <= Integer.MAX_VALUE))
+          return (int)lv;
+        else {
+          throw StandardException.newException(
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGINT_TYPE_ID: {
@@ -1720,22 +1586,15 @@ public abstract class DataTypeUtilities {
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(inBytes, offset, columnWidth);
-        if (!dvd.isNull()) {
-          return dvd.getInt();
-        } else {
-          wasNull.setWasNull();
-          return 0;
-        }
+        return dvd.getInt();
       }
     }
   }
 
   public static final int getAsInt(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth, final OffHeapByteSource bs,
-      final ColumnDescriptor cd, final ResultWasNull wasNull)
-      throws StandardException {
+      final ColumnDescriptor cd) throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -1755,18 +1614,13 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal bd = SQLDecimal.getAsBigDecimal(unsafe, memOffset,
             columnWidth);
-        if (bd != null) {
-          final long lv = SQLDecimal.getLong(bd);
-          if ((lv >= Integer.MIN_VALUE) && (lv <= Integer.MAX_VALUE))
-            return (int)lv;
-          else {
-            throw StandardException.newException(
-                SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
-                cd.getColumnName());
-          }
-        } else {
-          wasNull.setWasNull();
-          return 0;
+        final long lv = SQLDecimal.getLong(bd);
+        if ((lv >= Integer.MIN_VALUE) && (lv <= Integer.MAX_VALUE))
+          return (int)lv;
+        else {
+          throw StandardException.newException(
+              SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "INTEGER",
+              cd.getColumnName());
         }
       }
       case StoredFormatIds.LONGINT_TYPE_ID: {
@@ -1815,21 +1669,15 @@ public abstract class DataTypeUtilities {
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
-        if (!dvd.isNull()) {
-          return dvd.getInt();
-        } else {
-          wasNull.setWasNull();
-          return 0;
-        }
+        return dvd.getInt();
       }
     }
   }
 
   public static final long getAsLong(final byte[] inBytes, final int offset,
-      final int columnWidth, final ColumnDescriptor cd,
-      final ResultWasNull wasNull) throws StandardException {
+      final int columnWidth, final ColumnDescriptor cd)
+      throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -1849,12 +1697,7 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal bd = SQLDecimal.getAsBigDecimal(inBytes, offset,
             columnWidth);
-        if (bd != null) {
-          return SQLDecimal.getLong(bd);
-        } else {
-          wasNull.setWasNull();
-          return 0l;
-        }
+        return SQLDecimal.getLong(bd);
       }
       case StoredFormatIds.LONGINT_TYPE_ID: {
         return SQLLongint.getAsLong(inBytes, offset);
@@ -1897,22 +1740,15 @@ public abstract class DataTypeUtilities {
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(inBytes, offset, columnWidth);
-        if (!dvd.isNull()) {
-          return dvd.getLong();
-        } else {
-          wasNull.setWasNull();
-          return 0;
-        }
+        return dvd.getLong();
       }
     }
   }
 
   public static final long getAsLong(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth, final OffHeapByteSource bs,
-      final ColumnDescriptor cd, final ResultWasNull wasNull)
-      throws StandardException {
+      final ColumnDescriptor cd) throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -1932,12 +1768,7 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal bd = SQLDecimal.getAsBigDecimal(unsafe, memOffset,
             columnWidth);
-        if (bd != null) {
-          return SQLDecimal.getLong(bd);
-        } else {
-          wasNull.setWasNull();
-          return 0l;
-        }
+        return SQLDecimal.getLong(bd);
       }
       case StoredFormatIds.LONGINT_TYPE_ID: {
         return SQLLongint.getAsLong(unsafe, memOffset);
@@ -1980,21 +1811,15 @@ public abstract class DataTypeUtilities {
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
-        if (!dvd.isNull()) {
-          return dvd.getLong();
-        } else {
-          wasNull.setWasNull();
-          return 0;
-        }
+        return dvd.getLong();
       }
     }
   }
 
   public static final float getAsFloat(final byte[] inBytes, final int offset,
-      final int columnWidth, final ColumnDescriptor cd,
-      final ResultWasNull wasNull) throws StandardException {
+      final int columnWidth, final ColumnDescriptor cd)
+      throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -2011,12 +1836,7 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal localValue = SQLDecimal.getAsBigDecimal(inBytes,
             offset, columnWidth);
-        if (localValue != null) {
-          return NumberDataType.normalizeREAL(localValue.floatValue());
-        } else {
-          wasNull.setWasNull();
-          return 0.0f;
-        }
+        return NumberDataType.normalizeREAL(localValue.floatValue());
       }
       case StoredFormatIds.LONGINT_TYPE_ID:
         return SQLLongint.getAsLong(inBytes, offset);
@@ -2051,22 +1871,15 @@ public abstract class DataTypeUtilities {
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(inBytes, offset, columnWidth);
-        if (!dvd.isNull()) {
-          return dvd.getFloat();
-        } else {
-          wasNull.setWasNull();
-          return 0.0f;
-        }
+        return dvd.getFloat();
       }
     }
   }
 
   public static final float getAsFloat(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth, final OffHeapByteSource bs,
-      final ColumnDescriptor cd, final ResultWasNull wasNull)
-      throws StandardException {
+      final ColumnDescriptor cd) throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -2083,12 +1896,7 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal localValue = SQLDecimal.getAsBigDecimal(unsafe,
             memOffset, columnWidth);
-        if (localValue != null) {
-          return NumberDataType.normalizeREAL(localValue.floatValue());
-        } else {
-          wasNull.setWasNull();
-          return 0.0f;
-        }
+        return NumberDataType.normalizeREAL(localValue.floatValue());
       }
       case StoredFormatIds.LONGINT_TYPE_ID:
         return SQLLongint.getAsLong(unsafe, memOffset);
@@ -2123,21 +1931,15 @@ public abstract class DataTypeUtilities {
       default: {
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
-        if (!dvd.isNull()) {
-          return dvd.getFloat();
-        } else {
-          wasNull.setWasNull();
-          return 0.0f;
-        }
+        return dvd.getFloat();
       }
     }
   }
 
   public static double getAsDouble(final byte[] inBytes,
-      final int offset, final int columnWidth, final ColumnDescriptor cd,
-      final ResultWasNull wasNull) throws StandardException {
+      final int offset, final int columnWidth, final ColumnDescriptor cd)
+      throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -2148,12 +1950,7 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID:
         final BigDecimal bd = SQLDecimal.getAsBigDecimal(inBytes, offset,
             columnWidth);
-        if (bd != null) {
-          return SQLDecimal.getDouble(bd);
-        } else {
-          wasNull.setWasNull();
-          return 0.0;
-        }
+        return SQLDecimal.getDouble(bd);
       case StoredFormatIds.LONGINT_TYPE_ID:
         return SQLLongint.getAsLong(inBytes, offset);
       case StoredFormatIds.REAL_TYPE_ID:
@@ -2187,21 +1984,14 @@ public abstract class DataTypeUtilities {
       default:
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(inBytes, offset, columnWidth);
-        if (!dvd.isNull()) {
-          return dvd.getDouble();
-        } else {
-          wasNull.setWasNull();
-          return 0.0;
-        }
+        return dvd.getDouble();
     }
   }
 
   public static final double getAsDouble(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth, final OffHeapByteSource bs,
-      final ColumnDescriptor cd, final ResultWasNull wasNull)
-      throws StandardException {
+      final ColumnDescriptor cd) throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
@@ -2212,12 +2002,7 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID:
         final BigDecimal bd = SQLDecimal.getAsBigDecimal(unsafe, memOffset,
             columnWidth);
-        if (bd != null) {
-          return SQLDecimal.getDouble(bd);
-        } else {
-          wasNull.setWasNull();
-          return 0.0;
-        }
+        return SQLDecimal.getDouble(bd);
       case StoredFormatIds.LONGINT_TYPE_ID:
         return SQLLongint.getAsLong(unsafe, memOffset);
       case StoredFormatIds.REAL_TYPE_ID:
@@ -2251,34 +2036,20 @@ public abstract class DataTypeUtilities {
       default:
         final DataValueDescriptor dvd = dtd.getNull();
         dvd.readBytes(unsafe, memOffset, columnWidth, bs);
-        if (!dvd.isNull()) {
-          return dvd.getDouble();
-        } else {
-          wasNull.setWasNull();
-          return 0.0;
-        }
+        return dvd.getDouble();
     }
   }
 
   public static final BigDecimal getAsBigDecimal(final byte[] inBytes,
-      final int offset, final int columnWidth, final ColumnDescriptor cd,
-      final ResultWasNull wasNull) throws StandardException {
+      final int offset, final int columnWidth, final ColumnDescriptor cd)
+      throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     try {
       switch (formatID) {
-        case StoredFormatIds.DECIMAL_TYPE_ID: {
-          final BigDecimal bd = SQLDecimal.getAsBigDecimal(inBytes, offset,
-              columnWidth);
-          if (bd != null) {
-            return bd;
-          } else {
-            wasNull.setWasNull();
-            return null;
-          }
-        }
+        case StoredFormatIds.DECIMAL_TYPE_ID:
+          return SQLDecimal.getAsBigDecimal(inBytes, offset, columnWidth);
         case StoredFormatIds.DOUBLE_TYPE_ID: {
           final double value = SQLDouble.getAsDouble(inBytes, offset);
           return BigDecimal.valueOf(value);
@@ -2311,12 +2082,7 @@ public abstract class DataTypeUtilities {
         default: {
           final DataValueDescriptor dvd = dtd.getNull();
           dvd.readBytes(inBytes, offset, columnWidth);
-          if (!dvd.isNull()) {
-            return SQLDecimal.getBigDecimal(dvd);
-          } else {
-            wasNull.setWasNull();
-            return null;
-          }
+          return SQLDecimal.getBigDecimal(dvd);
         }
       }
     } catch (NumberFormatException nfe) {
@@ -2327,24 +2093,14 @@ public abstract class DataTypeUtilities {
 
   public static final BigDecimal getAsBigDecimal(final UnsafeWrapper unsafe,
       final long memOffset, final int columnWidth, final OffHeapByteSource bs,
-      final ColumnDescriptor cd, final ResultWasNull wasNull)
-      throws StandardException {
+      final ColumnDescriptor cd) throws StandardException {
 
-    assert wasNull != null;
     final DataTypeDescriptor dtd = cd.getType();
     final int formatID = dtd.getTypeId().getTypeFormatId();
     try {
       switch (formatID) {
-        case StoredFormatIds.DECIMAL_TYPE_ID: {
-          final BigDecimal bd = SQLDecimal.getAsBigDecimal(unsafe, memOffset,
-              columnWidth);
-          if (bd != null) {
-            return bd;
-          } else {
-            wasNull.setWasNull();
-            return null;
-          }
-        }
+        case StoredFormatIds.DECIMAL_TYPE_ID:
+          return SQLDecimal.getAsBigDecimal(unsafe, memOffset, columnWidth);
         case StoredFormatIds.DOUBLE_TYPE_ID: {
           final double value = SQLDouble.getAsDouble(unsafe, memOffset);
           return BigDecimal.valueOf(value);
@@ -2378,12 +2134,7 @@ public abstract class DataTypeUtilities {
         default: {
           final DataValueDescriptor dvd = dtd.getNull();
           dvd.readBytes(unsafe, memOffset, columnWidth, bs);
-          if (!dvd.isNull()) {
-            return SQLDecimal.getBigDecimal(dvd);
-          } else {
-            wasNull.setWasNull();
-            return null;
-          }
+          return SQLDecimal.getBigDecimal(dvd);
         }
       }
     } catch (NumberFormatException nfe) {
@@ -2393,10 +2144,9 @@ public abstract class DataTypeUtilities {
   }
 
   public static final byte[] getAsBytes(final byte[] inBytes, final int offset,
-      final int columnWidth, final DataTypeDescriptor dtd,
-      final ResultWasNull wasNull) throws StandardException {
+      final int columnWidth, final DataTypeDescriptor dtd)
+      throws StandardException {
 
-    assert wasNull != null;
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.BIT_TYPE_ID:
@@ -2419,7 +2169,6 @@ public abstract class DataTypeUtilities {
             return bytes;
           }
         } else {
-          wasNull.setWasNull();
           return null;
         }
       }
@@ -2430,7 +2179,6 @@ public abstract class DataTypeUtilities {
           return dvd.getBytes();
         }
         else {
-          wasNull.setWasNull();
           return null;
         }
       }
@@ -2439,10 +2187,9 @@ public abstract class DataTypeUtilities {
 
   public static final byte[] getAsBytes(final UnsafeWrapper unsafe,
       final long memAddr, final int addrOffset, final int columnWidth,
-      final OffHeapByteSource bs, final DataTypeDescriptor dtd,
-      final ResultWasNull wasNull) throws StandardException {
+      final OffHeapByteSource bs, final DataTypeDescriptor dtd)
+      throws StandardException {
 
-    assert wasNull != null;
     final int formatID = dtd.getTypeId().getTypeFormatId();
     switch (formatID) {
       case StoredFormatIds.BIT_TYPE_ID:
@@ -2462,7 +2209,6 @@ public abstract class DataTypeUtilities {
               columnWidth);
           return bytes;
         } else {
-          wasNull.setWasNull();
           return null;
         }
       }
@@ -2473,7 +2219,6 @@ public abstract class DataTypeUtilities {
           return dvd.getBytes();
         }
         else {
-          wasNull.setWasNull();
           return null;
         }
       }


### PR DESCRIPTION
## Changes proposed in this pull request

Performance enhancements as seen in profiling for row store queries from Spark.
- added a getHeapValueInVMOrDiskWithoutFaultIn in RegionEntry that avoids any handling of offheap storage (i.e. avoids multiple instanceof checks and all)
- use Unsafe reads/writes for int/long even heap values in RowFormatter since it avoids having to do multiple single byte reads/writes followed by somewhat expensive bitmask operations; in microbenchmarks the new way is about 20% faster for reads and 600% (6X) for writes
- optimize RowFormatter.getAs\* calls for primitive types for the common case of fixed width types by inlining the fixed width check and returning value immediately without calling getOffsetAndWidth and related methods
- optimize the common case of iteration of single entry in a cell of CustomEntryConcurrentHashMap so avoid copying it to a list and instead assign to a separate variable for single value
- cache includeHDFS flag in PartitionedRegion; cache offheap flag in MemHeapScanController
- avoid instanceof check for NonLocalRegionEntry.isMarkedForEviction by having it return false
- removed unnecessary null checks in DataTypeUtilities where incoming values are known to be always non-null
## Patch testing

snappydata precheckin; store precheckin ongoing
## ReleaseNotes changes

NA
## Other PRs

PR on snappydata for SNAP-1036 will be created next.
