### PR TITLE
Fix for snap-1517 

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
@@ -747,7 +747,7 @@ public class CacheServerLauncher  {
   /**
    * Sets the status of the cache server to be {@link #RUNNING}.
    */
-  public void running(final InternalDistributedSystem system) {
+  public void running(final InternalDistributedSystem system, boolean endWaiting) {
     Status stat = this.status;
     if (stat == null) {
       stat = this.status = createStatus(this.baseName, RUNNING, getProcessId());
@@ -755,25 +755,12 @@ public class CacheServerLauncher  {
     else {
       if (stat.state == WAITING) {
         stat.dsMsg = null;
+        if (endWaiting) {
+          stat.state = RUNNING;
+        }
       } else {
         stat.state = RUNNING;
       }
-    }
-    setRunningStatus(stat, system);
-  }
-
-  /**
-   * Sets the status of the cache server to be {@link #RUNNING}.
-   * This differs from {@link #running(InternalDistributedSystem)} in that
-   * status will be changed to running even if current status is {@link #WAITING}
-   */
-  public void runningForced(final InternalDistributedSystem system) {
-    Status stat = this.status;
-    if (stat == null) {
-      stat = this.status = createStatus(this.baseName, RUNNING, getProcessId());
-    } else {
-      stat.dsMsg = null;
-      stat.state = RUNNING;
     }
     setRunningStatus(stat, system);
   }
@@ -925,7 +912,7 @@ public class CacheServerLauncher  {
 
     startAdditionalServices(cache, options, props);
 
-    this.running(system);
+    this.running(system, false);
 
     clearLogListener();
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
@@ -762,6 +762,22 @@ public class CacheServerLauncher  {
     setRunningStatus(stat, system);
   }
 
+  /**
+   * Sets the status of the cache server to be {@link #RUNNING}.
+   * This differs from {@link #running(InternalDistributedSystem)} in that
+   * status will be changed to running even if current status is {@link #WAITING}
+   */
+  public void runningForced(final InternalDistributedSystem system) {
+    Status stat = this.status;
+    if (stat == null) {
+      stat = this.status = createStatus(this.baseName, RUNNING, getProcessId());
+    } else {
+      stat.dsMsg = null;
+      stat.state = RUNNING;
+    }
+    setRunningStatus(stat, system);
+  }
+
   protected void setRunningStatus(final Status stat,
       final InternalDistributedSystem system) {
     try {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
@@ -615,7 +615,7 @@ public abstract class FabricServiceImpl implements FabricService {
       // if started from command-line then change the status in the file too
       CacheServerLauncher launcher = CacheServerLauncher.getCurrentInstance();
       if (launcher != null) {
-        launcher.runningForced(Misc.getDistributedSystem());
+        launcher.running(Misc.getDistributedSystem(), true);
       }
     }
     this.previousServerStatus = State.UNINITIALIZED;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
@@ -612,6 +612,11 @@ public abstract class FabricServiceImpl implements FabricService {
     }
     if (this.previousServerStatus == State.RUNNING) {
       this.serverstatus = State.RUNNING;
+      // if started from command-line then change the status in the file too
+      CacheServerLauncher launcher = CacheServerLauncher.getCurrentInstance();
+      if (launcher != null) {
+        launcher.runningForced(Misc.getDistributedSystem());
+      }
     }
     this.previousServerStatus = State.UNINITIALIZED;
   }


### PR DESCRIPTION
Persistent server's status is not toggeled from "waiting" to running even if they are already "running".

As a fix, in FabricServiceImpl#endNotifyWaiting, changed the status to running. For this, added a new function CacheServerLauncher#runningForced(). 
There exists a similar function CacheServerLauncher#running() that is called from but that does not change the status to "running" if the current status is "waiting". So added a function runningForced() instead.

This is not related to large volume testing. The server always remains in "waiting" state (when checked with snappy-status-all.sh) if it had to wait for buckets from other nodes
 

## Patch testing
Tested manually by starting the cluster and checking the the status with snappy-status-all.sh.
Will run store precheckin prior to merge.

## ReleaseNotes changes
NA
## Other PRs 
NA
