### PR TITLE
Changes to disable offheap and heap memory settings for row store tests.

### DIFF
--- a/tests/core/src/main/java/regression/local.noIndexPersistence.conf
+++ b/tests/core/src/main/java/regression/local.noIndexPersistence.conf
@@ -1,2 +1,4 @@
+INCLUDE $JTESTS/sql/snappy.local.conf
+
 hydra.VmPrms-extraVMArgs += "-Dgemfirexd.persist-indexes=false";
 hydra.gemfirexd.FabricServerPrms-persistIndexes=false;

--- a/tests/core/src/main/java/regression/local.sql.preAllocate.conf
+++ b/tests/core/src/main/java/regression/local.sql.preAllocate.conf
@@ -1,3 +1,4 @@
+INCLUDE $JTESTS/sql/snappy.local.conf
 // PreAllocate setting are true by default in product
 hydra.VmPrms-extraVMArgs += "-ea -Dgemfire.preAllocateDisk=false";
 hydra.VmPrms-extraVMArgs += "-ea -Dgemfire.preAllocateIF=false";

--- a/tests/core/src/main/java/regression/local.sql.uniqueKeyOnly.conf
+++ b/tests/core/src/main/java/regression/local.sql.uniqueKeyOnly.conf
@@ -1,23 +1,11 @@
-hydra.VmPrms-extraClassPaths        +=   "/export/gcm/where/java/derby/derby-10.8.2.2/jars/insane/derby.jar";
-hydra.VmPrms-extraClassPaths        +=   "/export/gcm/where/java/derby/derby-10.8.2.2/jars/insane/derbyclient.jar";
-hydra.VmPrms-extraClassPaths        +=   "/export/gcm/where/java/derby/derby-10.8.2.2/jars/insane/derbytools.jar";
-hydra.Prms-derbyServerClassPath     =   "/export/gcm/where/java/derby/derby-10.8.2.2/jars/insane/derbynet.jar";
-hydra.Prms-extraDerbyServerVMArgs += " -Xmx1024m -Dderby.storage.pageCacheSize=32000 -Dderby.locks.waitTimeout=30 -Dderby.locks.deadlockTimeout=20 ";
-hydra.Prms-clientShutdownHook += sql.SQLTest dumpResults;
-//hydra.VmPrms-extraVMArgs   += "-DDistributionManager.MAX_PR_THREADS=100";
-//hydra.VmPrms-extraVMArgs   += "-DDistributionManager.MAX_FE_THREADS=100";
-//hydra.GemFirePrms-conserveSockets = fcn "hydra.TestConfigFcns.oneof(\"true\", \"false\")" ncf;
-//hydra.gemfirexd.FabricServerPrms-conserveSockets = fcn "hydra.TestConfigFcns.oneof(\"true\", \"false\")" ncf;
-hydra.GemFirePrms-conserveSockets = false; //per team, this is recommended to customers and should only test this setting now
-hydra.gemfirexd.FabricServerPrms-conserveSockets = false;
+INCLUDE $JTESTS/sql/snappy.local.conf
+
 //hydra.VmPrms-extraVMArgs += "-XX:+UseParNewGC";
 //hydra.VmPrms-extraVMArgs += "-XX:+UseConcMarkSweepGC";
 //hydra.VmPrms-extraVMArgs += "-XX:CMSInitiatingOccupancyFraction=50";
 
 //sql.SQLPrms-isSingleHop = fcn "hydra.TestConfigFcns.oneof(\"true\", \"false\")" ncf;
 //sql.SQLPrms-isSingleHop = true; //temp use
-
-sql.SQLPrms-dropProc = fcn "hydra.TestConfigFcns.oneof(\"true\", \"false\")" ncf; //whether there are concurrent ddl ops of procedures
 
 //for cheetah GA, temporarily disallow the concurrent update on the same row.
 sql.SQLPrms-testUniqueKeys = true;

--- a/tests/sql/src/main/java/sql/joins/offHeap.inc
+++ b/tests/sql/src/main/java/sql/joins/offHeap.inc
@@ -1,3 +1,4 @@
+/* currently not running tests with offheap enabled. hence commented.  
 // want off-heap memory defined and used in the test; either all tables will be off-heap or only some tables
 hydra.GemFirePrms-offHeapMemorySize=350m;               // this sets off-heap memory for older tests (ignored in newer tests)
 hydra.gemfirexd.FabricServerPrms-offHeapMemorySize=350m;  // this sets off-heap memory for newer tests (ignored in older tests)
@@ -13,3 +14,4 @@ CLOSETASK taskClass = memscale.OffHeapHelper taskMethod = closeAllOffHeapRegions
 CLOSETASK taskClass = memscale.OffHeapHelper taskMethod = verifyOffHeapMemoryConsistencyOnce;
 ENDTASK taskClass = memscale.OffHeapMemoryLifecycleListener taskMethod = checkForErrors;
 
+*/

