### PR TITLE
Fix for SNAP-1228

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
@@ -335,9 +335,11 @@ public class GenericStatement
 		boolean foundInCache = false;
 		if (preparedStmt == null)
 		{
-			if (cacheMe)
-				preparedStmt = (GenericPreparedStatement)((GenericLanguageConnectionContext)lcc).lookupStatement(this);
-
+                        boolean isRemoteDDLAndSnappyStore = lcc.isConnectionForRemoteDDL() && !routeQuery;
+                        if (cacheMe && !isRemoteDDLAndSnappyStore) {
+                                preparedStmt = (GenericPreparedStatement)((GenericLanguageConnectionContext)lcc).lookupStatement(this);
+                        }
+      
 			if (preparedStmt == null)
 			{
 				preparedStmt = new GenericPreparedStatement(this);


### PR DESCRIPTION
## Changes proposed in this pull request
Drop table command hangs if executed on JDBC connection if the exact same command if fired twice.

In the first execution, the drop DDL is routed to lead node, executed successfully and table is dropped. When the exact same command is fired again, then the query is routed to lead and from there sent to server. On the serevr, in GenericStatement#prepMinion a cached preparedStmt picked. The cached preparedStmt is for the first execution and consists of SnappyActivation because of which it again get routed leading to a hang/deadlock.

When the drop DDL reaches a server from lead node it should not pick this cached preparedStmt if drop DDL was a routed statement to lead.

As a fix not picking up cached statement routeQuery is false (that is query is sent from lead to server) and query is a DDL statement.

## Patch testing
Run the JDBCExample.scala multiple times to repro
running precheckin

(Fill in the details about how this patch was tested)

## ReleaseNotes changes



## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)

