### PR TITLE
Avoid qinfo creation for internal queries of smart connector executors.

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
@@ -653,8 +653,8 @@ public class GenericStatement
 				  StringBuilder queryTextForStats = null;
 				  boolean continueLoop = true;
 			    int i = 0;
-          boolean forceSkipQueryInfoCreation = Misc.getMemStore().isSnappyStore()
-            && lcc.getBucketIdsForLocalExecution() != null;
+			    boolean forceSkipQueryInfoCreation = Misc.getMemStore().isSnappyStore()
+					  && lcc.getBucketIdsForLocalExecution() != null;
 			    while (continueLoop) {
 			      i++;
 			      continueLoop = false;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
@@ -653,8 +653,8 @@ public class GenericStatement
 				  StringBuilder queryTextForStats = null;
 				  boolean continueLoop = true;
 			    int i = 0;
-          boolean forceSkipQueryInfoCreation = (Misc.getMemStore().isSnappyStore()
-            && lcc.getBucketIdsForLocalExecution() != null) ? true : false;
+          boolean forceSkipQueryInfoCreation = Misc.getMemStore().isSnappyStore()
+            && lcc.getBucketIdsForLocalExecution() != null;
 			    while (continueLoop) {
 			      i++;
 			      continueLoop = false;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
@@ -653,7 +653,8 @@ public class GenericStatement
 				  StringBuilder queryTextForStats = null;
 				  boolean continueLoop = true;
 			    int i = 0;
-			    boolean forceSkipQueryInfoCreation = false;
+          boolean forceSkipQueryInfoCreation = (Misc.getMemStore().isSnappyStore()
+            && lcc.getBucketIdsForLocalExecution() != null) ? true : false;
 			    while (continueLoop) {
 			      i++;
 			      continueLoop = false;


### PR DESCRIPTION
Fixes SNAP-1699.

## Changes proposed in this pull request

Since the smart connector executor set the bucket list in such a way that they will be found locally and also internally remote iterator happens if the bucket got migrated to some where else so ne need to create gemfire activation for these queries. So avoiding qinfo creation to use derby execution itself.

## Patch testing

ct.bt showing very slow execution of queries in smart connector are faster with this change now. 

## ReleaseNotes changes

None.

## Other PRs 

None.