### PR TITLE
SNAP-1374 : Incorrect check to identify Lead node while creating Disk Stores

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -1462,9 +1462,10 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
       // persistence to be created; however, if "sys-disk-dir" is explicitly
       // set then that can be used for overflow/gateway
 
-      StoreCallbacks callback = com.gemstone.gemfire.internal.snappy.CallbackFactoryProvider.getStoreCallbacks();
+      String serverGroup = this.getBootProperty("server-groups");
+      Boolean isLeadMember = serverGroup != null ? serverGroup.contains("IMPLICIT_LEADER_SERVERGROUP") : false;
 
-      if (this.persistingDD || this.persistenceDir != null || (this.myKind.isAccessor() && callback != null)) {
+      if (this.persistingDD || this.persistenceDir != null || isLeadMember) {
         try {
           DiskStoreFactory dsf = this.gemFireCache.createDiskStoreFactory();
           File file = new File(generatePersistentDirName(null))
@@ -1482,7 +1483,7 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
               dsf.setMaxOplogSize(DiskStoreFactory.DEFAULT_MAX_OPLOG_SIZE);
             }
             else {
-              if (this.myKind.isAccessor()) {
+              if (isLeadMember) {
                 dsf.setMaxOplogSize(1);
               } else {
                 dsf.setMaxOplogSize(10);


### PR DESCRIPTION


## Changes proposed in this pull request

    Updated code for correction. Identifying Lead node by adding check on server-group IMPLICIT_LEADER_SERVERGROUP.

## Patch testing

    Tested Manually.

