### PR TITLE
Executorcatalog

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -719,7 +719,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
         endLocalWrite(event);
         //create and insert cached batch
         if (success && getPartitionedRegion().needsBatching()
-            && this.size() >= GemFireCacheImpl.getColumnBatchSize()) {
+            && this.size() >= this.getPartitionedRegion().getColumnBatchSize()) {
           createAndInsertCachedBatch(false);
         }
       }
@@ -745,9 +745,9 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     // TODO: with forceFlush, ideally we should merge with an existing
     // CachedBatch if the current size to be flushed is small like < 1000
     // (and split if total size has become too large)
-    final int columnBatchSize = GemFireCacheImpl.getColumnBatchSize();
+    final int columnBatchSize = this.getPartitionedRegion().getColumnBatchSize();
     final int batchSize = !forceFlush ? columnBatchSize
-        : Math.min(GemFireCacheImpl.getColumnMinBatchSize(),
+        : Math.min(this.getPartitionedRegion().getColumnMinBatchSize(),
         Math.max(columnBatchSize, 1));
     // we may have to use region.size so that no state
     // has to be maintained
@@ -782,7 +782,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
       UUID batchUUIDToUse = null;
       if (event.getPutAllOperation() != null) { //isPutAll op
         batchUUIDToUse = generateAndSetBatchIDIfNULL(resetBatchId);
-      } else if (this.size() >= GemFireCacheImpl.getColumnBatchSize()) {// loose check on size..not very strict
+      } else if (this.size() >= this.getPartitionedRegion().getColumnBatchSize()) {// loose check on size..not very strict
         batchUUIDToUse = generateAndSetBatchIDIfNULL(resetBatchId);
         if (getCache().getLoggerI18n().fineEnabled()) {
           getCache()

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ExternalTableMetaData.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ExternalTableMetaData.java
@@ -14,7 +14,7 @@
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
-package com.pivotal.gemfirexd.internal.catalog;
+package com.gemstone.gemfire.internal.cache;
 
 
 public class ExternalTableMetaData {
@@ -22,7 +22,7 @@ public class ExternalTableMetaData {
   public ExternalTableMetaData(String entityName,
       Object schema,
       Object externalStore,
-      long cachedBatchSize,
+      int cachedBatchSize,
       Boolean useCompression,
       String baseTable,
       String dml,
@@ -41,7 +41,7 @@ public class ExternalTableMetaData {
   public Object schema;
   // No type specified as the class is in snappy core
   public Object externalStore;
-  public long cachedBatchSize;
+  public int cachedBatchSize;
   public boolean useCompression;
   public String baseTable;
   public String dml;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -553,12 +553,6 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   // Indicates whether foreign key checks for events received on WAN gateways should be skipped when applying them 
   private boolean skipFKChecksForGatewayEvents = false;
 
-  /** Default size for CachedBatches. */
-  private static int COLUMN_BATCH_SIZE = 10000;
-
-  /** Minimum size for CachedBatches. */
-  private static int COLUMN_MIN_BATCH_SIZE = 200;
-
   /** {@link PropertyResolver} to resolve ${} type property strings */
   protected static PropertyResolver resolver;
 
@@ -5619,6 +5613,11 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
      * Returns authentication properties required during reconnect.
      */
     public Properties getSecurityPropertiesForReconnect();
+
+    /**
+     * Fetches hive meta data for Snappy tables.
+     */
+    public ExternalTableMetaData fetchSnappyTablesHiveMetaData(PartitionedRegion region);
   }
 
   /**
@@ -5931,19 +5930,6 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   
   public boolean skipFKChecksForGatewayEvents() {
     return skipFKChecksForGatewayEvents;
-  }
-
-  public static void setColumnBatchSizes(int size, int minSize) {
-    COLUMN_BATCH_SIZE = size;
-    COLUMN_MIN_BATCH_SIZE = minSize < size ? minSize : size;
-  }
-
-  public static int getColumnBatchSize() {
-    return COLUMN_BATCH_SIZE;
-  }
-
-  public static int getColumnMinBatchSize() {
-    return COLUMN_MIN_BATCH_SIZE;
   }
 
   public final boolean isHadoopGfxdLonerMode() {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -494,8 +494,6 @@ public class LocalRegion extends AbstractRegion
 
   final private boolean isUsedForIndex;
 
-  private boolean isUsedForUserReplicatedTable;
-
   final private SerialGatewaySenderImpl serialGatewaySender;
 
   protected volatile boolean hasLocalSerialAEQorWAN;
@@ -2931,14 +2929,6 @@ public class LocalRegion extends AbstractRegion
   {
     checkReadiness();
     this.regionUserAttribute = value;
-  }
-
-  public final boolean isUsedForUserReplicatedTable() {
-    return this.isUsedForUserReplicatedTable;
-  }
-
-  public final void setIsUsedForUserReplicatedTable(boolean flag) {
-    this.isUsedForUserReplicatedTable = flag;
   }
 
   public final boolean containsKey(Object key) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
@@ -408,7 +408,6 @@ public class PartitionedRegion extends LocalRegion implements
 
   private volatile int shutDownAllStatus = RUNNING_MODE;
 
-  final public static int COLUMN_BATCH_SIZE_DEFAULT = 10000;
   /** Default size for CachedBatches. */
   private int columnBatchSize = -1;
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
@@ -52,42 +52,7 @@ import java.util.concurrent.locks.Lock;
 import com.gemstone.gemfire.CancelException;
 import com.gemstone.gemfire.StatisticsFactory;
 import com.gemstone.gemfire.SystemFailure;
-import com.gemstone.gemfire.cache.AttributesFactory;
-import com.gemstone.gemfire.cache.AttributesMutator;
-import com.gemstone.gemfire.cache.Cache;
-import com.gemstone.gemfire.cache.CacheClosedException;
-import com.gemstone.gemfire.cache.CacheException;
-import com.gemstone.gemfire.cache.CacheListener;
-import com.gemstone.gemfire.cache.CacheLoader;
-import com.gemstone.gemfire.cache.CacheLoaderException;
-import com.gemstone.gemfire.cache.CacheStatistics;
-import com.gemstone.gemfire.cache.CacheWriter;
-import com.gemstone.gemfire.cache.CacheWriterException;
-import com.gemstone.gemfire.cache.CustomExpiry;
-import com.gemstone.gemfire.cache.DataPolicy;
-import com.gemstone.gemfire.cache.DiskAccessException;
-import com.gemstone.gemfire.cache.EntryExistsException;
-import com.gemstone.gemfire.cache.EntryNotFoundException;
-import com.gemstone.gemfire.cache.ExpirationAttributes;
-import com.gemstone.gemfire.cache.InterestPolicy;
-import com.gemstone.gemfire.cache.InterestRegistrationEvent;
-import com.gemstone.gemfire.cache.LoaderHelper;
-import com.gemstone.gemfire.cache.LowMemoryException;
-import com.gemstone.gemfire.cache.Operation;
-import com.gemstone.gemfire.cache.PartitionAttributes;
-import com.gemstone.gemfire.cache.PartitionResolver;
-import com.gemstone.gemfire.cache.PartitionedRegionDistributionException;
-import com.gemstone.gemfire.cache.PartitionedRegionStorageException;
-import com.gemstone.gemfire.cache.Region;
-import com.gemstone.gemfire.cache.RegionAttributes;
-import com.gemstone.gemfire.cache.RegionDestroyedException;
-import com.gemstone.gemfire.cache.RegionEvent;
-import com.gemstone.gemfire.cache.RegionExistsException;
-import com.gemstone.gemfire.cache.RegionMembershipListener;
-import com.gemstone.gemfire.cache.TimeoutException;
-import com.gemstone.gemfire.cache.TransactionDataNodeHasDepartedException;
-import com.gemstone.gemfire.cache.TransactionDataRebalancedException;
-import com.gemstone.gemfire.cache.TransactionException;
+import com.gemstone.gemfire.cache.*;
 import com.gemstone.gemfire.cache.asyncqueue.internal.AsyncEventQueueImpl;
 import com.gemstone.gemfire.cache.asyncqueue.internal.AsyncEventQueueStats;
 import com.gemstone.gemfire.cache.execute.EmptyRegionFunctionException;
@@ -442,7 +407,32 @@ public class PartitionedRegion extends LocalRegion implements
   public static final int OFFLINE_EQUAL_PERSISTED = 3;
 
   private volatile int shutDownAllStatus = RUNNING_MODE;
-  
+
+  final public static int COLUMN_BATCH_SIZE_DEFAULT = 10000;
+  /** Default size for CachedBatches. */
+  private int columnBatchSize = -1;
+
+  /** Minimum size for CachedBatches. */
+  private int columnMinBatchSize = 200;
+
+  public void setColumnBatchSizes(int size, int minSize) {
+    columnBatchSize = size;
+    columnMinBatchSize = minSize < columnBatchSize ? minSize : size;
+  }
+
+  public int getColumnBatchSize() {
+    if (columnBatchSize == -1) {
+      final GemFireCacheImpl.StaticSystemCallbacks sysCb = GemFireCacheImpl
+          .getInternalProductCallbacks();
+      ExternalTableMetaData metadata = sysCb.fetchSnappyTablesHiveMetaData(this);
+    }
+    return columnBatchSize;
+  }
+
+  public int getColumnMinBatchSize() {
+    return columnMinBatchSize;
+  }
+
   private final long birthTime = System.currentTimeMillis();
 
   public void setShutDownAllStatus(int newStatus) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/partitioned/PutAllPRMessage.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/partitioned/PutAllPRMessage.java
@@ -658,7 +658,7 @@ public final class PutAllPRMessage extends PartitionMessageWithDirectReply {
         // TODO: For concurrent putALLs, this will club other putall as well
         // the putAlls in worst case so cachedbatchsize may be large?
         if (success && bucketRegion.getPartitionedRegion().needsBatching()
-            && bucketRegion.size() >= GemFireCacheImpl.getColumnBatchSize()) {
+            && bucketRegion.size() >= bucketRegion.getPartitionedRegion().getColumnBatchSize()) {
           bucketRegion.createAndInsertCachedBatch(false);
         }
           if (lockedForPrimary) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
@@ -54,10 +54,6 @@ public abstract class CallbackFactoryProvider {
     }
 
     @Override
-    public void invalidateReplicatedTableCache(LocalRegion region) {
-    }
-
-    @Override
     public String cachedBatchTableName(String tableName) {
       throw new UnsupportedOperationException("unexpected invocation for "
           + toString());

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
@@ -41,8 +41,6 @@ public interface StoreCallbacks {
 
   public String snappyInternalSchemaName();
 
-  void invalidateReplicatedTableCache(LocalRegion region);
-
   void cleanUpCachedObjects(String table, Boolean sentFromExternalCluster);
 
   void registerRelationDestroyForHiveStore();

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/catalog/ExternalCatalog.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/catalog/ExternalCatalog.java
@@ -20,6 +20,8 @@ package com.pivotal.gemfirexd.internal.catalog;
 import java.util.HashMap;
 import java.util.List;
 
+import com.gemstone.gemfire.internal.cache.ExternalTableMetaData;
+
 /**
  * Need to keep GemXD independent of any snappy/spark/hive related
  * classes. An implementation of this can be made which adheres to this

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/catalog/ExternalCatalog.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/catalog/ExternalCatalog.java
@@ -66,5 +66,12 @@ public interface ExternalCatalog {
    */
   public String catalogSchemaName();
 
+  /**
+   * Returns the meta data of the Hive Table
+   *
+   */
+  public ExternalTableMetaData getHiveTableMetaData(String schema, String tableName,
+      boolean skipLocks);
+
   void stop();
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/catalog/ExternalTableMetaData.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/catalog/ExternalTableMetaData.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.pivotal.gemfirexd.internal.catalog;
+
+
+public class ExternalTableMetaData {
+
+  public ExternalTableMetaData(String entityName,
+      Object schema,
+      Object externalStore,
+      long cachedBatchSize,
+      Boolean useCompression,
+      String baseTable,
+      String dml,
+      String[] dependents) {
+    this.entityName = entityName;
+    this.schema = schema;
+    this.externalStore = externalStore;
+    this.cachedBatchSize = cachedBatchSize;
+    this.useCompression = useCompression;
+    this.baseTable = baseTable;
+    this.dml = dml;
+    this.dependents = dependents;
+  }
+
+  public String entityName;
+  public Object schema;
+  // No type specified as the class is in snappy core
+  public Object externalStore;
+  public long cachedBatchSize;
+  public boolean useCompression;
+  public String baseTable;
+  public String dml;
+  public String[] dependents;
+
+}

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/GfxdIndexManager.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/GfxdIndexManager.java
@@ -1046,10 +1046,6 @@ public final class GfxdIndexManager implements Dependent, IndexUpdater,
           this.container, getObjectString(indexes), entry, success,
           event);
     }
-    if (owner.isUsedForUserReplicatedTable()) {
-      CallbackFactoryProvider.getStoreCallbacks()
-          .invalidateReplicatedTableCache(owner);
-    }
     if (event.getTXState() != null && event.isCustomEviction()) {
       return;
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -432,6 +432,10 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
     initTableFlags();
   }
 
+  public void invalidateHiveMetaData() {
+    externalTableMetaData.set(null);
+  }
+
   public ExternalTableMetaData fetchHiveMetaData(boolean refresh) {
     if (refresh || externalTableMetaData.get() == null) {
       // containers are created during initialization, ignore them
@@ -439,7 +443,8 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
           Misc.getMemStore().getExternalCatalog().getHiveTableMetaData(
               this.schemaName, this.tableName, true));
       if (isPartitioned()) {
-        ((PartitionedRegion)this.region).setColumnBatchSizes(externalTableMetaData.get().cachedBatchSize, 200);
+        ((PartitionedRegion)this.region).
+            setColumnBatchSizes(externalTableMetaData.get().cachedBatchSize, 200);
       }
     }
     return externalTableMetaData.get();

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -67,7 +67,6 @@ import com.gemstone.gemfire.internal.util.ArrayUtils;
 import com.gemstone.gemfire.pdx.internal.unsafe.UnsafeWrapper;
 import com.gemstone.gnu.trove.THashSet;
 import com.pivotal.gemfirexd.internal.catalog.ExternalCatalog;
-import com.pivotal.gemfirexd.internal.catalog.ExternalTableMetaData;
 import com.pivotal.gemfirexd.internal.engine.GemFireXDQueryObserver;
 import com.pivotal.gemfirexd.internal.engine.GemFireXDQueryObserverHolder;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
@@ -439,6 +438,9 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
       externalTableMetaData.compareAndSet(null,
           Misc.getMemStore().getExternalCatalog().getHiveTableMetaData(
               this.schemaName, this.tableName, true));
+      if (isPartitioned()) {
+        ((PartitionedRegion)this.region).setColumnBatchSizes(externalTableMetaData.get().cachedBatchSize, 200);
+      }
     }
     return externalTableMetaData.get();
   }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -562,6 +562,14 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
         }
       }
     }
+    invalidateHiveMetaDataForAllTables();
+  }
+
+  public void invalidateHiveMetaDataForAllTables() {
+    List<GemFireContainer> containers = getAllContainers();
+    for (GemFireContainer container : containers) {
+      container.invalidateHiveMetaData();
+    }
   }
 
   public void dropConglomerate(Transaction xact, ContainerKey id)
@@ -593,6 +601,7 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
         this.uninitializedConglomerates.remove(id);
       }
     }
