### PR TITLE
Check added to skip entries from LRUlist which are not in memory.

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskLRURegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskLRURegionEntry.java
@@ -39,8 +39,8 @@ public abstract class AbstractDiskLRURegionEntry
   }
 
   @Override
-  public Object getValue() {
-    return super._getValue();
+  public boolean isValueNull() {
+    return super.isValueNull();
   }
   
   /////////////////////////////////////////////////////////////

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskLRURegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskLRURegionEntry.java
@@ -37,6 +37,11 @@ public abstract class AbstractDiskLRURegionEntry
   protected AbstractDiskLRURegionEntry(RegionEntryContext context, Object value) {
     super(context, value);
   }
+
+  @Override
+  public Object getValue() {
+    return super._getValue();
+  }
   
   /////////////////////////////////////////////////////////////
   /////////////////////////// fields //////////////////////////

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractLRURegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractLRURegionEntry.java
@@ -38,6 +38,12 @@ public abstract class AbstractLRURegionEntry
   protected AbstractLRURegionEntry(RegionEntryContext context, Object value) {
     super(context, value);
   }
+
+  @Override
+  public Object getValue() {
+    super.getValueInVM(null);
+    return super._getValue();
+  }
  
   /////////////////////////////////////////////////////////////
   /////////////////////////// fields //////////////////////////

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractLRURegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractLRURegionEntry.java
@@ -41,7 +41,6 @@ public abstract class AbstractLRURegionEntry
 
   @Override
   public Object getValue() {
-    super.getValueInVM(null);
     return super._getValue();
   }
  

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractLRURegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractLRURegionEntry.java
@@ -40,8 +40,8 @@ public abstract class AbstractLRURegionEntry
   }
 
   @Override
-  public Object getValue() {
-    return super._getValue();
+  public boolean isValueNull() {
+    return super.isValueNull();
   }
  
   /////////////////////////////////////////////////////////////

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/lru/LRUClockNode.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/lru/LRUClockNode.java
@@ -80,5 +80,9 @@ public interface LRUClockNode {
   public void resetRefCount(NewLRUClockHand lruList);
   */
 
+  /**
+   * Get in memory value for this node.
+   * @return value of this entry
+   */
   public Object getValue();
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/lru/LRUClockNode.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/lru/LRUClockNode.java
@@ -79,4 +79,6 @@ public interface LRUClockNode {
    *
   public void resetRefCount(NewLRUClockHand lruList);
   */
+
+  public Object getValue();
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/lru/LRUClockNode.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/lru/LRUClockNode.java
@@ -81,8 +81,8 @@ public interface LRUClockNode {
   */
 
   /**
-   * Get in memory value for this node.
-   * @return value of this entry
+   * Is the in-memory value for this node is null
+   * @return true or false
    */
-  public Object getValue();
+  public boolean isValueNull();
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/lru/NewLRUClockHand.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/lru/NewLRUClockHand.java
@@ -253,7 +253,7 @@ public NewLRUClockHand(Object region, EnableLRU ccHelper,
       // faultIn is in process
       // TODO Remove SnappyStore check after 0.9 . Added this check to
       // reduce regression cycles
-      if (snappyStore && (aNode.getValue() == null || aNode.testEvicted())) {
+      if (snappyStore && (aNode.isValueNull()|| aNode.testEvicted())) {
         if (debug) {
           logWriter
               .info(LocalizedStrings.NewLRUClockHand_DISCARDING_EVICTED_ENTRY);
@@ -486,8 +486,8 @@ public NewLRUClockHand(Object region, EnableLRU ccHelper,
     }
 
     @Override
-    public Object getValue() {
-      return null;
+    public boolean isValueNull() {
+      return false; // Guard nodes can never be null
     }
   }
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/lru/NewLRUClockHand.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/lru/NewLRUClockHand.java
@@ -28,6 +28,7 @@ import com.gemstone.gemfire.internal.cache.PartitionedRegion;
 import com.gemstone.gemfire.internal.cache.locks.ExclusiveSharedSynchronizer;
 import com.gemstone.gemfire.internal.cache.PlaceHolderDiskRegion;
 import com.gemstone.gemfire.internal.cache.versions.RegionVersionVector;
+import com.gemstone.gemfire.internal.snappy.CallbackFactoryProvider;
 
 
 /**
@@ -57,6 +58,9 @@ public static final boolean debug = Boolean.getBoolean("gemfire.verbose-lru-cloc
 public static LogWriterI18n logWriter;
 
 static private final int maxEntries;
+
+private boolean snappyStore =
+    CallbackFactoryProvider.getStoreCallbacks().isSnappyStore();
 
 static {
   String squelch = System.getProperty("gemfire.lru.maxSearchEntries");
@@ -244,6 +248,18 @@ public NewLRUClockHand(Object region, EnableLRU ccHelper,
         continue;
       }
 
+      // Checking whether this entry is outside lock ,
+      // so that we won;t attempt to evict an entry whose
+      // faultIn is in process
+      // TODO Remove SnappyStore check after 0.9 . Added this check to
+      // reduce regression cycles
+      if (snappyStore && (aNode.getValue() == null || aNode.testEvicted())) {
+        if (debug) {
+          logWriter
+              .info(LocalizedStrings.NewLRUClockHand_DISCARDING_EVICTED_ENTRY);
+        }
+        continue;
+      }
       // If this Entry is part of a transaction, skip it since
       // eviction should not cause commit conflicts
       synchronized (aNode) {
@@ -467,6 +483,11 @@ public NewLRUClockHand(Object region, EnableLRU ccHelper,
 
     public int getState() {
       return 0;
+    }
+
+    @Override
+    public Object getValue() {
+      return null;
     }
   }
 }

--- a/gemfire-junit/src/main/java/com/gemstone/gemfire/internal/cache/lru/LRUClockTest.java
+++ b/gemfire-junit/src/main/java/com/gemstone/gemfire/internal/cache/lru/LRUClockTest.java
@@ -367,8 +367,8 @@ public class LRUClockTest extends junit.framework.TestCase {
     }
 
     @Override
-    public Object getValue() {
-      return null;
+    public boolean isValueNull() {
+      return false;
     }
 
     public void setInList() {

--- a/gemfire-junit/src/main/java/com/gemstone/gemfire/internal/cache/lru/LRUClockTest.java
+++ b/gemfire-junit/src/main/java/com/gemstone/gemfire/internal/cache/lru/LRUClockTest.java
@@ -366,6 +366,11 @@ public class LRUClockTest extends junit.framework.TestCase {
       return 0;
     }
 
+    @Override
+    public Object getValue() {
+      return null;
+    }
+
     public void setInList() {
       inList = true;
     }


### PR DESCRIPTION
## Changes proposed in this pull request
Check added to skip entries from LRUlist which are not in memory.

When column batch iterations happen it tries to fault in values from disk if they are evicted or not yet in memory because of server restart. The faultIn thread accesses UMM and similarly, other threads might be evicting entries from LRU list. If they happen to work one same region entry it creates a deadlock for region entry object lock.

Removing entries which are not yet in memory from possible LRU candidate solves this issue. 

## Patch testing

precheckin (TODO)

## ReleaseNotes changes
NA

## Other PRs 

NA
