### PR TITLE
[SNAP-1140] Performance issues seen in query re-routing

### DIFF
--- a/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/ClientThread.java
+++ b/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/ClientThread.java
@@ -104,6 +104,7 @@ final class ClientThread extends Thread {
                         else {
                           clientSocket.setKeepAlive(false);
                         }
+                        clientSocket.setTcpNoDelay(true);
                         /* (original code)
                         clientSocket.setKeepAlive(parent.getKeepAlive());
                         */

--- a/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/DRDAStatement.java
+++ b/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/DRDAStatement.java
@@ -891,7 +891,7 @@ class DRDAStatement
 		    }
 		    setStatus("EXECUTING BATCH");
 		    this.statementAccessFrequency++;
-		    this.executionBeginTime = System.currentTimeMillis();
+		    this.executionBeginTime = System.nanoTime();
 		    this.batchResult = this.ps.executeBatch();
 		    hasResultSet = false;
 		  }
@@ -899,7 +899,7 @@ class DRDAStatement
 		    this.batchResult = null;
                     setStatus("EXECUTING PREPAREDSTATEMENT");
                     this.statementAccessFrequency++;
-                    this.executionBeginTime = System.currentTimeMillis();
+                    this.executionBeginTime = System.nanoTime();
 		    hasResultSet = this.ps.execute();
 		    if (!hasResultSet) {
                       setStatus("CHECKING BUCKET HOSTED");
@@ -911,7 +911,7 @@ class DRDAStatement
 		    this.batchResult = null;
 		    s = this.pstmt;
                     setStatus("EXECUTING STATEMENT");
-                    this.executionBeginTime = System.currentTimeMillis();
+                    this.executionBeginTime = System.nanoTime();
 		    hasResultSet = this.pstmt.execute(this.sqlText);
                     if (!hasResultSet) {
                       setStatus("DONE");

--- a/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/NetworkServerControlImpl.java
+++ b/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/NetworkServerControlImpl.java
@@ -4469,8 +4469,8 @@ public final class NetworkServerControlImpl {
           cs.currentStatement = st.toDebugString("");
           cs.currentStatementStatus = st.getStatus();
           if (st.getExecutionBeginTime() > 0) {
-            cs.currentStatementElapsedTime = (System.currentTimeMillis()
-                - st.getExecutionBeginTime()) / 1000;
+            cs.currentStatementElapsedTime = Math.max(System.nanoTime()
+                - st.getExecutionBeginTime(), 0L) / 1000000000.0;
           }
           cs.currentStatementAccessFrequency = st.getAccessFrequency();
           long estimatedUsage = st.getEstimatedMemoryUsage();
@@ -4515,8 +4515,8 @@ public final class NetworkServerControlImpl {
           cs.currentStatement = st.toDebugString("");
           cs.currentStatementStatus = st.getStatus();
           if (st.getExecutionBeginTime() > 0) {
-            cs.currentStatementElapsedTime = (System.currentTimeMillis()
-                - st.getExecutionBeginTime()) / 1000;
+            cs.currentStatementElapsedTime = Math.max(System.nanoTime()
+                - st.getExecutionBeginTime(), 0L) / 1000000000.0;
           }
           long estimatedUsage = st.getEstimatedMemoryUsage();
           if (estimatedUsage > 0) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/SessionsVTI.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/SessionsVTI.java
@@ -165,7 +165,7 @@ public class SessionsVTI extends GfxdVTITemplate {
           CURRENT_STATEMENT_STATUS, Types.VARCHAR, true, 32),
           
       EmbedResultSetMetaData.getResultColumnDescriptor(
-          CURRENT_STATEMENT_ELAPSED_TIME, Types.BIGINT, true),
+          CURRENT_STATEMENT_ELAPSED_TIME, Types.DOUBLE, true),
           
       EmbedResultSetMetaData.getResultColumnDescriptor(
           CURRENT_STATEMENT_ACCESS_FREQUENCY, Types.BIGINT, true),
@@ -331,7 +331,7 @@ public class SessionsVTI extends GfxdVTITemplate {
 
       public String currentStatementStatus;
       
-      public long currentStatementElapsedTime;
+      public double currentStatementElapsedTime;
       
       public long currentStatementAccessFrequency;
       

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericPreparedStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericPreparedStatement.java
@@ -1356,18 +1356,7 @@ recompileOutOfDatePlan:
 			}
 		}
 // GemStone changes BEGIN
-		for (;;) {
-		  final int invalidFlags = this.isInvalid.get();
-		  if ((invalidFlags & IS_INVALID) != 0) {
-		    if (this.isInvalid.compareAndSet(invalidFlags,
-		        invalidFlags & (~IS_INVALID))) {
-		      return;
-		    }
-		  }
-		  else {
-		    return;
-		  }
-		}
+		makeValid();
 		/* (original code)
 		isValid = true;
 
@@ -1375,6 +1364,23 @@ recompileOutOfDatePlan:
 		*/
 // GemStone changes END
 	}
+// GemStone changes BEGIN
+
+  void makeValid() {
+    for (;;) {
+      final int invalidFlags = this.isInvalid.get();
+      if ((invalidFlags & IS_INVALID) != 0) {
+        if (this.isInvalid.compareAndSet(invalidFlags,
+            invalidFlags & (~IS_INVALID))) {
+          return;
+        }
+      }
+      else {
+        return;
+      }
+    }
+  }
+// GemStone changes END
 
 	public GeneratedClass getActivationClass()
 		throws StandardException


### PR DESCRIPTION
## Changes proposed in this pull request
- Re-routed prepared statements are never marked as invalid so they are always re-prepared and multiple times
  in one round (because reprepare gets invoked from multiple places). Mark as valid and also increment version
  counter which is used by DRDA server to invalidate client side descriptors in case it gets re-prepared due
  to a genuine reason.
- Disable nagle's algorithm on the server-side DRDA socket. Otherwise queries returning small results can
  block for quite long time (e.g. ~40ms delay seen for a query returning single row with two columns which
      was tracked down to the nagle's algorithm on server-side socket); client socket already disables it
- Move out pattern matching for INSERT/PUT...SELECT for re-routing to be pre-compiled static. Also changed
  the STREAM pattern to be a regex rather than string match which is buggy. In addition removed the
  toUpperCase() of source which is very inefficient way of matching and instead use CASE_INSENSITIVE regex.
- Changed some instances of System.currentTimeInMillis() with nanoTime() spotted while reviewing code
  which is much more efficient and also much more accurate for measuring intervals. Changed SessionVTI
  interval type to be DOUBLE rather than BIGINT (latter was useless since time is shown in seconds).
## Patch testing

Store precheckin in progress.
## ReleaseNotes changes

NA
## Other PRs

NA
