### PR TITLE
MaxNewSize being set as a very low number 

### DIFF
--- a/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/internal/GfxdServerLauncher.java
+++ b/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/internal/GfxdServerLauncher.java
@@ -699,6 +699,7 @@ public class GfxdServerLauncher extends CacheServerLauncher {
         vmArgs.add("-XX:+UseConcMarkSweepGC");
         vmArgs.add("-XX:CMSInitiatingOccupancyFraction=50");
         vmArgs.add("-XX:+CMSClassUnloadingEnabled");
+        vmArgs.add("-XX:NewRatio=3");
       }
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request

During testing we observed that the MaxNewSize i.e. par new size was set as very less as compared to old gen size. As an example, oldgen size was set as 91GB while the par new size was set as 1.5 GB.

Actually when UseConcMarkSweepGC property is set, jdk sets the new size as a very low number. It has been discussed in the following open jdk issue.

https://bugs.openjdk.java.net/browse/JDK-8153578

We need the new gen size to be on the higher side as there are too many temporary objects being created. Setting it as a 1/4 of the JVM size for now.