+    invalidateHiveMetaDataForAllTables();
   }
 
   public boolean addPendingOperation(MemOperation op, GemFireTransaction tran)

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
@@ -21,6 +21,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -37,26 +38,8 @@ import com.gemstone.gemfire.internal.DSCODE;
 import com.gemstone.gemfire.internal.DataSerializableFixedID;
 import com.gemstone.gemfire.internal.HeapDataOutputStream;
 import com.gemstone.gemfire.internal.InternalDataSerializer;
-import com.gemstone.gemfire.internal.cache.AbstractDiskRegion;
-import com.gemstone.gemfire.internal.cache.AbstractRegionEntry;
-import com.gemstone.gemfire.internal.cache.BucketRegion;
-import com.gemstone.gemfire.internal.cache.DiskStoreImpl;
-import com.gemstone.gemfire.internal.cache.EventErrorHandler;
+import com.gemstone.gemfire.internal.cache.*;
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl.StaticSystemCallbacks;
-import com.gemstone.gemfire.internal.cache.InternalRegionArguments;
-import com.gemstone.gemfire.internal.cache.LocalRegion;
-import com.gemstone.gemfire.internal.cache.NonLocalRegionEntry;
-import com.gemstone.gemfire.internal.cache.NonLocalRegionEntryWithStats;
-import com.gemstone.gemfire.internal.cache.OffHeapRegionEntry;
-import com.gemstone.gemfire.internal.cache.PartitionedRegion;
-import com.gemstone.gemfire.internal.cache.PartitionedRegionHelper;
-import com.gemstone.gemfire.internal.cache.PlaceHolderDiskRegion;
-import com.gemstone.gemfire.internal.cache.ProxyBucketRegion;
-import com.gemstone.gemfire.internal.cache.RegionEntry;
-import com.gemstone.gemfire.internal.cache.RegionEntryContext;
-import com.gemstone.gemfire.internal.cache.SortedIndexContainer;
-import com.gemstone.gemfire.internal.cache.TXStateProxy;
-import com.gemstone.gemfire.internal.cache.Token;
 import com.gemstone.gemfire.internal.cache.control.MemoryThresholdListener;
 import com.gemstone.gemfire.internal.cache.delta.Delta;
 import com.gemstone.gemfire.internal.cache.execute.BucketMovedException;
@@ -1575,6 +1558,15 @@ public final class RegionEntryUtils {
       } else {
         return null;
       }
+    }
+    public ExternalTableMetaData fetchSnappyTablesHiveMetaData(PartitionedRegion region) {
+      List<GemFireContainer> containers =  Misc.getMemStore().getAllContainers();
+      for (GemFireContainer container: containers) {
+        if (container.getRegion() != null  &&
+            container.getRegion().getName() == region.getName())
+          return container.fetchHiveMetaData(false);
+      }
+      return null;
     }
   };
 


### PR DESCRIPTION
## Changes proposed in this pull request

The cached batch size is saved in the hive catalog per table and this hive meta data is available on executor. The hive meta data is fetched once and then is kept in the container. ExternalTableMetaData is the class that holds the hive meta data. All hive meta data is invalidated when a new container is created. This is brute force but currently when hive meta data is updated, no events are received on the executor. 

Removed the unused functions isUsedForUserReplicatedTable and setUsedForUserReplicatedTable.

## Patch testing

Clean precheckin. Will be adding a test to verify the hive meta data on executors in embedded and connector modes. 

## Other PRs 
https://github.com/SnappyDataInc/snappydata/pull/500
https://github.com/SnappyDataInc/snappy-aqp/pull/131
