### PR TITLE
Changed snappy-shell to snappy

### DIFF
--- a/tests/sql/src/main/java/hydra/gemfirexd/FabricServerHelper.java
+++ b/tests/sql/src/main/java/hydra/gemfirexd/FabricServerHelper.java
@@ -317,10 +317,10 @@ public class FabricServerHelper {
     String gfxdScript = null;
     switch (hd.getOSType()) {
       case unix:
-        gfxdScript = "snappy-shell";
+        gfxdScript = "snappy-sql";
         break;
       case windows:
-        gfxdScript = "snappy-shell.bat";
+        gfxdScript = "snappy-sql.bat";
         break;
     }
     String gfxd = productBin + sep + gfxdScript;


### PR DESCRIPTION
## Changes proposed in this pull request

snappy-shell is currently being used to start lead,locators and server and it is also used as a sql shell. But its name does not indicate that it is a sql shell. 

So, renamed snappy-shell to snappy. And created a new script snappy-sql that is just a wrapper over 'snappy' shell. So now our documents would tell that to start lead, locator and servers, use bin/snappy. While to start sql shell, run bin/snappy-sql. However, bin/snappy and bin/snappy-sql can be both be used to start components and start the sql shell. 

## Patch testing
manual testing and ran ./gradlew :snappy-examples:scalaTest 
 
## Other PRs 
https://github.com/SnappyDataInc/snappydata/pull/504