### PR TITLE
Don't rollback the gemfire txstate if snapshot txstate is set

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/GemFireTransaction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/GemFireTransaction.java
@@ -2450,8 +2450,12 @@ public final class GemFireTransaction extends RawTransaction implements
         if (lcc != null && !lcc.isConnectionForRemote()
             // also don't rollback when no connection ID i.e. nested connection
             && this.connectionID.longValue() >= 0) {
-          this.txManager.rollback(tx, this.connectionID, false);
-          setTXState(null);
+          // In case, the tx is started by gemfire layer for snapshot, it should be rollbacked by gemfire layer.
+          TXStateInterface gfTx = TXManagerImpl.snapshotTxState.get();
+          if (tx != gfTx) {
+            this.txManager.rollback(tx, this.connectionID, false);
+            setTXState(null);
+          }
         }
       }
 


### PR DESCRIPTION
## Changes proposed in this pull request

Don't rollback the snapshot tx started at gemfire layer if conn.rollback is called.

## Patch testing

precheckin.

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
