### PR TITLE
SNAP-1306: enabling DBVisualizer to connect to SnappyData using its 0.7 client jar.

### DIFF
--- a/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/am/Cursor.java
+++ b/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/am/Cursor.java
@@ -1618,7 +1618,7 @@ public abstract class Cursor {
         switch (jdbcTypes_[column - 1]) {
         case java.sql.Types.SMALLINT:
 // GemStone changes BEGIN
-            return get_SMALLINT(column); // See Table 4 in JDBC 1 spec (pg. 932 in jdbc book)
+            return (int)get_SMALLINT(column); // See Table 4 in JDBC 1 spec (pg. 932 in jdbc book)
         case java.sql.Types.INTEGER:
             return get_INTEGER(column);
         case java.sql.Types.BIGINT:

--- a/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/am/PreparedStatement.java
+++ b/gemfirexd/client/src/main/java/com/pivotal/gemfirexd/internal/client/am/PreparedStatement.java
@@ -751,8 +751,7 @@ public class PreparedStatement extends Statement
                 
                 parameterMetaData_.clientParamtertype_[parameterIndex - 1] = java.sql.Types.TINYINT;
 // GemStone changes BEGIN
-                // changed to use Short.valueOf() if possible
-                setInput(parameterIndex, x);
+                setInput(parameterIndex, (short)x);
                 /* (original code)
                 setInput(parameterIndex, new Short(x));
                 */
@@ -798,7 +797,6 @@ public class PreparedStatement extends Statement
     void setShortX(int parameterIndex, short x) throws SqlException {
         parameterMetaData_.clientParamtertype_[parameterIndex - 1] = java.sql.Types.SMALLINT;
 // GemStone changes BEGIN
-        // changed to use Short.valueOf() if possible
         setInput(parameterIndex, x);
         /* (original code)
         setInput(parameterIndex, new Short(x));
@@ -838,7 +836,6 @@ public class PreparedStatement extends Statement
     void setIntX(int parameterIndex, int x) throws SqlException {
         parameterMetaData_.clientParamtertype_[parameterIndex - 1] = java.sql.Types.INTEGER;
 // GemStone changes BEGIN
-        // changed to use Integer.valueOf() if possible
         setInput(parameterIndex, x);
         /* (original code)
         setInput(parameterIndex, new Integer(x));
@@ -879,7 +876,6 @@ public class PreparedStatement extends Statement
         parameterMetaData_.clientParamtertype_[parameterIndex - 1] 
                 = java.sql.Types.BIGINT;
 // GemStone changes BEGIN
-        // changed to use valueOf() if possible
         setInput(parameterIndex, x);
         /* (original code)
         setInput(parameterIndex, new Long(x));


### PR DESCRIPTION
## Changes proposed in this pull request
Fix from Sumedh for SNAP-1306, enabling DBVisualizer to connect to SnappyData using its 0.7 client jar.

## Patch testing
precheckin is clean

## ReleaseNotes changes
NA

## Other PRs 
NA