### PR TITLE
[SNAP-788] initialize buckets of a new table in parallel

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/CancelCriterion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/CancelCriterion.java
@@ -36,21 +36,6 @@ public abstract class CancelCriterion
 //    * <p>
 //    * In particular, a {@link DistributionManager} returns a non-null result if
 //    * message distribution has been terminated.
-  
-  /**
-   * Use this utility  function in your implementation of cancelInProgress()
-   * and cancelled() to indicate a system failure
-   * 
-   * @return failure string if system failure has occurred
-   */
-  protected final String checkFailure() {
-    Throwable tilt = SystemFailure.getFailure();
-    if (tilt != null) {
-      // Allocate no objects here!
-      return SystemFailure.JVM_CORRUPTION;
-    }
-    return null;
-  }
 
   /**
    * See if the current operation is being cancelled.  If so, it either

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DM.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DM.java
@@ -293,7 +293,7 @@ public interface DM extends ReplySender {
   /**
    * Return the function message-processing executor 
    */
-  public Executor getFunctionExcecutor();
+  public ExecutorService getFunctionExcecutor();
 
   /**
    * gets this distribution manager's message-processing executor

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionManager.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionManager.java
@@ -75,6 +75,7 @@ import com.gemstone.gemfire.distributed.internal.membership.MemberAttributes;
 import com.gemstone.gemfire.distributed.internal.membership.MemberFactory;
 import com.gemstone.gemfire.distributed.internal.membership.MembershipManager;
 import com.gemstone.gemfire.distributed.internal.membership.NetView;
+import com.gemstone.gemfire.distributed.internal.membership.jgroup.JGroupMember;
 import com.gemstone.gemfire.i18n.LogWriterI18n;
 import com.gemstone.gemfire.internal.Assert;
 import com.gemstone.gemfire.internal.LogWriterImpl;
@@ -790,8 +791,6 @@ public final class DistributionManager
     }
     @Override
     public String cancelInProgress() {
-      checkFailure();
-
       // remove call to validateDM() to fix bug 38356
       
       if (dm.shutdownMsgSent) {
@@ -1537,7 +1536,7 @@ public final class DistributionManager
     StringBuffer sb = new StringBuffer();
     Object leadObj = v.getLeadMember();
     InternalDistributedMember lead = leadObj==null? null
-                            : new InternalDistributedMember(v.getLeadMember());
+                            : new InternalDistributedMember((JGroupMember)v.getLeadMember());
     sb.append("[");
     Iterator it = v.iterator();
     while (it.hasNext()) {
@@ -4354,7 +4353,7 @@ public final class DistributionManager
    * Return the function message-processing executor 
    */
   @Override
-  public Executor getFunctionExcecutor() {
+  public ExecutorService getFunctionExcecutor() {
     if (this.functionExecutionThread != null) {
       return this.functionExecutionThread;
     } else {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/InternalDistributedSystem.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/InternalDistributedSystem.java
@@ -1024,7 +1024,6 @@ public final class InternalDistributedSystem
   protected final class Stopper extends CancelCriterion {
     @Override
     public String cancelInProgress() {
-      checkFailure();
       if (dm == null) {
         return "No dm";
       }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/LonerDistributionManager.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/LonerDistributionManager.java
@@ -285,7 +285,7 @@ public class LonerDistributionManager implements DM {
   }
 
   @Override
-  public Executor getFunctionExcecutor() {
+  public ExecutorService getFunctionExcecutor() {
     return executor;
   }
 
@@ -765,7 +765,6 @@ public class LonerDistributionManager implements DM {
 
     @Override
     public String cancelInProgress() {
-      checkFailure();
       return null;
     }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -592,7 +592,6 @@ public class LocalRegion extends AbstractRegion
       // ---
       // This grossness is necessary because there are instances where the
       // region can exist without having a cache (XML creation)
-      checkFailure();
       Cache c = LocalRegion.this.getCache();
       if (c == null) {
         return LocalizedStrings.LocalRegion_THE_CACHE_IS_NOT_AVAILABLE.toLocalizedString();
@@ -609,7 +608,6 @@ public class LocalRegion extends AbstractRegion
       // ---
       // This grossness is necessary because there are instances where the
       // region can exist without having a cache (XML creation)
-      checkFailure();
       Cache c = LocalRegion.this.getCache();
       if (c == null) {
         return new CacheClosedException("No cache", e);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionDataStore.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionDataStore.java
@@ -140,7 +140,7 @@ public final class PartitionedRegionDataStore implements HasCachePerfStats
    * Keys are instances of {@link Integer}.
    * Values are instances of (@link BucketRegion}.
    */
-  final ConcurrentMap<Integer, BucketRegion> localBucket2RegionMap;
+  final ConcurrentHashMap<Integer, BucketRegion> localBucket2RegionMap;
 
   /**
    * A counter of the number of concurrent bucket creates in progress on
@@ -296,17 +296,13 @@ public final class PartitionedRegionDataStore implements HasCachePerfStats
    * The result of this method is not stable.
    */
   public int getNumberOfPrimaryBucketsManaged() {
-    final AtomicInteger numPrimaries = new AtomicInteger();
-    visitBuckets(new BucketVisitor() {
-      @Override
-      public void visit(Integer bucketId, Region r) {
-        BucketRegion br = (BucketRegion) r;
-        if (br.getBucketAdvisor().isPrimary()) {
-          numPrimaries.incrementAndGet();
-        }
+    int numPrimaries = 0;
+    for (BucketRegion br : localBucket2RegionMap.values()) {
+      if (br.getBucketAdvisor().isPrimary()) {
+        numPrimaries++;
       }
-    });
-    return numPrimaries.get();
+    }
+    return numPrimaries;
   }
 
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/SingleWriteSingleReadRegionQueue.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/SingleWriteSingleReadRegionQueue.java
@@ -1121,7 +1121,6 @@ public class SingleWriteSingleReadRegionQueue implements RegionQueue
     protected class Stopper extends CancelCriterion {
       @Override
       public String cancelInProgress() {
-        checkFailure();
         GemFireCacheImpl gfc = SingleReadWriteMetaRegion.this.getCache();
         assert gfc!=null;
 


### PR DESCRIPTION
## Changes proposed in this pull request

- use function execution pool to schedule parallel tasks for CREATE_ALL_BUCKETS
  that is used standard by SnappyData
- removed contention in PRHARedundancyProvider.createBucketAtomically to use bucket
  specific lock and not global lock; not using lock on ProxyBucketRegion since it
  leads to deadlock with CreateMissingBuckets task that too locks PBR first and
  then waits for primary of the bucket
- other optimizations seen to take high CPU in bucket creation:
  - InternalDistributedMember.equals shows up at 25-30% CPU. This is due to large
    hash collisions and equals being somewhat inefficient. Now using the new
    hash mixing functions (from SnappyData) to combine port and InetAddress.
    Also optimized equals itself a bit by removing virtual calls etc.
  - checkCancelInProgress shows at ~10%: removed checkFailure() which actually
    returns the failure and does not fail (callers never check return value);
    since this is already invoked in SystemFailure.checkFailure() it is both
    redundant and unused.

With above changes creation of a table with even 5K buckets and redundancy=1
in a 12 node cluster takes < 20s (as opposed to minutes).

## Patch testing

precheckin, manual testing

## ReleaseNotes changes

NA

## Other PRs 

NA