### PR TITLE
[SNAP-1040]Fault in the CachedBatches

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -305,6 +305,8 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
       .getServerInstance().getBoolean("cacheGlobalIndexINMap", false);
 
   private CacheMap globalIndexMap;
+  private final boolean isUsedForCachedBatch;
+
   /**
    * !!!:ezoerner:20080320 need to determine what exceptions this should throw
    * 
@@ -360,6 +362,13 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
     setTraceLock();
     this.locking = getContainerLockingPolicy(properties, this.schemaName,
         this.tableName, this.qualifiedName, this.baseId, this);
+
+    if (this.schemaName != null) {
+      this.isUsedForCachedBatch = this.schemaName.contains("SNAPPYSYS_INTERNAL");
+    }
+    else {
+      this.isUsedForCachedBatch = false;
+    }
 
     String propVal = properties.getProperty(MemIndex.PROPERTY_DDINDEX);
     if (propVal != null) {
@@ -2264,6 +2273,11 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
         true, false, false, r);
     
   }
+
+  public boolean storesCachedBatches() {
+    return isUsedForCachedBatch;
+  }
+
   /**
    * Returns a full scan on the table that will fetch entries from all nodes
    * used by global index scan for index consistency checks. The difference from

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
@@ -426,8 +426,21 @@ public final class RegionEntryUtils {
   public static ExecRow getRowWithoutFaultIn(
       final GemFireContainer baseContainer, final LocalRegion region,
       final RegionEntry entry, final ExtraTableInfo tableInfo) {
-    final Object value = getValueWithoutFaultInOrOffHeapEntry(
-        getDataRegion(region, entry), (RowLocation)entry);
+    final Object value;
+    LocalRegion lr = getDataRegion(region, entry);
+    if (baseContainer != null && !baseContainer.storesCachedBatches()) {
+      value = getValueWithoutFaultInOrOffHeapEntry(
+          lr, (RowLocation)entry);
+    }
+    else {
+      Object tmp = ((RowLocation)entry).getValueOrOffHeapEntry(lr);
+      if (!isValueToken(tmp)) {
+        value = tmp;
+      }
+      else {
+        value = null;
+      }
+    }
     if (value != null) {
       return baseContainer.newExecRow(value, tableInfo, false);
     }


### PR DESCRIPTION
## Changes proposed in this pull request

  In some cases it is seen that, column table evicts the
  cached batches due to memory pressure. This leads to permanent
  query performance issue as currently, there is no way a cached batch
  could be faulted in back to memory.
## Patch testing

(Fill in the details about how this patch was tested)
## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)
## Other PRs

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

  In some cases it is seen that, column table evicts the
  cached batches due to memory pressure. This leads to permanent
  query performance issue as currently, there is no way a cached batch
  could be faulted in back to memory.
