### PR TITLE
[SNAP-1188] Fix for SNAP-1188 to set batch uuid to previous record if…

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -678,6 +678,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
       }
       setBatchUUID(event);
     }
+    boolean success = false;
     try {
       if (this.partitionedRegion.isLocalParallelWanEnabled()) {
         handleWANEvent(event);
@@ -691,6 +692,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
 //          getCache().getLoggerI18n().info(LocalizedStrings.DEBUG,
 //              "BR.virtualPut: oldEntry returned = " + oldEntry + " so basic put returned: " + (oldEntry != null));
 //        }
+        success = true;
         return oldEntry != null;
       }
       if (event.getDeltaBytes() != null && event.getRawNewValue() == null) {
@@ -710,12 +712,13 @@ public class BucketRegion extends DistributedRegion implements Bucket {
             "BR.virtualPut: this cache has already seen this event " + event);
       }
       distributeUpdateOperation(event, lastModified);
+      success = true;
       return true;
     } finally {
       if (locked) {
         endLocalWrite(event);
         //create and insert cached batch
-        if (getPartitionedRegion().needsBatching()
+        if (success && getPartitionedRegion().needsBatching()
             && this.size() >= GemFireCacheImpl.getColumnBatchSize()) {
           createAndInsertCachedBatch(false);
         }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RemotePutAllMessage.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RemotePutAllMessage.java
@@ -352,7 +352,10 @@ public final class RemotePutAllMessage extends
         VersionTag<?> tag = putAllData[i].versionTag;
         versionTags.add(tag);
         putAllData[i].versionTag = null;
-        this.putAllData[i].toData(out, requiresRegionContext);
+        // Part of hackish fix for SNAP-1188. Null is ok here because
+        // gemfire client server mechanism does not come in play in
+        // snappydata column tables.
+        this.putAllData[i].toData(out, requiresRegionContext, null);
         this.putAllData[i].versionTag = tag;
       }
 


### PR DESCRIPTION
## Changes proposed in this pull request
 * Fix for SNAP-1188.This issue was caused because data serializer was getting batchuuid as null. 

## Patch testing
* Manually tested as well as executed unit test multiple time as this is caused intermitently
* Also ran precheckin and all test passed

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?) No

## Other PRs 


… the current batchuuid is null