### PR TITLE
SNAP-1651

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/store/ManagedDirectBufferAllocator.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/store/ManagedDirectBufferAllocator.java
@@ -63,11 +63,7 @@ public final class ManagedDirectBufferAllocator extends DirectBufferAllocator {
       "SNAPPYDATA_DIRECT_STORE_OBJECTS";
 
   public static final String DIRECT_STORE_DATA_FRAME_OUTPUT =
-      "DIRECT_STORE_DATA_FRAME_OUTPUT";
-
-  public static final List<String> nonEvictingOwners = new ArrayList<String>() {{
-    add(DIRECT_STORE_DATA_FRAME_OUTPUT);
-  }};
+      "DIRECT_" + STORE_DATA_FRAME_OUTPUT;
 
   public static ManagedDirectBufferAllocator instance() {
     return instance;

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/BufferAllocator.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/BufferAllocator.java
@@ -26,6 +26,9 @@ import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder;
  */
 public abstract class BufferAllocator implements Closeable {
 
+  public static final String STORE_DATA_FRAME_OUTPUT =
+      "STORE_DATA_FRAME_OUTPUT";
+
   /**
    * Allocate a new ByteBuffer of given size.
    */


### PR DESCRIPTION
## Changes proposed in this pull request

Patch From @sumwale

This PR combines the fixes for the two issues:

a) the OOME with large aggregates: new property "snappydata.hashAggregateSize" which is expressed as a string with b/k/m/g units. Kishor, when running with this (hopefully checked in when you run) then do not need the separate patch (the one titled 1651). Set the property to something like 4g: "snappydata.hashAggregateSize=4g"
b) SNAP-1651: it now reads spark driver size and estimates the maximum size to use for a partition result allowing eviction till that point. Rishi, I have removed the array of nonEvictingOwners and added a specific check for partition result to indicate that the workaround only works for partition result (because it applies a specific size limit for eviction and not zero eviction). Also have applied the same to the heap byte[] created at the end because that too can fail with LME frequently.

## Patch testing

Manual testing. Running precheckin.

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/636