### PR TITLE
Modify test code to have enableConcurrencyChecks to be flag based for snapshot isolation.

### DIFF
--- a/tests/sql/src/main/java/sql/SQLPrms.java
+++ b/tests/sql/src/main/java/sql/SQLPrms.java
@@ -642,9 +642,12 @@ public class SQLPrms extends BasePrms{
     SQLBB.getBB().getSharedMap().put(SQLPrms.HDFS_TRIGGER, StrTriggerName);
     return triggerStmt.toArray(new String[triggerStmt.size()]);
   }
-  
- 
- 
+
+  /** (boolean) whether snapshotIsolation is enabled.
+   *  default is true;.
+   */
+   public static Long isSnapshotEnabled;
+
   /** (boolean) whether a record is manipulated only by the thread which creates it.
    *  default is true;.
    */

--- a/tests/sql/src/main/java/sql/SQLTest.java
+++ b/tests/sql/src/main/java/sql/SQLTest.java
@@ -332,8 +332,11 @@ public class SQLTest {
   public static boolean dumpThreads = TestConfig.tab().booleanAt(SQLPrms.dumpThreads, false);
   public static int dumpThreadsInterval = (int) TestConfig.tab().longAt(SQLPrms.dumpThreadsInterval, 10000);
   public static int dumpThreadsTotalTime = (int) TestConfig.tab().longAt(SQLPrms.dumpThreadsTotalTime, 600); //maxResultWaitSec
-  //public static boolean enableConcurrencyCheck = isHATest ? true : (random.nextBoolean() && testUniqueKeys? false: true);
-  public static boolean enableConcurrencyCheck = true; //Not covered in this 1.0 cheetah release, and removed from docs
+  //public static boolean enableConcurrencyCheck = isHATest ? true : (random.nextBoolean() &&  testUniqueKeys? false: true);
+  //enableConcurrecyChecks : needs to true in case of snapshotIsolation is enabled.
+  //Was set to false earlier (Not covered in this 1.0 cheetah release, and removed from docs)
+  public static boolean enableConcurrencyCheck = TestConfig.tab().booleanAt(SQLPrms
+      .isSnapshotEnabled,true);
   public static String ENABLECONCURRENCYCHECKS = " ENABLE CONCURRENCY CHECKS ";
   private static boolean isTicket51584Fixed = false;
   public static boolean reproduceTicket51628 = false;
@@ -1123,7 +1126,7 @@ public class SQLTest {
             }
           }
         }
-        
+
         if (enableConcurrencyCheck) {
           for (int i =0; i<gfeDDL.length; i++) {
             gfeDDL[i] += ENABLECONCURRENCYCHECKS;

--- a/tests/sql/src/main/java/sql/local.snapshot.conf
+++ b/tests/sql/src/main/java/sql/local.snapshot.conf
@@ -1,0 +1,4 @@
+//Use this local.conf and set value to false if snapshotIsolation is disabled. 
+//In case snapshotIsolation is enabled, no need to use this conf, as default value is true.
+sql.SQLPrms-isSnapshotEnabled = false;
+

--- a/tests/sql/src/main/java/sql/local.snapshotForTX.conf
+++ b/tests/sql/src/main/java/sql/local.snapshotForTX.conf
@@ -1,0 +1,7 @@
+//If snapshotIsolation is disabled for transaction only, run transaction tests using this conf, setting value to false. 
+//In case snapshotIsolation is enabled for transactions, no need to use this conf, as default value is true. Run the tests with snappy.local.conf
+
+INCLUDE $JTESTS/sql/snappy.local.conf;
+
+sql.SQLPrms-isSnapshotEnabled = false;
+

--- a/tests/sql/src/main/java/sql/snappy.local.conf
+++ b/tests/sql/src/main/java/sql/snappy.local.conf
@@ -24,3 +24,7 @@ hydra.VmPrms-extraVMArgs += "-Dgemfirexd.critical-heap-percentage=90 -Dgemfirexd
 hydra.VmPrms-extraVMArgs += "-Dgemfire.eviction-thresholdThickness=8.1 -Dgemfire.HeapLRUCapacityController.evictionBurstPercentage=1.62 -Dgemfire.heapPollerInterval=50";
 hydra.VmPrms-extraVMArgs += "-Dgemfire.HeapLRUCapacityController.evictHighEntryCountBucketsFirst=false -Dgemfire.HeapLRUCapacityController.evictHighEntryCountBucketsFirstForEvictor=true";
 */
+
+//For disabling snaphotIsolation in rowStore tests. Remove this if snapshotIsolation is enabled in product. 
+//Note : For transaction tests, there is a separate conf local.snapshotForTX.conf, to disable snapshotIsolation in transaction tests only. Please run the transaction bts with local.snapshotForTX.conf.
+INCLUDE $JTESTS/sql/local.snapshot.conf;


### PR DESCRIPTION
## Changes proposed in this pull request

- Adding a test flag to determine whether snapshot isolation should be enabled in rowStore tests. Default value for this flag is true, but when set to false, concurrency checks wont be enabled on the tables. 
- Added a local conf for using the test flag, which is included in snappy.local.conf
- Added a separate local conf for transaction tests to have Snapshot Isolation disabled only in rowStore transaction bts.

## Patch testing

Ran tests from rowStore.

