### PR TITLE
[SNAP-1084] Fix GemFire/Snappy activation classes to return proper classLoaderVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ allprojects {
   ext {
     scalaBinaryVersion = '2.11'
     scalaVersion = scalaBinaryVersion + '.8'
+    sparkVersion = '2.0.0'
     springVersion = '3.2.17.RELEASE'
     log4jVersion = '1.2.17'
     slf4jVersion = '1.7.21'

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/ClientSharedData.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/ClientSharedData.java
@@ -20,6 +20,8 @@ package com.gemstone.gemfire.internal.shared;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
 
 public final class ClientSharedData {
 
@@ -64,11 +66,15 @@ public final class ClientSharedData {
 
   public static final byte CLIENT_TXID_NOT_WRITTEN = (byte)0;
 
+  public static final TimeZone DEFAULT_TIMEZONE = TimeZone.getDefault();
+  public static final Locale DEFAULT_LOCALE = Locale.getDefault(
+      Locale.Category.FORMAT);
+
   private static final ThreadLocal<GregorianCalendar> DEFAULT_CALENDAR =
       new ThreadLocal<GregorianCalendar>() {
     @Override
     public GregorianCalendar initialValue() {
-      return new GregorianCalendar();
+      return new GregorianCalendar(DEFAULT_TIMEZONE, DEFAULT_LOCALE);
     }
   };
 

--- a/gemfirexd/core/build.gradle
+++ b/gemfirexd/core/build.gradle
@@ -45,6 +45,8 @@ dependencies {
   provided "org.mortbay.jetty:jetty:${hadoopJettyVersion}"
   provided "org.mortbay.jetty:jetty-util:${hadoopJettyVersion}"
   provided "com.google.code.findbugs:jsr305:${jsr305Version}"
+  provided "org.apache.spark:spark-unsafe_${scalaBinaryVersion}:${sparkVersion}"
+  provided "com.esotericsoftware:kryo-shaded:3.0.3"
 }
 
 // move javacc output directory to a place where IDEA can easily register

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/callbacks/AsyncEventHelper.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/callbacks/AsyncEventHelper.java
@@ -123,7 +123,7 @@ public class AsyncEventHelper {
    * instance.
    */
   public final boolean traceExecute() {
-    return GemFireXDUtils.TraceExecute;
+    return GemFireXDUtils.TraceExecution;
   }
 
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -2049,7 +2049,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
    * @throws StandardException
    */
   public static void REPAIR_CATALOG() throws SQLException, StandardException {
-    if (GemFireXDUtils.TraceExecute) {
+    if (GemFireXDUtils.TraceExecution) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
           "in procedure REPAIR_CATALOG()");
     }
@@ -2106,7 +2106,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
     long statementId = Long.parseLong(s[1]);
     long executionID = Long.parseLong(s[2]);
     
-    if (GemFireXDUtils.TraceExecute) {
+    if (GemFireXDUtils.TraceExecution) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
           "CANCEL_STATEMENT connectionId=" + connectionId + " statementId="
               + statementId + " executionID=" + executionID);
@@ -2143,7 +2143,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
     }
     final Object[] params;
 
-    if (GemFireXDUtils.TraceExecute) {
+    if (GemFireXDUtils.TraceExecution) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
           "CHECK_TABLE_EX schema:" + schema + "table: " + table);
     }
@@ -2212,7 +2212,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
     }
 
     ldapGroup = StringUtil.SQLToUpperCase(ldapGroup);
-    if (GemFireXDUtils.TraceExecute) {
+    if (GemFireXDUtils.TraceExecution) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
           "REFRESH_LDAP_GROUP ldapGroup=" + ldapGroup);
     }
@@ -2290,7 +2290,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
       throw PublicAPI.wrapStandardException(StandardException.newException(
           SQLState.TABLE_NOT_FOUND, table));
     }
