### PR TITLE
[SNAP-1587] Update FabricServerTest to remove obsolete options

### DIFF
--- a/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/DRDAStatement.java
+++ b/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/DRDAStatement.java
@@ -700,7 +700,7 @@ class DRDAStatement
 	private static String trimNulls(String sqlStmt) {
 	  // trim any trailing nulls
 	  int stmtEnd = sqlStmt.length();
-	  while (sqlStmt.charAt(stmtEnd - 1) == 0) stmtEnd--;
+	  while (stmtEnd > 0 && sqlStmt.charAt(stmtEnd - 1) == 0) stmtEnd--;
 	  if (stmtEnd < sqlStmt.length()) {
 	    sqlStmt = sqlStmt.substring(0, stmtEnd);
 	  }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
@@ -680,20 +680,9 @@ public abstract class FabricServiceImpl implements FabricService {
             .getProperty(com.pivotal.gemfirexd.Attribute.PASSWORD_ATTR);
       }
     }
+    System.out.println("SW: got port=" + port + " thrift=" + thriftServer);
     if (port <= 0) {
-      if (!thriftServer) {
-        final String portStr = (String)networkProperties
-            .remove(com.pivotal.gemfirexd.Property.DRDA_PROP_PORTNUMBER);
-        if (portStr != null) {
-          port = Integer.parseInt(portStr);
-        }
-        else {
-          port = NETSERVER_DEFAULT_PORT;
-        }
-      }
-      else {
-        port = NETSERVER_DEFAULT_PORT;
-      }
+      port = NETSERVER_DEFAULT_PORT;
     }
 
     final InetAddress listenAddress = getListenAddress(bindAddress);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
@@ -680,7 +680,6 @@ public abstract class FabricServiceImpl implements FabricService {
             .getProperty(com.pivotal.gemfirexd.Attribute.PASSWORD_ATTR);
       }
     }
-    System.out.println("SW: got port=" + port + " thrift=" + thriftServer);
     if (port <= 0) {
       port = NETSERVER_DEFAULT_PORT;
     }


### PR DESCRIPTION
## Changes proposed in this pull request

Two fixes:

- fixed string index out of bounds for empty string
- removed obsolete and undocumented Property.START_DRDA and DRDA_PROP_PORTNUMBER
  from FabricServerTest and updated the test to also test thrift server instead

Also removed DRDA_PROP_PORTNUMBER in network property bag in FabricServiceImpl

## Patch testing

store precheckin

## ReleaseNotes changes

NA

## Other PRs 

NA