### PR TITLE
If the root project is snappydata then use the version of snappydata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ allprojects {
 
     if (rootProject.name == 'snappy-store') {
       subprojectBase = ':'
+      version = PRODUCT_VERSION
     } else {
       subprojectBase = ':snappy-store:'
       // gitCmd = "git --git-dir=${project(':snappy-store').projectDir}/.git --work-tree=${project(':snappy-store').projectDir}"
@@ -142,7 +143,6 @@ allprojects {
   }
 
   group = 'io.snappydata'
-  version = PRODUCT_VERSION
 
   apply plugin: 'java'
   apply plugin: 'maven'


### PR DESCRIPTION
as the product version.

## Changes proposed in this pull request

So the version is already assigned as snappydata's version in the base build.gradle, so overriding it with store version only when the root project is store itself and not snappydata. 

## Patch testing

Manual testing.

## ReleaseNotes changes

None.

## Other PRs 

None.