### PR TITLE
SNAP-1604 If transaction is already active then dont begin transaction while creating cache batch

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -766,8 +766,11 @@ public class BucketRegion extends DistributedRegion implements Bucket {
                 "Creating the column batch for bucket " + this.getId()
                 + ", and batchID " + this.batchUUID);
       }
-      if(getCache().snapshotEnabled())
+      boolean txStarted = false;
+      if (getCache().snapshotEnabled() && getCache().getCacheTransactionManager().getTXState() == null) {
         getCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+        txStarted = true;
+      }
       try {
         if (getCache().getLoggerI18n().fineEnabled()) {
           getCache().getLoggerI18n().info(LocalizedStrings.DEBUG, "createAndInsertCachedBatch: " +
@@ -800,7 +803,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
         // Returning from here as we dont want to clean the row buffer data.
         success = false;
       } finally {
-        if (getCache().snapshotEnabled()) {
+        if (getCache().snapshotEnabled() && txStarted) {
           if (success) {
             getCache().getCacheTransactionManager().commit();
             if (null != getCache().getRvvSnapshotTestHook()) {


### PR DESCRIPTION
…eating cache batch

## Changes proposed in this pull request
* If transaction is already active then dont begin transaction while creating cache batch

## Patch testing
* precheckin in  progress

## ReleaseNotes changes
NA

## Other PRs 
NA
