### PR TITLE
Fix as provided for neeraj for issue of lock of gfxddatadictionary.

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/cache/query/internal/IndexUpdater.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/cache/query/internal/IndexUpdater.java
@@ -116,15 +116,16 @@ public interface IndexUpdater {
    *         iterator on List of RegionEntry belonging to the bucket which is being destroyed.
    *         null is passed for non bucket regions.
    * @param destroyOffline
+   * @param createNewConnection
    * @return  Returns whether write lock was acqired by clearIndex or not
    */
 
   boolean clearIndexes(LocalRegion region, boolean lockForGII,
-      boolean holdIndexLock, Iterator<?> bucketEntriesIter, boolean destroyOffline);
+      boolean holdIndexLock, Iterator<?> bucketEntriesIter, boolean destroyOffline, boolean createNewConnection);
 
   /**
    * should be invoked if "holdIndexLock" argument was true in
-   * {@link #clearIndexes(LocalRegion, boolean, boolean, Iterator, boolean)}
+   * {@link #clearIndexes(LocalRegion, boolean, boolean, Iterator, boolean, boolean)}
    */
   public void releaseIndexLock(LocalRegion region);
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegionIndexCleaner.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegionIndexCleaner.java
@@ -36,7 +36,7 @@ public class BucketRegionIndexCleaner {
   public void clearEntries(List<RegionEntry> entries) {
     IndexUpdater indexUpdater = region.getIndexUpdater();
     boolean indexGiiLockTaken = indexUpdater.clearIndexes(region, lockForGII,
-        holdIndexLock, entries.iterator(), false);
+        holdIndexLock, entries.iterator(), false, true);
     if (indexGiiLockTaken) {
       indexUpdater.unlockForGII(indexGiiLockTaken);
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -37,7 +37,6 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.LongBinaryOperator;
-import java.util.function.LongUnaryOperator;
 import java.util.regex.Pattern;
 
 import com.gemstone.gemfire.CancelCriterion;
@@ -8975,7 +8974,7 @@ public class LocalRegion extends AbstractRegion
     // complete index is going to be blown away; bucket region will need to
     // override to clear in every case
     if (!setIsDestroyed) {
-      return indexUpdater.clearIndexes(this, lockForGII, true, null, false);
+      return indexUpdater.clearIndexes(this, lockForGII, true, null, false, false);
     }
     return false;
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyBucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyBucketRegion.java
@@ -543,7 +543,7 @@ public final class ProxyBucketRegion implements Bucket {
     if (iup != null) {
       RegionMap rmap = diskRegion.getRecoveredEntryMap();
       if (rmap != null && rmap.regionEntries() != null) {
-        iup.clearIndexes(this.partitionedRegion, true, false, rmap.regionEntries().iterator(), true);
+        iup.clearIndexes(this.partitionedRegion, true, false, rmap.regionEntries().iterator(), true, false);
       }
     }
   }

--- a/tests/core/src/main/java/com/gemstone/gemfire/internal/cache/Bug43522DUnit.java
+++ b/tests/core/src/main/java/com/gemstone/gemfire/internal/cache/Bug43522DUnit.java
@@ -189,7 +189,7 @@ public class Bug43522DUnit extends CacheTestCase {
 
               @Override
               public boolean clearIndexes(LocalRegion region, boolean lockForGII,
-                  boolean holdIndexLock, Iterator<?> bucketEntriesIter, boolean destroyOffline) {
+                  boolean holdIndexLock, Iterator<?> bucketEntriesIter, boolean destroyOffline, boolean createNewConnection) {
                 return false;
               }
 
@@ -519,7 +519,7 @@ public class Bug43522DUnit extends CacheTestCase {
 
               @Override
               public boolean clearIndexes(LocalRegion region, boolean lockForGII,
-                  boolean holdIndexLock, Iterator<?> bucketEntriesIter, boolean destroyOffline) {
+                  boolean holdIndexLock, Iterator<?> bucketEntriesIter, boolean destroyOffline, boolean createNewConnection) {
                 return false;
               }
 
@@ -852,7 +852,7 @@ public class Bug43522DUnit extends CacheTestCase {
 
               @Override
               public boolean clearIndexes(LocalRegion region, boolean lockForGII,
-                  boolean holdIndexLock, Iterator<?> bucketEntriesIter, boolean destroyOffline) {
+                  boolean holdIndexLock, Iterator<?> bucketEntriesIter, boolean destroyOffline, boolean createNewConnection) {
                 return false;
               }
 


### PR DESCRIPTION
## Changes proposed in this pull request
As of now, an incoming request picks up last connection which happened to be transactional; and so it do not release read lock thinking that transaction primitive would release lock itself which never happen.

## Patch testing
Precheckin - underway

## ReleaseNotes changes
No

## Other PRs 
No
