### PR TITLE
[SNAP-1541] use separate thread for bucket redundancy recovery

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PRHARedundancyProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PRHARedundancyProvider.java
@@ -129,7 +129,7 @@ public class PRHARedundancyProvider
     this.prRegion = region;
     final InternalResourceManager resourceManager = region.getGemFireCache()
     .getResourceManager();
-    recoveryExecutor = new OneTaskOnlyExecutor(resourceManager.getExecutor(),
+    recoveryExecutor = new OneTaskOnlyExecutor(resourceManager.getRecoveryExecutor(),
         new OneTaskOnlyExecutor.ConflatedTaskListener() {
           public void taskDropped() {
             InternalResourceManager.getResourceObserver().recoveryConflated(region);
@@ -1930,7 +1930,7 @@ public class PRHARedundancyProvider
       Runnable task = new CreateMissingBucketsTask(this);
       final InternalResourceManager resourceManager = this.prRegion
           .getGemFireCache().getResourceManager();
-      resourceManager.getExecutor().submit(task);
+      resourceManager.getRecoveryExecutor().submit(task);
     }
   }
   

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -1723,20 +1723,27 @@ public class GfxdSystemProcedures extends SystemProcedures {
     }
   }
 
+  private static void assignBucketsToPartitions(PartitionedRegion pr) {
+    int numBuckets = pr.getTotalNumberOfBuckets();
+    for (int i = 0; i < numBuckets; i++) {
+      // this method will return quickly if the bucket already exists
+      pr.createBucket(i, 0, null);
+    }
+  }
+
   private static void CREATE_ALL_BUCKETS_INTERNAL(LocalRegion region,
       String tableName) throws SQLException {
     if (region.getAttributes().getPartitionAttributes() != null) {
       // force creation of all buckets in the region
-      // final PartitionedRegion pr = (PartitionedRegion)region;
       try {
-        PartitionRegionHelper.assignBucketsToPartitions(region);
+        assignBucketsToPartitions((PartitionedRegion)region);
         GfxdIndexManager indexManager = (GfxdIndexManager) region.getIndexUpdater();
         if (indexManager != null) {
           List<GemFireContainer> indexContainers = indexManager.getIndexContainers();
             if (indexContainers != null) {
               for (GemFireContainer indexContainer : indexContainers) {
                 if (indexContainer.isGlobalIndex()) {
-                  PartitionRegionHelper.assignBucketsToPartitions(indexContainer.getRegion());
+                  assignBucketsToPartitions((PartitionedRegion)indexContainer.getRegion());
                 }
               }
             }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/ConstraintConstantAction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/ConstraintConstantAction.java
@@ -44,6 +44,7 @@ package com.pivotal.gemfirexd.internal.impl.sql.execute;
 import java.util.Set;
 
 import com.gemstone.gemfire.internal.cache.BucketAdvisor;
+import com.gemstone.gemfire.internal.cache.ColocationHelper;
 import com.gemstone.gemfire.internal.cache.PartitionedRegion;
 import com.gemstone.gemfire.internal.cache.PartitionedRegion.RecoveryLock;
 import com.gemstone.gemfire.internal.cache.partitioned.RegionAdvisor;
@@ -274,7 +275,8 @@ public abstract class ConstraintConstantAction extends DDLSingleTableConstantAct
 			
 			if(partitionColIndexInRefKeyForSelectiveCheck != null && !tc.skipLocks()) {
 			      //Take region lock so that no rebalance occurs during constraint check
-			      RecoveryLock recoveryLock = refTablePR.getRecoveryLock();
+			      RecoveryLock recoveryLock = ColocationHelper.getLeaderRegion(refTablePR)
+			          .getRecoveryLock();
 			      recoveryLock.lock();
 			      //check if all the hosted buckets have primary
 			      int bucketIDWithNoPrimary = checkIfAllHostedBucketsHavePrimary(refTablePR);


### PR DESCRIPTION
## Changes proposed in this pull request

- long waits/hangs in bucket creation are due to the following sequence (or variants):
  - CREATE_ALL_BUCKETS acquires the recovery lock and waits for primary election of child table
  - meanwhile a node schedules redundancy recovery or CreateMissingBuckets for the child table
  - this sends a FetchPartitionDetails message to other node which again starts waiting
    for primary election
  - since the recovery/rebalance thread is only one, so no primary election is possible
    until the redundancy recovery thread ends the run and the thread becomes available
- now using a separate thread for background RedundancyRecovery and CreateMissingBuckets
  tasks while others keep using the ResourceManagerRecoveryThread as before
- avoid any recovery lock for CREATE_ALL_BUCKETS since it is not really required and
  causes unnecessary waits in primary election
- use leader region recovery lock (instead of own) for TRUNCATE and constraint creation;
  also ensure that the recovery lock is always released if it was taken for TRUNCATE regardless
  of whether the TRUNCATE operation itself was committed or rolled back

## Patch testing

precheckin, manual runs of cluster dunits that were having occasionally hangs

## ReleaseNotes changes

NA

## Other PRs 

NA