### PR TITLE
The internal buffer of ClientClob was getting closed before being use…

### DIFF
--- a/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientBlob.java
+++ b/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientBlob.java
@@ -146,7 +146,6 @@ public final class ClientBlob extends ClientLobBase implements BufferedBlob {
           }
           int streamSize = out.getUsed();
           this.dataStream = new MemInputStream(out, streamSize);
-          out.close(); // no-op to remove a warning
           return streamSize;
         }
       } else {


### PR DESCRIPTION
…d. Removed the close() call.

## Changes proposed in this pull request
 The internal buffer of ClientClob was getting closed before being used. Removed the close() call.

## Patch testing

Pre checkin

## ReleaseNotes changes

NA

## Other PRs 

NA