### PR TITLE
[SNAP-1191] Store side changes for plan caching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ allprojects {
     pxfVersion = '2.5.1.0'
     osgiVersion = '6.0.0'
     jettyVersion = '9.2.16.v20160414'
-    hadoopVersion = '2.7.2'
+    hadoopVersion = '2.7.3'
     protobufVersion = '2.6.1'
     sunJerseyVersion = '1.19.1'
     hadoopJettyVersion = '6.1.26'

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/ByteArrayDataInput.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/ByteArrayDataInput.java
@@ -231,6 +231,15 @@ public final class ByteArrayDataInput extends DataInputStreamBase implements
     }
   }
 
+  public final byte peekByte() throws IOException {
+    if (this.pos < this.nBytes) {
+      return this.bytes[this.pos];
+    }
+    else {
+      throw new EOFException();
+    }
+  }
+
   /**
    * {@inheritDoc}
    */

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/ByteArrayDataInput.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/ByteArrayDataInput.java
@@ -231,15 +231,6 @@ public final class ByteArrayDataInput extends DataInputStreamBase implements
     }
   }
 
-  public final byte peekByte() throws IOException {
-    if (this.pos < this.nBytes) {
-      return this.bytes[this.pos];
-    }
-    else {
-      throw new EOFException();
-    }
-  }
-
   /**
    * {@inheritDoc}
    */

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -742,8 +742,10 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     // TODO: with forceFlush, ideally we should merge with an existing
     // CachedBatch if the current size to be flushed is small like < 1000
     // (and split if total size has become too large)
