### PR TITLE
  [SNAP-1664] LowMemoryException during cluster restart

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
@@ -79,6 +79,7 @@ import com.gemstone.gemfire.CancelException;
 import com.gemstone.gemfire.DataSerializer;
 import com.gemstone.gemfire.SerializationException;
 import com.gemstone.gemfire.cache.*;
+import com.gemstone.gemfire.distributed.DistributedMember;
 import com.gemstone.gemfire.distributed.OplogCancelledException;
 import com.gemstone.gemfire.distributed.internal.DM;
 import com.gemstone.gemfire.i18n.LogWriterI18n;
@@ -124,6 +125,7 @@ import com.gemstone.gemfire.internal.shared.UnsupportedGFXDVersionException;
 import com.gemstone.gemfire.internal.shared.Version;
 import com.gemstone.gemfire.internal.shared.unsafe.ChannelBufferUnsafeDataInputStream;
 import com.gemstone.gemfire.internal.shared.unsafe.ChannelBufferUnsafeDataOutputStream;
+import com.gemstone.gemfire.internal.snappy.CallbackFactoryProvider;
 import com.gemstone.gemfire.internal.util.IOUtils;
 import com.gemstone.gemfire.internal.util.TransformUtils;
 import com.gemstone.gemfire.pdx.internal.PdxWriterImpl;
@@ -7376,6 +7378,17 @@ public final class Oplog implements CompactableOplog {
           diskRecoveryStores.remove(diskRegionId);
           continue;
         }
+
+        if (CallbackFactoryProvider.getStoreCallbacks().shouldStopRecovery()) {
+          System.out.println("Oplog::recoverValuesIfNeeded: stopping recovery of " +
+              diskRegionId + "as memory consumed is 90% of maxStorageSize");
+          diskRecoveryStores.remove(diskRegionId);
+          this.logger.info(LocalizedStrings.ONE_ARG,
+              "Oplog::recoverValuesIfNeeded: stopping recovery of " +
+                  diskRegionId + "as memory consumed is 90% of maxStorageSize");
+          continue;
+        }
+
         synchronized(diskEntry) {
           //Make sure the entry hasn't been modified
           if(diskEntry.getDiskId() != null && diskEntry.getDiskId().getOplogId() == oplogId) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
@@ -7380,8 +7380,6 @@ public final class Oplog implements CompactableOplog {
         }
 
         if (CallbackFactoryProvider.getStoreCallbacks().shouldStopRecovery()) {
-          System.out.println("Oplog::recoverValuesIfNeeded: stopping recovery of " +
-              diskRegionId + "as memory consumed is 90% of maxStorageSize");
           diskRecoveryStores.remove(diskRegionId);
           this.logger.info(LocalizedStrings.ONE_ARG,
               "Oplog::recoverValuesIfNeeded: stopping recovery of " +

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
@@ -141,6 +141,11 @@ public abstract class CallbackFactoryProvider {
     }
 
     @Override
+    public boolean shouldStopRecovery() {
+      return false;
+    }
+
+    @Override
     public long getOffHeapMemory(String objectName) {
       return 0L;
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
@@ -84,6 +84,8 @@ public interface StoreCallbacks {
   long getExecutionPoolUsedMemory(boolean offHeap);
   long getExecutionPoolSize(boolean offHeap);
 
+  boolean shouldStopRecovery();
+
   /**
    * Get the number of bytes used for off-heap storage for given object name.
    */


### PR DESCRIPTION
## Changes proposed in this pull request
  When recovery was in progress it occupied almost all the off-heap memory available.
  Also during recovery we use a temp UMM which has its limit set from defaults.
  Also it can not do any eviction.But a side effect of exhausting all off-heap memory
  in recovery is other messaging are not able to get any memory and restart hangs

## Patch testing

manual

## ReleaseNotes changes

NA

## Other PRs 

na
