### PR TITLE
Fixes SNAP-1138

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/load/ImportBase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/load/ImportBase.java
@@ -528,9 +528,11 @@ public class ImportBase extends ImportAbstract{
                   if (err.get() != null) {
                     // try to interrupt as soon as possible
                     th.join(100);
-                    if (th.isAlive()) {
-                      th.interrupt();
-                    }
+                    // Not giving interrupt to all the threads as it can close the oplog file channel
+                    // which can close the region and the network interfaces. See bug SNAP-1138.
+                    // if (th.isAlive()) {
+                      // th.interrupt();
+                    // }
                     th.join(1000);
                     break;
                   }


### PR DESCRIPTION
## Changes proposed in this pull request

Removing the code to interrupt all the threads doing the import. This interrupt was leading to ChannelCloseException/ChannelClose due to Interrupt which was getting wrapped in DiskAccessException which in turn was leading to region close and network interface close. This was probably added to eagerly fail the imports. Right now just removing it. Later the connection calls rollback if error is there. 
## Patch testing

dunit and junit passed.
## ReleaseNotes changes

No.
## Other PRs

No.

Failure in Import causes the system to close region and network interfaces.
