### PR TITLE
SNAP-1808 Create cachedbatch tables in user's schema instead of SNAPPYSYS_INTERNAL

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
@@ -45,6 +45,11 @@ public abstract class CallbackFactoryProvider {
     }
 
     @Override
+    public boolean isColumnTable(String qualifiedName) {
+      return false;
+    }
+
+    @Override
     public int getHashCodeSnappy(Object dvd, int numPartitions) {
       throw new UnsupportedOperationException("unexpected invocation for "
           + toString());
@@ -58,12 +63,6 @@ public abstract class CallbackFactoryProvider {
 
     @Override
     public String columnBatchTableName(String tableName) {
-      throw new UnsupportedOperationException("unexpected invocation for "
-          + toString());
-    }
-
-    @Override
-    public String snappyInternalSchemaName() {
       throw new UnsupportedOperationException("unexpected invocation for "
           + toString());
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
@@ -38,13 +38,13 @@ public interface StoreCallbacks {
 
   List<String> getInternalTableSchemas();
 
+  boolean isColumnTable(String qualifiedName);
+
   int getHashCodeSnappy(Object dvd, int numPartitions);
 
   int getHashCodeSnappy(Object dvds[], int numPartitions);
 
   public String columnBatchTableName(String tableName);
-
-  public String snappyInternalSchemaName();
 
   void registerRelationDestroyForHiveStore();
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/tools/sizer/ObjectSizer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/tools/sizer/ObjectSizer.java
@@ -996,7 +996,7 @@ public class ObjectSizer {
   }
 
   private static final Pattern columnTableRegex =
-      Pattern.compile(StoreCallbacks.SHADOW_SCHEMA_NAME + "(.*)" +
+      Pattern.compile(".*" + StoreCallbacks.SHADOW_SCHEMA_NAME + "(.*)" +
           StoreCallbacks.SHADOW_TABLE_SUFFIX);
   private Boolean isColumnTable(String fullyQualifiedTable) {
     return columnTableRegex.matcher(fullyQualifiedTable).matches();


### PR DESCRIPTION
## Changes proposed in this pull request
* Changes from Sumedh @sumwale to create the CachedBatch tables inside user's schema
  instead of in the earlier common schema named SNAPPYSYS_INTERNAL
* Fix the Catalog consistency part with the above changes.

git cherry-pick -n 9b51e3312db76ca49d7066a1bcd2c108f1e5d33a
git cherry-pick -n 81c3dec565f5e68582e66981a4a685245168cd9f
git cherry-pick -n efab3d93015118cf2e23ad5cff3a276faac2db76

Old PR https://github.com/SnappyDataInc/snappy-store/pull/239

## Patch testing
Clean precheckin

## ReleaseNotes changes
NA

## Other PRs 
https://github.com/SnappyDataInc/snappy-aqp/pull/153