### PR TITLE
Fixing precheckin failure caused due to locale properties file was no…

### DIFF
--- a/gemfirexd/client/build.gradle
+++ b/gemfirexd/client/build.gradle
@@ -59,6 +59,7 @@ compileJava {
 archivesBaseName = 'snappydata-store-client'
 
 jar {
+  dependsOn ':gemfirexd-core:doSplit'
   baseName = 'snappydata-store-client'
   manifest {
     attributes = getManifest('gemfirexdclient', '*',
@@ -71,7 +72,7 @@ jar {
 }
 
 shadowJar {
-  dependsOn jar
+  dependsOn ':gemfirexd-core:doSplit', jar
   baseName = 'snappydata-client'
   classifier = ''
   // avoid conflict with the older incompatible thrift versions


### PR DESCRIPTION
…t getting bundled in client jar

## Changes proposed in this pull request
* Gemfirexd client was generated before generation of clientmessage.properties and hence it was not getting bundled in client jar which was causing locale issue

## Patch testing
* Ran the tests which were failing
* Precheckin in progress

## ReleaseNotes changes
NA
## Other PRs 
NA

