### PR TITLE
Fix for StatementStatsDUnit failure

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
@@ -342,7 +342,7 @@ public class GenericStatement
 		boolean foundInCache = false;
 		if (preparedStmt == null)
 		{
-                        boolean isRemoteDDLAndSnappyStore = lcc.isConnectionForRemoteDDL() && !routeQuery;
+                        boolean isRemoteDDLAndSnappyStore =  Misc.getMemStore().isSnappyStore() && lcc.isConnectionForRemoteDDL() && !routeQuery;
                         if (cacheMe && !isRemoteDDLAndSnappyStore) {
                                 preparedStmt = (GenericPreparedStatement)((GenericLanguageConnectionContext)lcc).lookupStatement(this);
                         }


### PR DESCRIPTION
Fix for failure in StatementStatsDunit

Now do not allow routing if its not a Snappy store.