--- a/tests/sql/src/main/java/sql/offHeap.inc
+++ b/tests/sql/src/main/java/sql/offHeap.inc
@@ -1,3 +1,4 @@
+/* currently not running tests with offheap enabled. hence commented.
 hydra.GemFirePrms-offHeapMemorySize=350m;               // this sets off-heap memory for older tests (ignored in newer tests)
 hydra.gemfirexd.FabricServerPrms-offHeapMemorySize=350m;  // this sets off-heap memory for newer tests (ignored in older tests)
 sql.SQLPrms-isOffheap = true;                           // true means all tables are offheap (via offheap keyword on create table statement)
@@ -11,3 +12,4 @@ CLOSETASK taskClass = memscale.OffHeapHelper taskMethod = closeAllOffHeapRegions
 CLOSETASK taskClass = memscale.OffHeapHelper taskMethod = verifyOffHeapMemoryConsistencyOnce;
 ENDTASK taskClass = memscale.OffHeapMemoryLifecycleListener taskMethod = checkForErrors;
 
+*/

--- a/tests/sql/src/main/java/sql/snappy.local.conf
+++ b/tests/sql/src/main/java/sql/snappy.local.conf
@@ -16,8 +16,10 @@ hydra.gemfirexd.FabricServerPrms-conserveSockets = false;
 //sql.SQLPrms-isSingleHop = fcn "hydra.TestConfigFcns.oneof(\"true\", \"false\")" ncf;
 //sql.SQLPrms-isSingleHop = true; //temp use
 
+/* currently not running tests with below settings as we get LowMemoryException.
 sql.SQLPrms-dropProc = fcn "hydra.TestConfigFcns.oneof(\"true\", \"false\")" ncf; //whether there are concurrent ddl ops of procedures
 hydra.VmPrms-extraVMArgs += "-XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=50 -XX:+CMSClassUnloadingEnabled";
 hydra.VmPrms-extraVMArgs += "-Dgemfirexd.critical-heap-percentage=90 -Dgemfirexd.eviction-heap-percentage=80 -Dgemfire.thresholdThickness=4.5";
 hydra.VmPrms-extraVMArgs += "-Dgemfire.eviction-thresholdThickness=8.1 -Dgemfire.HeapLRUCapacityController.evictionBurstPercentage=1.62 -Dgemfire.heapPollerInterval=50";
 hydra.VmPrms-extraVMArgs += "-Dgemfire.HeapLRUCapacityController.evictHighEntryCountBucketsFirst=false -Dgemfire.HeapLRUCapacityController.evictHighEntryCountBucketsFirstForEvictor=true";
+*/

--- a/tests/sql/src/main/java/sql/snappy.local.conf
+++ b/tests/sql/src/main/java/sql/snappy.local.conf
@@ -16,8 +16,9 @@ hydra.gemfirexd.FabricServerPrms-conserveSockets = false;
 //sql.SQLPrms-isSingleHop = fcn "hydra.TestConfigFcns.oneof(\"true\", \"false\")" ncf;
 //sql.SQLPrms-isSingleHop = true; //temp use
 
-/* currently not running tests with below settings as we get LowMemoryException.
 sql.SQLPrms-dropProc = fcn "hydra.TestConfigFcns.oneof(\"true\", \"false\")" ncf; //whether there are concurrent ddl ops of procedures
+
+/* currently not running tests with below settings as we get LowMemoryException.
 hydra.VmPrms-extraVMArgs += "-XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=50 -XX:+CMSClassUnloadingEnabled";
 hydra.VmPrms-extraVMArgs += "-Dgemfirexd.critical-heap-percentage=90 -Dgemfirexd.eviction-heap-percentage=80 -Dgemfire.thresholdThickness=4.5";
 hydra.VmPrms-extraVMArgs += "-Dgemfire.eviction-thresholdThickness=8.1 -Dgemfire.HeapLRUCapacityController.evictionBurstPercentage=1.62 -Dgemfire.heapPollerInterval=50";

--- a/tests/sql/src/main/java/sql/sqlEviction/sqlEviction.bt
+++ b/tests/sql/src/main/java/sql/sqlEviction/sqlEviction.bt
@@ -133,6 +133,7 @@ sql/sqlEviction/multiTablesUniqDAPWithAccessorsHA.conf
     B=accessor accessorHosts=2 accessorVMsPerHost=5 accessorThreadsPerVM=5
     redundantCopies=2
 
+/* currently not running tests with offheap enabled. hence commented.
 // offHeap variants of the above tests
 sql/sqlEviction/evictionOverflowOffHeap.conf
   A=store storeHosts=2 storeVMsPerHost=2 storeThreadsPerVM=1
@@ -190,3 +191,4 @@ sql/sqlEviction/evictionOverflowHAOffHeap.conf
   useHeapPercentage = true 
   maxHeapSize=350 offHeapMemorySize=1m
   setCriticalHeap = true
+*/


### PR DESCRIPTION
## Changes proposed in this pull request
off-heap is not supported with RowStore. Hence did the required changes to run the tests with offheap disabled. 
With the heap memory settings, the row store test failed with LowMemoryException , hence commenting those settings.
 
## Patch testing
Ran row store regression with the changes.

