### PR TITLE
Fix windows dll gradle build

### DIFF
--- a/native/build.gradle
+++ b/native/build.gradle
@@ -246,8 +246,12 @@ if ((rootProject.name.contains('native') && !rootProject.hasProperty('skipNative
             // explicitly include UCRT since its still not passed through by gradle
             String VS_2015_INCLUDE_DIR = 'C:/Program Files (x86)/Windows Kits/10/Include/10.0.10240.0/ucrt'
             String VS_2015_LIB_DIR = 'C:/Program Files (x86)/Windows Kits/10/Lib/10.0.10240.0/ucrt'
+            String VS_2015_INCLUDE_DIR_UM = 'C:/Program Files (x86)/Windows Kits/10/Include/10.0.10240.0/um'
+            String VS_2015_LIB_DIR_UM = 'C:/Program Files (x86)/Windows Kits/10/Lib/10.0.10240.0/um'
+            String VS_2015_INCLUDE_DIR_SHARED = 'C:/Program Files (x86)/Windows Kits/10/Include/10.0.10240.0/shared'
             cppCompiler.args '/W3', '/FS', '/Zc:inline', '/WX', '/EHsc',
                              '/Fdsnappyclient.pdb', '/errorReport:prompt',
+                             "/I${VS_2015_INCLUDE_DIR_UM}", "/I${VS_2015_INCLUDE_DIR_SHARED}",
                              "/I${VS_2015_INCLUDE_DIR}"
             if (buildType == buildTypes.debug) {
               cppCompiler.define '_DEBUG'
@@ -257,9 +261,9 @@ if ((rootProject.name.contains('native') && !rootProject.hasProperty('skipNative
               cppCompiler.args '/O2', '/GL', '/Oi', '/Gm-', '/Zi', '/MD'
             }
             if (targetPlatform == platforms.x64) {
-              linker.args "/LIBPATH:${VS_2015_LIB_DIR}/x64"
+              linker.args "/LIBPATH:${VS_2015_LIB_DIR}/x64:${VS_2015_LIB_DIR_UM}/x64"
             } else {
-              linker.args "/LIBPATH:${VS_2015_LIB_DIR}/x86"
+              linker.args "/LIBPATH:${VS_2015_LIB_DIR}/x86:${VS_2015_LIB_DIR_UM}/x86"
             }
           }
         }


### PR DESCRIPTION
## Changes proposed in this pull request

While trying to do a windows gradle build on my newly configured laptop (OS/libraries/SDKs/Visual Studio) there were the following three errors:

1. Include winsock2.h not found.
2. Include file winapifamily.h not found.
3. Link library file odbccp32.lib not found.

This was despite installing everything under the sun on my fresh windows VM, so finally concluded that this change was necessary to fix the build.

## Patch testing

Fresh gradle build passed after this change.

## ReleaseNotes changes

N/A

## Other PRs 

https://github.com/SnappyDataInc/snappy-odbc/pull/2 depends on this change.