-    final int batchSize = !forceFlush ? GemFireCacheImpl.getColumnBatchSize()
-        : GemFireCacheImpl.getColumnMinBatchSize();
+    final int columnBatchSize = GemFireCacheImpl.getColumnBatchSize();
+    final int batchSize = !forceFlush ? columnBatchSize
+        : Math.min(GemFireCacheImpl.getColumnMinBatchSize(),
+        Math.max(columnBatchSize, 1));
     // we may have to use region.size so that no state
     // has to be maintained
     // one more check for size to make sure that concurrent call doesn't succeed.

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/FinalizeObject.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/FinalizeObject.java
@@ -132,6 +132,8 @@ public abstract class FinalizeObject extends WeakReference<Object> implements
 
   /**
    * The finalizer method for the object for post GC cleanup.
+   * Return false to abort finalization just yet and place in a pending queue
+   * to be retried later.
    */
   protected abstract boolean doFinalize() throws Exception;
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/DistributedConnectionCloseExecutorFunction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/DistributedConnectionCloseExecutorFunction.java
@@ -77,7 +77,7 @@ public final class DistributedConnectionCloseExecutorFunction implements
     //TODO - Check only if the product is Snappy then call the remove connection ref messages
     if (Misc.getMemStore().isSnappyStore()) {
       CallbackFactoryProvider.getClusterCallbacks()
-          .clearSnappyContextForConnection(connId);
+          .clearSnappySessionForConnection(connId);
     }
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdHeapDataOutputStream.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdHeapDataOutputStream.java
@@ -70,7 +70,8 @@ public final class GfxdHeapDataOutputStream extends HeapDataOutputStream
   public final void write(byte[] source, int offset, int len) {
     // if there is enough space in current byte buffer, then use that instead
     // of always wrapping to avoid one additional allocation
-    if (this.wrapBytes && this.buffer.remaining() < len) {
+    if (this.wrapBytes &&
+        this.buffer.position() > 0 && this.buffer.remaining() < len) {
       this.writeWithByteArrayWrappedConditionally(source, offset, len);
     }
     else {
@@ -78,8 +79,20 @@ public final class GfxdHeapDataOutputStream extends HeapDataOutputStream
     }
   }
 
-  public final void writeNoWrap(byte[] source, int offset, int len) {
-    super.write(source, offset, len);
+  /**
+   * Write a byte buffer to this HeapDataOutputStream,
+   *
+   * The contents of the buffer between the position and the limit
+   * are copied to the output stream or the buffer kept as is (if wrapBytes
+   *   has been passed as true in constructor).
+   */
+  @Override
+  public final void write(ByteBuffer source) {
+    if (this.wrapBytes) {
+      this.writeWithByteBufferWrappedConditionally(source);
+    } else {
+      super.write(source);
+    }
   }
 
   public final void copyMemory(final Object src, long srcOffset, int length) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdHeapDataOutputStream.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdHeapDataOutputStream.java
@@ -129,10 +129,4 @@ public final class GfxdHeapDataOutputStream extends HeapDataOutputStream
     Misc.checkMemoryRuntime(thresholdListener, query, amount);
     super.expand(amount);
   }
-
-  public final byte[] toByteArrayCopy() {
-    final byte[] bytes = new byte[size()];
-    sendTo(bytes, 0);
-    return bytes;
-  }
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
@@ -83,6 +83,10 @@ public final class SnappyResultHolder extends GfxdDataSerializable {
     this.hasMetadata = true;
   }
 
+  public boolean hasMetadata() {
+    return this.hasMetadata;
+  }
+
   @Override
   public void toData(final DataOutput out) throws IOException {
     this.exec.serializeRows(out, this.hasMetadata);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
@@ -45,7 +45,7 @@ public final class SnappyResultHolder extends GfxdDataSerializable {
 
   private transient SparkSQLExecute exec;
 
-  private transient ByteArrayDataInput dis;
+  private transient volatile ByteArrayDataInput dis;
   private transient volatile String[] colNames;
   private transient volatile String[] tableNames;
   private transient volatile boolean[] nullability;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/SnappyResultHolder.java
@@ -85,6 +85,10 @@ public final class SnappyResultHolder extends GfxdDataSerializable {
     this.hasMetadata = true;
   }
 
+  public void clearHasMetadata() {
+    this.hasMetadata = false;
+  }
+
   public boolean hasMetadata() {
     return this.hasMetadata;
   }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/SnappySelectResultSet.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/SnappySelectResultSet.java
@@ -187,7 +187,6 @@ public final class SnappySelectResultSet
   }
 
   public ExecRow getNextRow() throws StandardException {
-    // TO IMPLEMENT
     try {
       nextExecRow();
       this.setCurrentRow(this.currentRow);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorFunction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorFunction.java
@@ -41,7 +41,6 @@ import com.gemstone.gemfire.management.internal.SystemManagementService;
 import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.store.GemFireContainer;
 import com.pivotal.gemfirexd.tools.sizer.GemFireXDInstrumentation;
-import com.sun.org.apache.xpath.internal.operations.Bool;
 
 public class SnappyRegionStatsCollectorFunction implements Function, Declarable {
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/CallbackFactoryProvider.java
@@ -17,12 +17,14 @@
 
 package com.pivotal.gemfirexd.internal.snappy;
 
+import java.util.HashSet;
+import java.util.Iterator;
+
+import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
 import com.gemstone.gemfire.internal.ByteArrayDataInput;
 import com.gemstone.gemfire.internal.shared.Version;
-import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
 import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor;
-
-import java.util.HashSet;
+import com.pivotal.gemfirexd.internal.impl.sql.execute.ValueRow;
 
 /**
  * This class should be used to hold the callback factories that are used to communicate
@@ -54,12 +56,13 @@ public abstract class CallbackFactoryProvider {
     }
 
     @Override
-    public void readDVDArray(DataValueDescriptor[] dvds, int[] types,
-        ByteArrayDataInput in, int numEightColGroups, int numPartialCols) {
+    public Iterator<ValueRow> getRowIterator(DataValueDescriptor[] dvds,
+        int[] types, int[] precisions, int[] scales, ByteArrayDataInput in) {
+      return null;
     }
 
     @Override
-    public void clearSnappyContextForConnection(Long connectionId) {
+    public void clearSnappySessionForConnection(Long connectionId) {
 
     }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/CallbackFactoryProvider.java
@@ -56,8 +56,14 @@ public abstract class CallbackFactoryProvider {
     }
 
     @Override
+    public Object readDataType(ByteArrayDataInput in) {
+      return null;
+    }
+
+    @Override
     public Iterator<ValueRow> getRowIterator(DataValueDescriptor[] dvds,
-        int[] types, int[] precisions, int[] scales, ByteArrayDataInput in) {
+        int[] types, int[] precisions, int[] scales, Object[] dataTypes,
+        ByteArrayDataInput in) {
       return null;
     }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/ClusterCallbacks.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/ClusterCallbacks.java
@@ -41,11 +41,13 @@ public interface ClusterCallbacks {
 
   SparkSQLExecute getSQLExecute(String sql, String schema, LeadNodeExecutionContext ctx, Version v);
 
+  Object readDataType(ByteArrayDataInput in);
+
   /**
    * Deserialize/decompress the SnappyResultHolder data and get an iterator.
    */
   Iterator<ValueRow> getRowIterator(DataValueDescriptor[] dvds, int[] types,
-      int[] precisions, int[] scales, ByteArrayDataInput in);
+      int[] precisions, int[] scales, Object[] dataTypes, ByteArrayDataInput in);
 
   void clearSnappySessionForConnection(Long connectionId);
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/ClusterCallbacks.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/ClusterCallbacks.java
@@ -17,12 +17,14 @@
 
 package com.pivotal.gemfirexd.internal.snappy;
 
+import java.util.HashSet;
+import java.util.Iterator;
+
+import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
 import com.gemstone.gemfire.internal.ByteArrayDataInput;
 import com.gemstone.gemfire.internal.shared.Version;
-import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
 import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor;
-
-import java.util.HashSet;
+import com.pivotal.gemfirexd.internal.impl.sql.execute.ValueRow;
 
 /**
  * Callbacks that are required for cluster management of Snappy should go here.
@@ -40,13 +42,12 @@ public interface ClusterCallbacks {
   SparkSQLExecute getSQLExecute(String sql, String schema, LeadNodeExecutionContext ctx, Version v);
 
   /**
-   * Deserialize the SnappyResultHolder object per batch.
+   * Deserialize/decompress the SnappyResultHolder data and get an iterator.
    */
-  void readDVDArray(DataValueDescriptor[] dvds, int[] types,
-      ByteArrayDataInput in, int numEightColGroups, int numPartialCols);
+  Iterator<ValueRow> getRowIterator(DataValueDescriptor[] dvds, int[] types,
+      int[] precisions, int[] scales, ByteArrayDataInput in);
 
-  void clearSnappyContextForConnection(Long connectionId);
-
+  void clearSnappySessionForConnection(Long connectionId);
 
   void publishColumnTableStats();
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/SparkSQLExecute.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/SparkSQLExecute.java
@@ -32,5 +32,5 @@ public interface SparkSQLExecute {
   /**
    * Called at the lowest level to serialize the SnappyResultHolder object per batch.
    */
-  void serializeRows(DataOutput out);
+  void serializeRows(DataOutput out, boolean hasMetadata);
 }


### PR DESCRIPTION
## Changes proposed in this pull request

- GfxdProfile addition of number of processors with backward compatibility (for customers using row store)
- Pass through DataType object (Spark DataType) for complex types now required for deserialization of compressed bytes and JSON formatting
- Optimized version of HeapDataOutputStream.writeWithByteBufferWrappedConditionally that takes a ByteBuffer similar to existing one that takes a byte array

## Patch testing

precheckin

## ReleaseNotes changes

NA

## Other PRs 

snappydata PR for SNAP-1191