### PR TITLE
Handling parameter constant for prepare statement.

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/PrepStatementSnappyActivation.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/PrepStatementSnappyActivation.java
@@ -122,12 +122,14 @@ public class PrepStatementSnappyActivation extends GemFireSelectDistributionActi
               final String str = this.sql.substring(startPos, beginC);
               startPos = v.endOffset + 1;
               DataValueDescriptor paramValue = pvs.getParameter(i++);
-              String paramStr = paramValue.toString();
+              String paramStr = null;
               if (paramValue instanceof SQLClob) {
                 char[] charArray = ((SQLClob)paramValue).getCharArray();
                 if (charArray != null) {
                   paramStr = String.valueOf(charArray);
                 }
+              } else {
+                paramStr = paramValue.toString();
               }
               modifiedSqlStr.append(str).append(" ").append(paramStr).append(" ");
             }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/PrepStatementSnappyActivation.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/PrepStatementSnappyActivation.java
@@ -27,6 +27,8 @@ import com.pivotal.gemfirexd.internal.iapi.services.sanity.SanityManager;
 import com.pivotal.gemfirexd.internal.iapi.sql.ResultDescription;
 import com.pivotal.gemfirexd.internal.iapi.sql.conn.LanguageConnectionContext;
 import com.pivotal.gemfirexd.internal.iapi.sql.execute.ExecPreparedStatement;
+import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor;
+import com.pivotal.gemfirexd.internal.iapi.types.SQLClob;
 import com.pivotal.gemfirexd.internal.impl.sql.compile.Token;
 import com.pivotal.gemfirexd.internal.impl.sql.GenericPreparedStatement;
 import com.pivotal.gemfirexd.internal.impl.sql.GenericResultDescription;
@@ -119,8 +121,15 @@ public class PrepStatementSnappyActivation extends GemFireSelectDistributionActi
               final int beginC = v.beginOffset;
               final String str = this.sql.substring(startPos, beginC);
               startPos = v.endOffset + 1;
-              modifiedSqlStr.append(str).append(" ").append(pvs
-                  .getParameter(i++).toString()).append(" ");
+              DataValueDescriptor paramValue = pvs.getParameter(i++);
+              String paramStr = paramValue.toString();
+              if (paramValue instanceof SQLClob) {
+                char[] charArray = ((SQLClob)paramValue).getCharArray();
+                if (charArray != null) {
+                  paramStr = String.valueOf(charArray);
+                }
+              }
+              modifiedSqlStr.append(str).append(" ").append(paramStr).append(" ");
             }
 
             final int cLen = this.sql.length();


### PR DESCRIPTION
## Changes proposed in this pull request
In case column is of "String" data type i.e. alias of Clob, when user set parameter value, that is internally created as SQLClob. But when this value is being extracted, being a Clob it gives its value as SQLClob@0xeeb6b6e. 

To resolve same, if datatype of column is SQLClob, its char-array is taken and converted to string that works fine. 

## Patch testing
Relevant test.

## ReleaseNotes changes
No

## Other PRs 
None.