-    if (GemFireXDUtils.TraceExecute) {
+    if (GemFireXDUtils.TraceExecution) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
           "GET_COLUMN_TABLE_SCHEMA table=" + table + " schema=" + schemaString);
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/JSONProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/JSONProcedures.java
@@ -46,7 +46,7 @@ public final class JSONProcedures {
    */
   public static String json_evalPath(JSON column, String jsonPath)
       throws StandardException {
-    if (GemFireXDUtils.TraceExecute) {
+    if (GemFireXDUtils.TraceExecution) {
       SanityManager.DEBUG_PRINT("info", "Json path to be evaluated : " + jsonPath);
     }
     PdxInstance pdxInstance = column.getPdxInstance();

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/QueryCancelFunction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/QueryCancelFunction.java
@@ -90,7 +90,7 @@ public final class QueryCancelFunction implements Function, Declarable {
       lcc = getLccFromContextService(args.connectionId);
     }
     
-    if (GemFireXDUtils.TraceExecute) {
+    if (GemFireXDUtils.TraceExecution) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
           " QueryCancelFunction#execute wrapper=" + wrapper + " statement="
               + stmt + " lcc=" + lcc + " connectionId=" + args.connectionId

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/ResultHolder.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/ResultHolder.java
@@ -641,7 +641,7 @@ public final class ResultHolder extends GfxdDataSerializable {
             "ResultHolder::prepareSend: got exception while sending", t);
       }
       else if (GemFireXDUtils.TraceFunctionException
-          | GemFireXDUtils.TraceExecute) {
+          | GemFireXDUtils.TraceExecution) {
         // log full stack for unexpected runtime exceptions
         boolean printStack = false;
         Throwable fail = t;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/GemFireXDUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/GemFireXDUtils.java
@@ -2034,7 +2034,7 @@ public final class GemFireXDUtils {
     StandardException se = StandardException.newException(
         SQLState.LANG_DUPLICATE_KEY_CONSTRAINT, eee, constraintType, indexName);
     // don't report constraint violations to logs by default
-    if (!GemFireXDUtils.TraceExecute) {
+    if (!GemFireXDUtils.TraceExecution) {
       se.setReport(StandardException.REPORT_NEVER);
     }
     return se;
@@ -2060,7 +2060,7 @@ public final class GemFireXDUtils {
     StandardException se = StandardException.newException(
         SQLState.NOT_IMPLEMENTED, eee, constraintType, indexName);
     // don't report constraint violations to logs by default
-    if (!GemFireXDUtils.TraceExecute) {
+    if (!GemFireXDUtils.TraceExecution) {
       se.setReport(StandardException.REPORT_NEVER);
     }
     return se;
@@ -3075,12 +3075,12 @@ public final class GemFireXDUtils {
   // statics for various derby debug flags used for GemFireXD trace logging
 
   /**
-   * Set to true of one of the different debug flags like
-   * {@link GfxdConstants#TRACE_QUERYDISTRIB} are set or fine level logging
-   * enabled. This is to do minimal tracing of the execution of different
-   * DDLs/DMLs/queries.
+   * Set to true if {@link GfxdConstants#TRACE_EXECUTION} or one of the debug
+   * flags like {@link GfxdConstants#TRACE_QUERYDISTRIB} are set or fine level
+   * logging enabled. This is to do minimal tracing of the execution of
+   * different DDLs/DMLs/queries.
    */
-  public static boolean TraceExecute;
+  public static boolean TraceExecution;
 
   /**
    * Set to true if {@link GfxdConstants#TRACE_QUERYDISTRIB} debug flag is set.
@@ -3315,17 +3315,17 @@ public final class GemFireXDUtils {
     // initialize GFE layer verbose logging as required
     initGFEFlags();
 
-    setTraceExecute(SanityManager.TRACE_ON(GfxdConstants.TRACE_EXECUTION));
+    setTraceExecution(SanityManager.TRACE_ON(GfxdConstants.TRACE_EXECUTION));
 
     TraceSysProcedures = SanityManager
         .TRACE_ON(GfxdConstants.TRACE_SYS_PROCEDURES) ||
-        (TraceExecute && !SanityManager.TRACE_OFF(
+        (TraceExecution && !SanityManager.TRACE_OFF(
             GfxdConstants.TRACE_SYS_PROCEDURES));
   }
 
-  private static void setTraceExecute(boolean force) {
+  private static void setTraceExecution(boolean force) {
 
-    TraceExecute = force || TraceQuery || SanityManager.isFineEnabled
+    TraceExecution = force || TraceQuery || SanityManager.isFineEnabled
         || TXStateProxy.TRACE_EXECUTE || DistributionManager.VERBOSE
         || TraceDBSynchronizer || TraceDBSynchronizerHA || TraceActivation
         || TraceLock || ExclusiveSharedSynchronizer.TRACE_LOCK_COMPACT

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/reflect/GemFireActivationClass.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/reflect/GemFireActivationClass.java
@@ -14,9 +14,6 @@
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
-/**
- * 
- */
 package com.pivotal.gemfirexd.internal.engine.reflect;
 
 import com.pivotal.gemfirexd.internal.engine.distributed.metadata.QueryInfo;
@@ -33,10 +30,13 @@ import com.pivotal.gemfirexd.internal.iapi.sql.execute.ExecPreparedStatement;
  */
 public final class GemFireActivationClass implements GeneratedClass {
 
-  protected QueryInfo querynodes;
+  private final QueryInfo querynodes;
+  private final int classLoaderVersion;
 
-  public GemFireActivationClass(QueryInfo qi) {
+  public GemFireActivationClass(LanguageConnectionContext lcc, QueryInfo qi) {
     querynodes = qi;
+    this.classLoaderVersion = lcc.getLanguageConnectionFactory()
+        .getClassFactory().getClassLoaderVersion();
   }
 
   public QueryInfo getQueryInfo() {
@@ -44,7 +44,7 @@ public final class GemFireActivationClass implements GeneratedClass {
   }
 
   public int getClassLoaderVersion() {
-    return 0;
+    return this.classLoaderVersion;
   }
 
   public GeneratedMethod getMethod(String simpleName) throws StandardException {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/reflect/SnappyActivationClass.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/reflect/SnappyActivationClass.java
@@ -25,13 +25,19 @@ import com.pivotal.gemfirexd.internal.iapi.sql.conn.LanguageConnectionContext;
 import com.pivotal.gemfirexd.internal.iapi.sql.execute.ExecPreparedStatement;
 
 public class SnappyActivationClass implements GeneratedClass {
-  boolean returnRows;
-  public SnappyActivationClass(boolean returnRows) {
+
+  private final boolean returnRows;
+  private final int classLoaderVersion;
+
+  public SnappyActivationClass(LanguageConnectionContext lcc,
+      boolean returnRows) {
     this.returnRows = returnRows;
+    this.classLoaderVersion = lcc.getLanguageConnectionFactory()
+        .getClassFactory().getClassLoaderVersion();
   }
 
   public int getClassLoaderVersion() {
-    return 0;
+    return this.classLoaderVersion;
   }
 
   public GeneratedMethod getMethod(String simpleName) throws StandardException {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/IdentityValueManager.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/IdentityValueManager.java
@@ -540,7 +540,7 @@ public final class IdentityValueManager {
       if (this.increment != 0) {
         result = IdentityValueManager.getInstance().getAfterRetrievedValue(
             this.table, this.start, this.increment, getSenderForReply());
-        if (GemFireXDUtils.TraceExecute | GemFireXDUtils.TraceFunctionException) {
+        if (GemFireXDUtils.TraceExecution | GemFireXDUtils.TraceFunctionException) {
           SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
               "IDENTITY: GetRetrievedIdentityValues: after identity generator "
                   + "start/failure, got retrieved value = " + result
@@ -550,7 +550,7 @@ public final class IdentityValueManager {
       else { // for clear
         IdentityValueManager.getInstance().clearRetrievedValue(this.table);
         result = 0;
-        if (GemFireXDUtils.TraceExecute) {
+        if (GemFireXDUtils.TraceExecution) {
           SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
               "IDENTITY: GetRetrievedIdentityValues: cleared any cached "
                   + "retrieved value for table " + this.table);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/AbstractCompactExecRow.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/AbstractCompactExecRow.java
@@ -47,6 +47,7 @@ import com.pivotal.gemfirexd.internal.iapi.sql.execute.ExecRow;
 import com.pivotal.gemfirexd.internal.iapi.types.DataTypeUtilities;
 import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor;
 import com.pivotal.gemfirexd.internal.iapi.types.SQLDecimal;
+import org.apache.spark.unsafe.types.UTF8String;
 
 /**
  * Common behavior for implementations of a compact Row used to minimize the
@@ -1251,6 +1252,9 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
             .getFullSQLTypeName(), cd.getColumnName());
   }
 
+  // TODO: SW: fix to store same full UTF8 format in GemXD like in UTF8String
+  public abstract UTF8String getAsUTF8String(int index)
+      throws StandardException;
   protected abstract String getString(int position, ResultWasNull wasNull)
       throws StandardException;
   protected abstract Object getObject(int position, ResultWasNull wasNull)
@@ -1273,9 +1277,15 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
       throws StandardException;
   protected abstract BigDecimal getBigDecimal(int position,
       ResultWasNull wasNull) throws StandardException;
+  // invoked by generated code of SnappyData
+  public abstract long getAsDateMillis(int index, Calendar cal,
+      ResultWasNull wasNull) throws StandardException;
   protected abstract java.sql.Date getDate(int position, Calendar cal,
       ResultWasNull wasNull) throws StandardException;
   protected abstract java.sql.Time getTime(int position, Calendar cal,
+      ResultWasNull wasNull) throws StandardException;
+  // invoked by generated code of SnappyData
+  public abstract long getAsTimestampMicros(int index, Calendar cal,
       ResultWasNull wasNull) throws StandardException;
   protected abstract java.sql.Timestamp getTimestamp(int position,
       Calendar cal, ResultWasNull wasNull) throws StandardException;
@@ -1292,8 +1302,7 @@ public abstract class AbstractCompactExecRow extends GfxdDataSerializable
         for (RegionAndKey rak : setOfKeys) {
           sz += ClassSize.refSize + rak.estimateMemoryUsage();
         }
-      } catch (ConcurrentModificationException ignore) {
-      } catch (NoSuchElementException ignore) {
+      } catch (ConcurrentModificationException | NoSuchElementException ignore) {
       }
     }
     return sz;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/CompactExecRow.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/CompactExecRow.java
@@ -33,6 +33,7 @@ import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
 import com.pivotal.gemfirexd.internal.iapi.services.io.FormatableBitSet;
 import com.pivotal.gemfirexd.internal.iapi.sql.execute.ExecRow;
 import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor;
+import org.apache.spark.unsafe.types.UTF8String;
 
 /**
  * A compact implementation of Row used to minimize the footprint of a row and
@@ -367,6 +368,11 @@ public final class CompactExecRow extends AbstractCompactExecRow {
   }
 
   @Override
+  public UTF8String getAsUTF8String(int index) throws StandardException {
+    return this.formatter.getAsUTF8String(index, this.source);
+  }
+
+  @Override
   protected String getString(int position, ResultWasNull wasNull)
       throws StandardException {
     return this.formatter.getAsString(position, this.source, wasNull);
@@ -433,6 +439,12 @@ public final class CompactExecRow extends AbstractCompactExecRow {
   }
 
   @Override
+  public long getAsDateMillis(int index, Calendar cal,
+      ResultWasNull wasNull) throws StandardException {
+    return this.formatter.getAsDateMillis(index, this.source, cal, wasNull);
+  }
+
+  @Override
   protected java.sql.Date getDate(int position, Calendar cal,
       ResultWasNull wasNull) throws StandardException {
     return this.formatter.getAsDate(position, this.source, cal, wasNull);
@@ -442,6 +454,12 @@ public final class CompactExecRow extends AbstractCompactExecRow {
   protected java.sql.Time getTime(int position, Calendar cal,
       ResultWasNull wasNull) throws StandardException {
     return this.formatter.getAsTime(position, this.source, cal, wasNull);
+  }
+
+  @Override
+  public long getAsTimestampMicros(int index, Calendar cal,
+      ResultWasNull wasNull) throws StandardException {
+    return this.formatter.getAsTimestampMicros(index, this.source, cal, wasNull);
   }
 
   @Override

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/CompactExecRowWithLobs.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/CompactExecRowWithLobs.java
@@ -38,6 +38,7 @@ import com.pivotal.gemfirexd.internal.iapi.sql.dictionary.ColumnDescriptor;
 import com.pivotal.gemfirexd.internal.iapi.sql.execute.ExecRow;
 import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor;
 import com.pivotal.gemfirexd.internal.shared.common.ResolverUtils;
+import org.apache.spark.unsafe.types.UTF8String;
 
 /**
  * A compact implementation of Row that contains one or more LOBs (i.e. BLOBs or
@@ -174,6 +175,11 @@ public final class CompactExecRowWithLobs extends AbstractCompactExecRow {
   }
 
   @Override
+  public UTF8String getAsUTF8String(int index) throws StandardException {
+    return this.formatter.getAsUTF8String(index, this.source);
+  }
+
+  @Override
   protected String getString(int position, ResultWasNull wasNull)
       throws StandardException {
     return this.formatter.getAsString(position, this.source, wasNull);
@@ -240,6 +246,12 @@ public final class CompactExecRowWithLobs extends AbstractCompactExecRow {
   }
 
   @Override
+  public long getAsDateMillis(int index, Calendar cal,
+      ResultWasNull wasNull) throws StandardException {
+    return this.formatter.getAsDateMillis(index, this.source, cal, wasNull);
+  }
+
+  @Override
   protected java.sql.Date getDate(int position, Calendar cal,
       ResultWasNull wasNull) throws StandardException {
     return this.formatter.getAsDate(position, this.source, cal, wasNull);
@@ -249,6 +261,12 @@ public final class CompactExecRowWithLobs extends AbstractCompactExecRow {
   protected java.sql.Time getTime(int position, Calendar cal,
       ResultWasNull wasNull) throws StandardException {
     return this.formatter.getAsTime(position, this.source, cal, wasNull);
+  }
+
+  @Override
+  public long getAsTimestampMicros(int index, Calendar cal,
+      ResultWasNull wasNull) throws StandardException {
+    return this.formatter.getAsTimestampMicros(index, this.source, cal, wasNull);
   }
 
   @Override

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/OffHeapCompactExecRowWithLobs.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/OffHeapCompactExecRowWithLobs.java
@@ -45,6 +45,7 @@ import com.pivotal.gemfirexd.internal.iapi.sql.dictionary.ColumnDescriptor;
 import com.pivotal.gemfirexd.internal.iapi.sql.execute.ExecRow;
 import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor;
 import com.pivotal.gemfirexd.internal.shared.common.ResolverUtils;
+import org.apache.spark.unsafe.types.UTF8String;
 
 import static com.gemstone.gemfire.internal.offheap.annotations.OffHeapIdentifier.OFFHEAP_COMPACT_EXEC_ROW_WITH_LOBS_SOURCE;
 
@@ -266,6 +267,24 @@ public final class OffHeapCompactExecRowWithLobs extends AbstractCompactExecRow 
       }
     }
     else {
+      return null;
+    }
+  }
+
+  @Override
+  public UTF8String getAsUTF8String(int index) throws StandardException {
+    final Object source = this.source;
+    if (source != null) {
+      final Class<?> cls = source.getClass();
+      if (cls == OffHeapRowWithLobs.class) {
+        return this.formatter.getAsUTF8String(index,
+            (OffHeapRowWithLobs)source);
+      } else if (cls == byte[][].class) {
+        return this.formatter.getAsUTF8String(index, (byte[][])source);
+      } else {
+        return this.formatter.getAsUTF8String(index, (OffHeapRow)source);
+      }
+    } else {
       return null;
     }
   }
@@ -519,6 +538,28 @@ public final class OffHeapCompactExecRowWithLobs extends AbstractCompactExecRow 
   }
 
   @Override
+  public long getAsDateMillis(int index, Calendar cal,
+      ResultWasNull wasNull) throws StandardException {
+    final Object source = this.source;
+    if (source != null) {
+      final Class<?> cls = source.getClass();
+      if (cls == OffHeapRowWithLobs.class) {
+        return this.formatter.getAsDateMillis(index,
+            (OffHeapRowWithLobs)source, cal, wasNull);
+      } else if (cls == byte[][].class) {
+        return this.formatter.getAsDateMillis(index, (byte[][])source,
+            cal, wasNull);
+      } else {
+        return this.formatter.getAsDateMillis(index, (OffHeapRow)source,
+            cal, wasNull);
+      }
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
+      return 0L;
+    }
+  }
+
+  @Override
   protected java.sql.Date getDate(int position, Calendar cal,
       ResultWasNull wasNull) throws StandardException {
     final Object source = this.source;
@@ -563,6 +604,28 @@ public final class OffHeapCompactExecRowWithLobs extends AbstractCompactExecRow 
     }
     else {
       return this.formatter.getAsTime(position, (byte[])null, cal, wasNull);
+    }
+  }
+
+  @Override
+  public long getAsTimestampMicros(int index, Calendar cal,
+      ResultWasNull wasNull) throws StandardException {
+    final Object source = this.source;
+    if (source != null) {
+      final Class<?> cls = source.getClass();
+      if (cls == OffHeapRowWithLobs.class) {
+        return this.formatter.getAsTimestampMicros(index,
+            (OffHeapRowWithLobs)source, cal, wasNull);
+      } else if (cls == byte[][].class) {
+        return this.formatter.getAsTimestampMicros(index, (byte[][])source,
+            cal, wasNull);
+      } else {
+        return this.formatter.getAsTimestampMicros(index, (OffHeapRow)source,
+            cal, wasNull);
+      }
+    } else {
+      if (wasNull != null) wasNull.setWasNull();
+      return 0L;
     }
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLDate.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLDate.java
@@ -455,7 +455,7 @@ public final class SQLDate extends DataType
      * @param isJdbcEscape if true then only the JDBC date escape syntax is allowed
      * @param localeFinder
      *
-     * @exception Standard exception if the syntax is invalid or the value is out of range.
+     * @exception StandardException if the syntax is invalid or the value is out of range.
      */
     public SQLDate( String dateStr, boolean isJdbcEscape, LocaleFinder localeFinder)
         throws StandardException
@@ -476,7 +476,7 @@ public final class SQLDate extends DataType
      * @param isJdbcEscape if true then only the JDBC date escape syntax is allowed
      * @param localeFinder
      *
-     * @exception Standard exception if the syntax is invalid or the value is out of range.
+     * @exception StandardException if the syntax is invalid or the value is out of range.
      */
     public SQLDate( String dateStr, boolean isJdbcEscape, LocaleFinder localeFinder, Calendar cal)
         throws StandardException
@@ -1176,6 +1176,15 @@ public final class SQLDate extends DataType
         getTypeFormatId());
   }
 
+  static final long getAsDateMillis(final byte[] bytes,
+      final int offset, final Calendar cal) {
+    final int encodedDate = RowFormatter.readInt(bytes, offset);
+    if (encodedDate == 0) return 0L;
+    cal.clear();
+    SQLDate.setDateInCalendar(cal, encodedDate);
+    return cal.getTimeInMillis();
+  }
+
   static final java.sql.Date getAsDate(final byte[] bytes,
       final int offset, final Calendar cal) {
     final int encodedDate = RowFormatter.readInt(bytes, offset);
@@ -1183,6 +1192,15 @@ public final class SQLDate extends DataType
     cal.clear();
     SQLDate.setDateInCalendar(cal, encodedDate);
     return new Date(cal.getTimeInMillis());
+  }
+
+  static final long getAsDateMillis(final UnsafeWrapper unsafe,
+      final long memOffset, final Calendar cal) {
+    final int encodedDate = RowFormatter.readInt(unsafe, memOffset);
+    if (encodedDate == 0) return 0L;
+    cal.clear();
+    SQLDate.setDateInCalendar(cal, encodedDate);
+    return cal.getTimeInMillis();
   }
 
   static final java.sql.Date getAsDate(final UnsafeWrapper unsafe,
@@ -1194,6 +1212,15 @@ public final class SQLDate extends DataType
     return new Date(cal.getTimeInMillis());
   }
 
+  static final long getAsTimeStampMicros(final byte[] bytes,
+      final int offset, final Calendar cal) {
+    final int encodedDate = RowFormatter.readInt(bytes, offset);
+    if (encodedDate == 0) return 0L;
+    cal.clear();
+    SQLDate.setDateInCalendar(cal, encodedDate);
+    return cal.getTimeInMillis() * 1000L;
+  }
+
   static final java.sql.Timestamp getAsTimeStamp(final byte[] bytes,
       final int offset, final Calendar cal) {
     final int encodedDate = RowFormatter.readInt(bytes, offset);
@@ -1201,6 +1228,15 @@ public final class SQLDate extends DataType
     cal.clear();
     SQLDate.setDateInCalendar(cal, encodedDate);
     return new Timestamp(cal.getTimeInMillis());
+  }
+
+  static final long getAsTimeStampMicros(final UnsafeWrapper unsafe,
+      final long memOffset, final Calendar cal) {
+    final int encodedDate = RowFormatter.readInt(unsafe, memOffset);
+    if (encodedDate == 0) return 0L;
+    cal.clear();
+    SQLDate.setDateInCalendar(cal, encodedDate);
+    return cal.getTimeInMillis() * 1000L;
   }
 
   static final java.sql.Timestamp getAsTimeStamp(final UnsafeWrapper unsafe,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLDecimal.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLDecimal.java
@@ -1512,7 +1512,8 @@ public final class SQLDecimal extends NumberDataType implements VariableSizeData
 			((desiredPrecision - desiredScale) <  SQLDecimal.getWholeDigits(getBigDecimal())))
 		{
 			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, 
-									("DECIMAL/NUMERIC("+desiredPrecision+","+desiredScale+")"), (String)null);
+									("DECIMAL/NUMERIC("+desiredPrecision+","+desiredScale+") - " +
+									    getBigDecimal()), (String)null);
 		}
 		value = value.setScale(desiredScale, BigDecimal.ROUND_DOWN);
 		rawData = null;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLTimestamp.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLTimestamp.java
@@ -1451,6 +1451,22 @@ public final class SQLTimestamp extends DataType
     return ResolverUtils.addIntToBucketHash(this.nanos, hash, typeId);
   }
 
+  static final long getAsTimeStampMicros(final byte[] bytes, int offset,
+      Calendar cal) {
+    final int encodedDate, encodedTime, nanos;
+    encodedDate = RowFormatter.readInt(bytes, offset);
+    if (encodedDate == 0) return 0L;
+    offset += 4;
+    encodedTime = RowFormatter.readInt(bytes, offset);
+    offset += 4;
+    nanos = RowFormatter.readInt(bytes, offset);
+    cal.clear();
+    SQLDate.setDateInCalendar(cal, encodedDate);
+    SQLTime.setTimeInCalendar(cal, encodedTime);
+    cal.set(Calendar.MILLISECOND, 0);
+    return cal.getTimeInMillis() * 1000L + (nanos / 1000L);
+  }
+
   static final Timestamp getAsTimeStamp(final byte[] bytes, int offset,
       Calendar cal) {
     final int encodedDate, encodedTime, nanos;
@@ -1467,6 +1483,22 @@ public final class SQLTimestamp extends DataType
     Timestamp t = new Timestamp(cal.getTimeInMillis());
     t.setNanos(nanos);
     return t;
+  }
+
+  static final long getAsTimeStampMicros(final UnsafeWrapper unsafe,
+      long memOffset, Calendar cal) {
+    final int encodedDate, encodedTime, nanos;
+    encodedDate = RowFormatter.readInt(unsafe, memOffset);
+    if (encodedDate == 0) return 0L;
+    memOffset += 4;
+    encodedTime = RowFormatter.readInt(unsafe, memOffset);
+    memOffset += 4;
+    nanos = RowFormatter.readInt(unsafe, memOffset);
+    cal.clear();
+    SQLDate.setDateInCalendar(cal, encodedDate);
+    SQLTime.setTimeInCalendar(cal, encodedTime);
+    cal.set(Calendar.MILLISECOND, 0);
+    return cal.getTimeInMillis() * 1000L + (nanos / 1000L);
   }
 
   static final Timestamp getAsTimeStamp(final UnsafeWrapper unsafe,
@@ -1566,6 +1598,15 @@ public final class SQLTimestamp extends DataType
     buffer.advance(TIMESTAMP_CHARS_MICROS);
   }
 
+  static final long getAsDateMillis(final byte[] inBytes, int offset,
+      final Calendar cal) {
+    int encodedDate = RowFormatter.readInt(inBytes, offset);
+    if (encodedDate == 0) return 0L;
+    cal.clear();
+    SQLDate.setDateInCalendar(cal, encodedDate);
+    return cal.getTimeInMillis();
+  }
+
   static final java.sql.Date getAsDate(final byte[] inBytes, int offset,
       final Calendar cal) {
     int encodedDate = RowFormatter.readInt(inBytes, offset);
@@ -1573,6 +1614,15 @@ public final class SQLTimestamp extends DataType
     cal.clear();
     SQLDate.setDateInCalendar(cal, encodedDate);
     return new Date(cal.getTimeInMillis());
+  }
+
+  static final long getAsDateMillis(final UnsafeWrapper unsafe,
+      long memOffset, final Calendar cal) {
+    int encodedDate = RowFormatter.readInt(unsafe, memOffset);
+    if (encodedDate == 0) return 0L;
+    cal.clear();
+    SQLDate.setDateInCalendar(cal, encodedDate);
+    return cal.getTimeInMillis();
   }
 
   static final java.sql.Date getAsDate(final UnsafeWrapper unsafe,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedStatement.java
@@ -836,7 +836,7 @@ public class EmbedStatement extends ConnectionChild
                                   new Integer(seconds));
         }
         
-        if (GemFireXDUtils.TraceExecute) {
+        if (GemFireXDUtils.TraceExecution) {
           SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
               "EmbedStatement#setQueryTimeout timeout=" + seconds + " seconds");
         }
@@ -868,7 +868,7 @@ public class EmbedStatement extends ConnectionChild
 	 *  * @exception SQLException thrown on failure.
 	 */
 	public void cancel() throws SQLException {
-	  if (GemFireXDUtils.TraceExecute) {
+	  if (GemFireXDUtils.TraceExecution) {
 	    SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
 	        "EmbedStatement#cancel statementId=" + this.statementID 
 	        + " activation=" + this.activation);
@@ -2100,7 +2100,7 @@ public class EmbedStatement extends ConnectionChild
         Set<DistributedMember> otherMembers = null;
         Set<DistributedMember> memberThatPersistOnHDFS = null;
         boolean hdfsPersistenceSuccess = false; 
-        if (GemFireXDUtils.TraceExecute) {
+        if (GemFireXDUtils.TraceExecution) {
           ParameterValueSet pvs;
           final String pvsStr;
           // mask passwords from being logged

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
@@ -214,7 +214,7 @@ public class GenericStatement
 			boolean commitNestedTransaction, StatementContext statementContext,
 			LanguageConnectionContext lcc, boolean isDDL, boolean checkCancellation) throws StandardException {
       GenericPreparedStatement gps = preparedStmt;
-      GeneratedClass ac = new SnappyActivationClass(!isDDL);
+      GeneratedClass ac = new SnappyActivationClass(lcc, !isDDL);
       gps.setActivationClass(ac);
       if (commitNestedTransaction) {
         lcc.commitNestedTransaction();
@@ -261,7 +261,7 @@ public class GenericStatement
                 ProviderList prevAPL = null;
 
                 boolean foundStats = false;
-                if (GemFireXDUtils.TraceExecute) {
+                if (GemFireXDUtils.TraceExecution) {
                   String sql = GemFireXDUtils.maskCreateUserPasswordFromSQLString(
                       this.statementText);
                   SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_QUERYDISTRIB,
@@ -1008,7 +1008,7 @@ public class GenericStatement
                                             }
                                           }
 
-                                          ac = new GemFireActivationClass(qinfo);
+                                          ac = new GemFireActivationClass(lcc, qinfo);
                                         }
 //                                      GemStone changes END
 
@@ -1356,7 +1356,7 @@ public class GenericStatement
             }
 
 
-            ac = new GemFireActivationClass(qinfo);
+            ac = new GemFireActivationClass(lcc, qinfo);
 
           }
           else {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericStatementContext.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericStatementContext.java
@@ -69,15 +69,12 @@ import com.pivotal.gemfirexd.internal.iapi.sql.conn.StatementContext;
 import com.pivotal.gemfirexd.internal.iapi.sql.depend.Dependency;
 import com.pivotal.gemfirexd.internal.iapi.sql.depend.DependencyManager;
 import com.pivotal.gemfirexd.internal.iapi.sql.execute.NoPutResultSet;
-import com.pivotal.gemfirexd.internal.iapi.store.access.TransactionController;
 import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedResultSet;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.sql.SQLException;
 
 /**
  * GenericStatementContext is pushed/popped around a statement prepare and execute
@@ -232,7 +229,7 @@ public final class GenericStatementContext
 		this.pvs = pvs;
 		rollbackParentContext = false;
         if (timeoutMillis > 0) {
-           if (GemFireXDUtils.TraceExecute) {
+           if (GemFireXDUtils.TraceExecution) {
                SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
                  "starting cancel task for query=" + this.stmtText +
                  " query timeout=" + (timeoutMillis / 1000) + " seconds");

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/BaseActivation.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/BaseActivation.java
@@ -2319,7 +2319,7 @@ public abstract class BaseActivation implements CursorActivation, GeneratedByteC
       switch (queryCancellationFlag) {
       case BaseActivation.CANCELLED_LOW_MEMORY:
         if (SanityManager.DEBUG) {
-          if (GemFireXDUtils.TraceHeapThresh || GemFireXDUtils.TraceExecute) {
+          if (GemFireXDUtils.TraceHeapThresh || GemFireXDUtils.TraceExecution) {
             SanityManager
                 .DEBUG_PRINT(
                     GfxdConstants.TRACE_HEAPTHRESH,
@@ -2335,7 +2335,7 @@ public abstract class BaseActivation implements CursorActivation, GeneratedByteC
         
       case BaseActivation.CANCELLED_TIMED_OUT:
         if (SanityManager.DEBUG) {
-          if (GemFireXDUtils.TraceExecute) {
+          if (GemFireXDUtils.TraceExecution) {
             SanityManager.DEBUG_PRINT(
                 GfxdConstants.TRACE_EXECUTION,
                 "BaseActivation: statement "
@@ -2350,7 +2350,7 @@ public abstract class BaseActivation implements CursorActivation, GeneratedByteC
         
       case BaseActivation.CANCELLED_USER_REQUESTED:
         if (SanityManager.DEBUG) {
-          if (GemFireXDUtils.TraceExecute) {
+          if (GemFireXDUtils.TraceExecution) {
             SanityManager.DEBUG_PRINT(
                 GfxdConstants.TRACE_EXECUTION,
                 "BaseActivation: statement "


### PR DESCRIPTION
## Changes proposed in this pull request

Fix for performance issue seen with queries in cluster mode where simple average on ~100M takes >300ms in single server cluster vs ~150ms in local[*] mode.
- added proper getClassLoaderVersion() impls for GemFireActivationClass and SnappyActivationClass
- cache default TimeZone and Locale statically since those showed up in some perf runs (esp from SnappyData side)
- renamed TraceExecute variable to TraceExecution to match the actual name and avoid confusion
## Patch testing

store precheckin
## ReleaseNotes changes

NA
## Other PRs

SnappyData layer will make use of above changes.
