### PR TITLE
Fix for snap-1297

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/PrepStatementSnappyActivation.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/PrepStatementSnappyActivation.java
@@ -89,9 +89,7 @@ public class PrepStatementSnappyActivation extends GemFireSelectDistributionActi
 
   @Override
   public ResultDescription getResultDescription() {
-    if (this.resultDescription == null) {
-      this.resultDescription = SnappyActivation.makeResultDescription(this.resultSet);
-    }
+    this.resultDescription = SnappyActivation.makeResultDescription(this.resultSet);
     return this.resultDescription;
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedPreparedStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedPreparedStatement.java
@@ -1328,33 +1328,35 @@ public abstract class EmbedPreparedStatement
 					// Gemstone changes END
 					gcDuringGetMetaData = execp.getActivationClass().getName();
 				}
-				Activation a = null;
-				if (this.getActivation() != null) {
-					if (this.getActivation() instanceof GenericActivationHolder) {
-						a = ((GenericActivationHolder)this.getActivation()).getActivation();
-					} else if (this.getActivation() instanceof Activation) {
-						a = this.getActivation();
-					}
-				}
-
-				if (rMetaData == null && !(a instanceof SnappyActivation || a instanceof PrepStatementSnappyActivation))
+				if (rMetaData == null)
 				{
-					ResultDescription resd = preparedStatement.getResultDescription();
-					if (resd != null)
-					{
-						// Internally, the result description has information
-						// which is used for insert, update and delete statements
-						// Externally, we decided that statements which don't
-						// produce result sets such as insert, update and delete
-						// should not return ResultSetMetaData.  This is enforced
-						// here
-						String statementType = resd.getStatementType();
-						if (statementType.equals("INSERT") ||
-								statementType.equals("UPDATE") ||
-								statementType.equals("DELETE"))
-							rMetaData = null;
-						else
-				    		rMetaData = newEmbedResultSetMetaData(resd);
+					Activation act = null;
+					if (this.getActivation() != null) {
+						if (this.getActivation() instanceof GenericActivationHolder) {
+							act = ((GenericActivationHolder)this.getActivation()).getActivation();
+						} else if (this.getActivation() instanceof Activation) {
+							act = this.getActivation();
+						}
+					}
+					if (act instanceof PrepStatementSnappyActivation || act instanceof  SnappyActivation) {
+						rMetaData = null;
+					} else {
+						ResultDescription resd = preparedStatement.getResultDescription();
+						if (resd != null) {
+							// Internally, the result description has information
+							// which is used for insert, update and delete statements
+							// Externally, we decided that statements which don't
+							// produce result sets such as insert, update and delete
+							// should not return ResultSetMetaData.  This is enforced
+							// here
+							String statementType = resd.getStatementType();
+							if (statementType.equals("INSERT") ||
+									statementType.equals("UPDATE") ||
+									statementType.equals("DELETE"))
+								rMetaData = null;
+							else
+								rMetaData = newEmbedResultSetMetaData(resd);
+						}
 					}
 				}
 			} catch (Throwable t) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedPreparedStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedPreparedStatement.java
@@ -70,6 +70,8 @@ import com.pivotal.gemfirexd.internal.engine.GemFireXDQueryObserver;
 import com.pivotal.gemfirexd.internal.engine.GemFireXDQueryObserverHolder;
 import com.pivotal.gemfirexd.internal.engine.access.GemFireTransaction;
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
+import com.pivotal.gemfirexd.internal.engine.sql.execute.PrepStatementSnappyActivation;
+import com.pivotal.gemfirexd.internal.engine.sql.execute.SnappyActivation;
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
 import com.pivotal.gemfirexd.internal.iapi.jdbc.BrokeredConnectionControl;
 import com.pivotal.gemfirexd.internal.iapi.jdbc.EngineParameterMetaData;
@@ -88,6 +90,7 @@ import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor;
 import com.pivotal.gemfirexd.internal.iapi.types.RawToBinaryFormatStream;
 import com.pivotal.gemfirexd.internal.iapi.types.ReaderToUTF8Stream;
 import com.pivotal.gemfirexd.internal.iapi.types.VariableSizeDataValue;
+import com.pivotal.gemfirexd.internal.impl.sql.GenericActivationHolder;
 import com.pivotal.gemfirexd.internal.impl.sql.GenericPreparedStatement;
 import com.pivotal.gemfirexd.internal.impl.sql.GenericStatement;
 import com.pivotal.gemfirexd.internal.shared.common.SingleHopInformation;
@@ -1325,7 +1328,16 @@ public abstract class EmbedPreparedStatement
 					// Gemstone changes END
 					gcDuringGetMetaData = execp.getActivationClass().getName();
 				}
-				if (rMetaData == null)
+				Activation a = null;
+				if (this.getActivation() != null) {
+					if (this.getActivation() instanceof GenericActivationHolder) {
+						a = ((GenericActivationHolder)this.getActivation()).getActivation();
+					} else if (this.getActivation() instanceof Activation) {
+						a = this.getActivation();
+					}
+				}
+
+				if (rMetaData == null && !(a instanceof SnappyActivation || a instanceof PrepStatementSnappyActivation))
 				{
 					ResultDescription resd = preparedStatement.getResultDescription();
 					if (resd != null)


### PR DESCRIPTION
## Changes proposed in this pull request
In case of prepared statements for routed queries, sending result set metadata after execution as it is not available during prepare time as seen in TPCH query 10 (reported in snap-1297). For simple query on one column table, metadata at prepare time is available but also contained internal columns (such as rowid). 

Now sending metadata from result set only (instead of from prepared statement) for routed queries.

PrepStatementSnappyActivation#getResultDescription used to send metadata from PS (variable resultDescription initialized in BaseActivation#setupActivation). Now the method is changed to send it always from the ResultSet. 

One more issue seen is that schemaname is not available in ResultSetMetaData(ResultSetMetaData.getSchemaName(columnNumber)). Need to file a separate bug for it. (Before the fix for this issue, it used to return schema name if  metadata is available at prepare time)

## Patch testing
Added tests in QueryRoutingDUnitTest. Also test reported in bug in TPCHDUnitTest.
Refer to PR https://github.com/SnappyDataInc/snappydata/pull/493 for tests.

Running precheckin.


## ReleaseNotes changes


## Other PRs 
