### PR TITLE
SNAP-1243 : Multiple Lead entries for same Lead Member with different status.

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskInitFile.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskInitFile.java
@@ -2428,7 +2428,10 @@ public class DiskInitFile implements DiskInitFileInterpreter {
       } catch (IOException ignore) {
       }
       if (this.liveRegions == 0 && !parent.isValidating()) {
-        basicDestroy();
+        GemFireCacheImpl.StaticSystemCallbacks ssc = this.parent.getCache().getInternalProductCallbacks();
+        if (ssc != null && !ssc.isAccessor()) {
+          basicDestroy();
+        }
       }
     } finally {
       lock.unlock();

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -5268,6 +5268,9 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
     /** If this node is booted as a SnappyStore node */
     public boolean isSnappyStore();
 
+    /** If this node is booted as a Accessor node */
+    public boolean isAccessor();
+
     /**
      * If this node has been booted as one that can perform operations as an
      * accessor or datastore (i.e. non-admin-only, non-agent-only,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -77,6 +77,7 @@ import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import com.gemstone.gemfire.internal.shared.ClientSharedUtils;
 import com.gemstone.gemfire.internal.shared.FinalizeObject;
 import com.gemstone.gemfire.internal.shared.StringPrintWriter;
+import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
 import com.gemstone.gnu.trove.THashMap;
 import com.gemstone.gnu.trove.TLongHashSet;
 import com.pivotal.gemfirexd.Attribute;
@@ -1451,8 +1452,10 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
       // when DD is not being persisted then we no longer allow regions with
       // persistence to be created; however, if "sys-disk-dir" is explicitly
       // set then that can be used for overflow/gateway
-      
-      if (this.persistingDD || this.persistenceDir != null) {
+
+      StoreCallbacks callback = com.gemstone.gemfire.internal.snappy.CallbackFactoryProvider.getStoreCallbacks();
+
+      if (this.persistingDD || this.persistenceDir != null || (this.myKind.isAccessor() && callback != null)) {
         try {
           DiskStoreFactory dsf = this.gemFireCache.createDiskStoreFactory();
           File file = new File(generatePersistentDirName(null))

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
@@ -1520,6 +1520,12 @@ public final class RegionEntryUtils {
     }
 
     @Override
+    public boolean isAccessor() {
+      GemFireStore.VMKind myVMKind = GemFireXDUtils.getMyVMKind();
+      return myVMKind != null && myVMKind.isAccessor();
+    }
+
+    @Override
     public boolean isOperationNode() {
       GemFireStore.VMKind myVMKind = GemFireXDUtils.getMyVMKind();
       return myVMKind != null && myVMKind.isAccessorOrStore();


### PR DESCRIPTION


## Changes proposed in this pull request

Fixes:
 - Creating Disk Store even if node is accessor (i.e lead ) in order to identify the lead restarted is same using unique DiskStoreUUID.
 - Do not delete IF file from lead node directory even if Live Regions count is zero.
 - Adding isAccessor method in StaticSystemCallbacks.

## Patch testing

 - Tested Manually.
 - Ran pre-checkin locally
