### PR TITLE
Fix to throw proper exception while inserting into column table

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/ResultColumnList.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/ResultColumnList.java
@@ -4116,7 +4116,7 @@ public class ResultColumnList extends QueryTreeNodeVector
 				}else{
 					if(cd.isAutoincAlways()){
 						GemFireStore ms = Misc.getMemStore();
-						if (ms != null && ms.isSnappyStore() && sourceRSRCL.size() == size) {
+						if (ms.isSnappyStore() && sourceRSRCL.size() == size) {
 						  TableDescriptor td = cd.getTableDescriptor();
 						  if (td != null && ms.getExternalCatalog().isColumnTable(
 						    td.getSchemaName(), td.getName(), true)) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/ResultColumnList.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/ResultColumnList.java
@@ -47,6 +47,8 @@ import java.util.Hashtable;
 import java.util.Vector;
 
 import com.pivotal.gemfirexd.internal.catalog.types.DefaultInfoImpl;
+import com.pivotal.gemfirexd.internal.engine.Misc;
+import com.pivotal.gemfirexd.internal.engine.store.GemFireStore;
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
 import com.pivotal.gemfirexd.internal.iapi.reference.ClassName;
 import com.pivotal.gemfirexd.internal.iapi.reference.SQLState;
@@ -4113,6 +4115,14 @@ public class ResultColumnList extends QueryTreeNodeVector
 
 				}else{
 					if(cd.isAutoincAlways()){
+						GemFireStore ms = Misc.getMemStore();
+						if (ms != null && ms.isSnappyStore() && sourceRSRCL.size() == size) {
+						  TableDescriptor td = cd.getTableDescriptor();
+						  if (td != null && ms.getExternalCatalog().isColumnTable(
+						    td.getSchemaName(), td.getName(), true)) {
+						      throw StandardException.newException(SQLState.LANG_DB2_INVALID_COLS_SPECIFIED);
+						  }
+						}
 						throw StandardException.newException(SQLState.LANG_AI_CANNOT_MODIFY_AI,
 									rc.getName());
 					}


### PR DESCRIPTION
The exception thrown does not tell what the real problem is. When the num of elements is exactly one more than the schema width this happens. This is because the store engine thinks that the attempt is to modify the internally generated ROWID column.

## Changes proposed in this pull request

Just check if it column table of snappydata and throw the error accordingly.

## Patch testing

unit test added. https://github.com/SnappyDataInc/snappydata/pull/690

## ReleaseNotes changes

No.

## Other PRs 

None.
