### PR TITLE
Fix for SNAP-1308 by adding the NUMROWS of the cachedbatch every time…

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionStats.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionStats.java
@@ -1238,6 +1238,10 @@ type, name /* fixes bug 42343 */);
     this.stats.incLong(prNumRowsInCachedBatches, inc);
   }
 
+  public void setPRNumRowsInCachedBatches(int value){
+    this.stats.setLong(prNumRowsInCachedBatches, value);
+  }
+
   public long getPRNumRowsInCachedBatches() {
     return this.stats.getLong(prNumRowsInCachedBatches);
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionStats.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionStats.java
@@ -1233,12 +1233,7 @@ type, name /* fixes bug 42343 */);
     return this.stats.getLong(prMetaDataSentCountId);
   }
 
-
-  public void incPRNumRowsInCachedBatches(int inc){
-    this.stats.incLong(prNumRowsInCachedBatches, inc);
-  }
-
-  public void setPRNumRowsInCachedBatches(int value){
+  public void setPRNumRowsInCachedBatches(long value) {
     this.stats.setLong(prNumRowsInCachedBatches, value);
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorFunction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorFunction.java
@@ -55,6 +55,9 @@ public class SnappyRegionStatsCollectorFunction implements Function, Declarable 
 
   @Override
   public void execute(FunctionContext context) {
+
+    com.pivotal.gemfirexd.internal.snappy.CallbackFactoryProvider.getClusterCallbacks().
+        publishColumnTableStats();
     SnappyRegionStatsCollectorResult result = new SnappyRegionStatsCollectorResult();
     Map<String, SnappyRegionStats> cachBatchStats = new HashMap<>();
     ArrayList<SnappyRegionStats> otherStats = new ArrayList<>();


### PR DESCRIPTION
## Changes proposed in this pull request
* SNAP-1308 by aggregating the NUMROWS of the cachedbatch every time instead of reading it from bean class

## Patch testing
Written and executed Dunit test

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
