### PR TITLE
Fix for SNAP-1742

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionAdvisor.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionAdvisor.java
@@ -1383,24 +1383,17 @@ public class DistributionAdvisor  {
       getLogWriter().fine("Intelligent Messaging Disabled");
       return getDefaultDistributionMembers();
     }
-    THashSet recipients = null;
+    THashSet recipients = new THashSet(4);
     Profile[] locProfiles = this.profiles; // grab current profiles
 //    getLogWriter().fine("adviseFilter: " + locProfiles.length + " to consider, f=" + f);
     for (int i = 0; i < locProfiles.length; i++) {
       Profile profile = locProfiles[i];
 //      getLogWriter().fine("adviseFilter; considering " + profile);
       if (f == null || f.include(profile)) {
-        if (recipients == null) {
-          recipients = new THashSet();
-        }
         recipients.add(profile.getDistributedMember());
       }
     }
-    if (recipients == null) {
-      return Collections.emptySet();
-    } else {
-      return recipients;
-    }
+    return recipients;
   }
 
   /**

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BridgeServerAdvisor.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BridgeServerAdvisor.java
@@ -31,7 +31,6 @@ import com.gemstone.gemfire.distributed.internal.DistributionManager;
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
 import com.gemstone.gemfire.i18n.LogWriterI18n;
 import com.gemstone.gemfire.internal.InternalDataSerializer;
-import com.gemstone.gnu.trove.THashSet;
 
 
 /**

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BridgeServerAdvisor.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BridgeServerAdvisor.java
@@ -31,6 +31,7 @@ import com.gemstone.gemfire.distributed.internal.DistributionManager;
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
 import com.gemstone.gemfire.i18n.LogWriterI18n;
 import com.gemstone.gemfire.internal.InternalDataSerializer;
+import com.gemstone.gnu.trove.THashSet;
 
 
 /**
@@ -66,7 +67,8 @@ public class BridgeServerAdvisor extends GridAdvisor {
 
   @Override
   public Set adviseProfileRemove() {
-    Set results = super.adviseProfileRemove();
+    Set results = new THashSet();
+    results.addAll(super.adviseProfileRemove());
     // Add other members as recipients which are neither locators nor running netservers,
     // if this is a snappy node. This could be helpful if a Spark Driver process is
     // connected as a peer to this DS in split-cluster mode. SNAP-737

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BridgeServerAdvisor.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BridgeServerAdvisor.java
@@ -67,8 +67,7 @@ public class BridgeServerAdvisor extends GridAdvisor {
 
   @Override
   public Set adviseProfileRemove() {
-    Set results = new THashSet();
-    results.addAll(super.adviseProfileRemove());
+    Set results = super.adviseProfileRemove();
     // Add other members as recipients which are neither locators nor running netservers,
     // if this is a snappy node. This could be helpful if a Spark Driver process is
     // connected as a peer to this DS in split-cluster mode. SNAP-737


### PR DESCRIPTION
SNAP-1742
UnsupportedOperationException in server during cluster shutdown and restarting of cluster fails after locator failover. Looking at the stacktrace, DistributionAdvisor#adviseFilter can return an immutable empty set (line 114). This will lead to UnsupportedOperationException in BridgeServerAdvisor.adviseProfileRemove when other members are tried to be added in this set. 

## Patch testing
tested with nwColumnTablesTestWithLocatorHA hydra test. Bug not seen after the change.
Snappy precheckin

## ReleaseNotes changes
Not applicable
## Other PRs 
Not applicable

