### PR TITLE
Concurrency changes - Moved the releasePendingReference to the ConnectionSignaller

### DIFF
--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
@@ -324,7 +324,6 @@ public abstract class UnsafeHolder {
       cleaner.clean();
       cleaner.clear();
     }
-    releasePendingReferences();
   }
 
   public static void releasePendingReferences() {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/conn/ConnectionSignaller.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/conn/ConnectionSignaller.java
@@ -29,6 +29,7 @@ import com.gemstone.gemfire.i18n.LogWriterI18n;
 import com.gemstone.gemfire.internal.LogWriterImpl;
 import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import com.gemstone.gemfire.internal.shared.FinalizeObject;
+import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder;
 import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
@@ -239,6 +240,9 @@ public final class ConnectionSignaller extends Thread {
           break;
         }
       }
+      // This clears the pending references of the offheap.
+      // Kept this call here to avoid creating a new thread. 
+      UnsafeHolder.releasePendingReferences();
     }
     if (GemFireXDUtils.TraceConnectionSignaller) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_CONNECTION_SIGNALLER,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/conn/ConnectionSignaller.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/conn/ConnectionSignaller.java
@@ -243,7 +243,7 @@ public final class ConnectionSignaller extends Thread {
           break;
         }
       }
-     }
+    }
     if (GemFireXDUtils.TraceConnectionSignaller) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_CONNECTION_SIGNALLER,
           "thread ending.");

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/conn/ConnectionSignaller.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/conn/ConnectionSignaller.java
@@ -209,9 +209,12 @@ public final class ConnectionSignaller extends Thread {
           changeList.clear();
         }
 
+        // This clears the pending references of the offheap.
+        // Kept this call here to avoid creating a new thread.
+        UnsafeHolder.releasePendingReferences();
+
         // invoke the finalizer reference queue
         FinalizeObject.getServerHolder().invokePendingFinalizers();
-
       } catch (InterruptedException ie) {
         SystemFailure.checkFailure();
         // Some interruption other than shutdown has caused it so exit.
@@ -240,10 +243,7 @@ public final class ConnectionSignaller extends Thread {
           break;
         }
       }
-      // This clears the pending references of the offheap.
-      // Kept this call here to avoid creating a new thread. 
-      UnsafeHolder.releasePendingReferences();
-    }
+     }
     if (GemFireXDUtils.TraceConnectionSignaller) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_CONNECTION_SIGNALLER,
           "thread ending.");


### PR DESCRIPTION
## Changes proposed in this pull request

While doing jfr analysis it was realized that the releasePendingReferences call in UnsafeHolder.releaseDirectBuffer() is consuming too many CPU cycles. @sumwale has suggested that this call in UnsafeHolder.releaseDirectBuffer() can be removed and instead added to ConnectionSignaller.run() after FinalizeObject.getServerHolder().invokePendingFinalizers. 

## Patch testing

Precheckin. 

## Other PRs 
https://github.com/SnappyDataInc/spark/pull/63
https://github.com/SnappyDataInc/snappydata/pull/730
