### PR TITLE
* Fix for bug SNAP-1050.

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
@@ -20,6 +20,7 @@ package com.pivotal.gemfirexd.internal.engine.distributed.message;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -33,6 +34,7 @@ import com.gemstone.gemfire.distributed.DistributedMember;
 import com.gemstone.gemfire.distributed.internal.InternalDistributedSystem;
 import com.gemstone.gemfire.distributed.internal.ReplyException;
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
+import com.gemstone.gemfire.internal.HeapDataOutputStream;
 import com.gemstone.gemfire.internal.cache.NoDataStoreAvailableException;
 import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import com.gemstone.gemfire.internal.shared.Version;
@@ -128,9 +130,6 @@ public final class LeadNodeExecutorMsg extends MemberExecutorMessage<Object> {
       SnappyResultHolder srh = new SnappyResultHolder(exec);
 
       srh.prepareSend(this);
-      //sendresult and lastResult is called via prepareSend
-//      this.sendResult(srh);
-//      this.lastResult(srh);
       this.lastResultSent = true;
       this.endMessage();
       if (GemFireXDUtils.TraceQuery) {
@@ -138,31 +137,51 @@ public final class LeadNodeExecutorMsg extends MemberExecutorMessage<Object> {
                 "LeadNodeExecutorMsg.execute: Sent Last result ");
       }
     } catch (Exception ex) {
-      // Catch all exceptions and convert so can be caught at XD side
-      Throwable cause = ex;
-      while (cause != null) {
-        if (cause.getClass().getName().contains("AnalysisException")) {
-          throw StandardException.newException(
-              SQLState.LANG_UNEXPECTED_USER_EXCEPTION, cause, cause.getMessage());
-        } else if (cause.getClass().getName().contains("apache.spark.storage")) {
-          throw StandardException.newException(
-              SQLState.DATA_UNEXPECTED_EXCEPTION, cause, cause.getMessage());
-        } else if (cause.getClass().getName().contains("apache.spark.sql")) {
-          Throwable nestedCause = cause.getCause();
-          while (nestedCause != null) {
-            if (nestedCause.getClass().getName().contains("ErrorLimitExceededException")) {
-              throw StandardException.newException(
-                  SQLState.LANG_UNEXPECTED_USER_EXCEPTION, nestedCause, nestedCause.getMessage());
-            }
-            nestedCause = nestedCause.getCause();
-          }
-          throw StandardException.newException(
-              SQLState.LANG_UNEXPECTED_USER_EXCEPTION, cause, cause.getMessage());
-        }
-        cause = cause.getCause();
-      }
-      throw ex;
+      throw getExceptionToSendToServer(ex);
     }
+  }
+
+  private static class SparkExceptionWrapper extends Exception {
+    public SparkExceptionWrapper(Exception ex) {
+      super(ex.getClass().getName() + ": " + ex.getMessage(), ex.getCause());
+      this.setStackTrace(ex.getStackTrace());
+    }
+  }
+
+  private Exception getExceptionToSendToServer(Exception ex) {
+    // Catch all exceptions and convert so can be caught at XD side
+    // Check if the exception can be serialized or not
+    SparkExceptionWrapper wrapperEx = null;
+    try {
+      HeapDataOutputStream hdos = new HeapDataOutputStream();
+      DataSerializer.writeObject(ex, hdos);
+    } catch (Exception e) {
+      wrapperEx = new SparkExceptionWrapper(ex);
+    }
+    Throwable cause = ex;
+    while (cause != null) {
+      if (cause.getClass().getName().contains("AnalysisException")) {
+        return StandardException.newException(
+            SQLState.LANG_UNEXPECTED_USER_EXCEPTION, (wrapperEx == null ? cause : wrapperEx), cause.getMessage());
+      } else if (cause.getClass().getName().contains("apache.spark.storage")) {
+        return StandardException.newException(
+            SQLState.DATA_UNEXPECTED_EXCEPTION, (wrapperEx == null ? cause : wrapperEx), cause.getMessage());
+      } else if (cause.getClass().getName().contains("apache.spark.sql")) {
+        Throwable nestedCause = cause.getCause();
+        while (nestedCause != null) {
+          if (nestedCause.getClass().getName().contains("ErrorLimitExceededException")) {
+            return StandardException.newException(
+                SQLState.LANG_UNEXPECTED_USER_EXCEPTION,
+                (wrapperEx == null ? nestedCause : wrapperEx), nestedCause.getMessage());
+          }
+          nestedCause = nestedCause.getCause();
+        }
+        return StandardException.newException(
+            SQLState.LANG_UNEXPECTED_USER_EXCEPTION, (wrapperEx == null ? cause : wrapperEx), cause.getMessage());
+      }
+      cause = cause.getCause();
+    }
+    return ex;
   }
 
   @Override


### PR DESCRIPTION
## Changes proposed in this pull request

Finding out if the spark side exception is serializable or not and then sending the full exception as it is or wrapping the exception's information like stack trace and message in a new wrapper exception. Fixes SNAP-1050 and SNAP-1037
## Patch testing

Manual testing of the scenario described in SNAP-1050
## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)
## Other PRs

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

The issue is that the AnapysisException can contain some fields which are not
Serializable. Ideally AnalysisException should not have such fields as it implements
the Serializable trait. It is very late before the rowstore sees this exception of
Non Serializable at the time of sending back the exception from lead node to server.
Added a wrapper exception class which carrie the same stack trace as the original exception
and the message but does not contain all the fields of the AnalysisException object.
Extended for oher Saprk side exception too.
