### PR TITLE
SNAP-1318 : Default disk store size on lead should be reduced from 1GB to say 1MB so that lead does not gobble up disk.

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
@@ -1170,6 +1170,13 @@ public final class Oplog implements CompactableOplog {
   }
   
   private void preblow(OplogFile olf, long maxSize) throws IOException {
+    GemFireCacheImpl.StaticSystemCallbacks ssc = GemFireCacheImpl.getInternalProductCallbacks();
+    if (ssc != null && ssc.isSnappyStore() && ssc.isAccessor()
+        && this.getParent().getName().equals(GemFireCacheImpl.getDefaultDiskStoreName())) {
+      logger.warning(LocalizedStrings.SHOULDNT_INVOKE, "Pre blow is invoked on Accessor Node.");
+      return;
+    }
+
 //     logger.info(LocalizedStrings.DEBUG, "DEBUG preblow(" + maxSize + ")  dirAvailSpace=" + this.dirHolder.getAvailableSpace());
     long availableSpace = this.dirHolder.getAvailableSpace();
     if (availableSpace >= maxSize) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -1473,7 +1473,11 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
               dsf.setMaxOplogSize(DiskStoreFactory.DEFAULT_MAX_OPLOG_SIZE);
             }
             else {
-              dsf.setMaxOplogSize(10);
+              if (this.myKind.isAccessor()) {
+                dsf.setMaxOplogSize(1);
+              } else {
+                dsf.setMaxOplogSize(10);
+              }
             }
           }
           dsf.setDiskDirs(new File[] { file });


### PR DESCRIPTION
## Changes proposed in this pull request

Fixes:
  - Default disk store size on lead is reduced to 1MB.
  - Skip preblow itself if type is accessor and the diskstore is default.

## Patch testing

  - Tested Manually.
  - Ran prechekin
