### PR TITLE
[SNAP-1199] Fix for SNAP-1199.ServerGroupUtils.isGroupMember should r…

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -507,6 +507,12 @@ public final class FabricDatabase implements ModuleControl,
       }
 
       // Initialize the catalog
+      // Lead is always started with ServerGroup hence for lead LeadGroup will never be null.
+      /**
+       * In LeadImpl server group is always  set to using following code:
+       * changeOrAppend(Constant * .STORE_PROPERTY_PREFIX +com.pivotal.gemfirexd.Attribute.
+       * SERVER_GROUPS, LeadImpl.LEADER_SERVERGROUP)
+       */
       HashSet<String> leadGroup = CallbackFactoryProvider.getClusterCallbacks().getLeaderGroup();
       final boolean isLead = this.memStore.isSnappyStore() && (leadGroup != null && leadGroup
           .size() > 0) && (ServerGroupUtils.isGroupMember(leadGroup)

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -507,8 +507,9 @@ public final class FabricDatabase implements ModuleControl,
       }
 
       // Initialize the catalog
-      final boolean isLead = this.memStore.isSnappyStore() && (ServerGroupUtils.isGroupMember(
-          CallbackFactoryProvider.getClusterCallbacks().getLeaderGroup())
+      HashSet<String> leadGroup = CallbackFactoryProvider.getClusterCallbacks().getLeaderGroup();
+      final boolean isLead = this.memStore.isSnappyStore() && (leadGroup != null && leadGroup
+          .size() > 0) && (ServerGroupUtils.isGroupMember(leadGroup)
           || Misc.getDistributedSystem().isLoner());
       Set<?> servers = GemFireXDUtils.getGfxdAdvisor().adviseDataStores(null);
       if (this.memStore.isSnappyStore() && (this.memStore.getMyVMKind() ==

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
@@ -255,4 +255,9 @@ public final class LeadNodeExecutorMsg extends MemberExecutorMessage<Object> {
     DataSerializer.writeString(this.schema , out);
     DataSerializer.writeObject(ctx, out);
   }
+
+  public void appendFields(final StringBuilder sb) {
+    sb.append("sql: "+sql);
+    sb.append("schema: "+schema);
+  }
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
@@ -257,7 +257,7 @@ public final class LeadNodeExecutorMsg extends MemberExecutorMessage<Object> {
   }
 
   public void appendFields(final StringBuilder sb) {
-    sb.append("sql: "+sql);
-    sb.append("schema: "+schema);
+    sb.append("sql: " + sql);
+    sb.append("schema: " + schema);
   }
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/ServerGroupUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/ServerGroupUtils.java
@@ -110,7 +110,7 @@ public final class ServerGroupUtils {
   /** return true if this VM is member of one of the given groups */
   public static boolean isGroupMember(Set<String> groups) {
     if (groups == null || groups.size() == 0) {
-      return false;
+      return true;
     }
     return isGroupMember(Misc.getMemStoreBooting().getAdvisee()
         .getServerGroups(), groups);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/ServerGroupUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/ServerGroupUtils.java
@@ -110,7 +110,7 @@ public final class ServerGroupUtils {
   /** return true if this VM is member of one of the given groups */
   public static boolean isGroupMember(Set<String> groups) {
     if (groups == null || groups.size() == 0) {
-      return true;
+      return false;
     }
     return isGroupMember(Misc.getMemStoreBooting().getAdvisee()
         .getServerGroups(), groups);


### PR DESCRIPTION
## Changes proposed in this pull request
* Fix for SNAP-1199 .
* The actual issue with this bug was in catalog cleanup we are checking if the current member is lead and if it is then cleanup code kicks in.This method was returning true even in the split mode and was cleaning up the catalog if inconsistency is observed,which was causing external table to be removed from catalog.

## Patch testing
Tested manually

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?) No

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change) 

…eturn false if groups is null