### PR TITLE
Snap 1499 2 : Support for snapshot write operation

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegion.java
@@ -180,6 +180,8 @@ public abstract class AbstractRegion implements Region, RegionAttributes,
   
   protected volatile boolean concurrencyChecksEnabled;
 
+  protected boolean snapshotEnabledRegion;
+
   protected boolean earlyAck;
 
   protected final boolean isPdxTypesRegion;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
@@ -2262,7 +2262,7 @@ RETRY_LOOP:
         if (owner.getCache().snapshotEnabledForTX()) {
           oldRe = NonLocalRegionEntry.newEntryWithoutFaultIn(re, owner, true);
           oldRe.setUpdateInProgress(true);
-          if (shouldCopyOldEntry(owner, null) /*&& re.getVersionStamp() != null && re.getVersionStamp()
+          if (owner.snapshotEnabledRegion /*&& re.getVersionStamp() != null && re.getVersionStamp()
             .asVersionTag().getEntryVersion() > 0*/) {
             owner.getCache().addOldEntry(oldRe, re, owner, oldSize);
           }
@@ -2326,7 +2326,7 @@ RETRY_LOOP:
         }
         if (owner.getCache().snapshotEnabledForTX()) {
           oldRe = NonLocalRegionEntry.newEntryWithoutFaultIn(re, owner, true);
-          if (shouldCopyOldEntry(owner, null) /*&& re.getVersionStamp()!=null && re.getVersionStamp()
+          if (owner.snapshotEnabledRegion /*&& re.getVersionStamp()!=null && re.getVersionStamp()
             .asVersionTag().getEntryVersion()>0*/) {
             owner.getCache().addOldEntry(oldRe, re, owner, 0);
           }
@@ -3951,7 +3951,7 @@ RETRY_LOOP:
                   // check if the event is loaded from HDFS and bucket is secondary then don't set
                   
                   setOldValueInEvent(event, re, cacheWrite, requireOldValue);
-                  if (shouldCopyOldEntry(owner, event) && re.getVersionStamp() != null ) {
+                  if (owner.snapshotEnabledRegion && re.getVersionStamp() != null ) {
                     checkConflict(owner, event, re);
                   }
                   if (!continueUpdate(re, event, ifOld, replaceOnClient)) {
@@ -3975,7 +3975,7 @@ RETRY_LOOP:
                     RegionEntry oldRe = null;
                     try {
                       final int oldSize = event.getLocalRegion().calculateRegionEntryValueSize(re);
-                      if (shouldCopyOldEntry(owner, event) && re.getVersionStamp() != null ) {
+                      if (owner.snapshotEnabledRegion && re.getVersionStamp() != null ) {
                         // we need to do the same for secondary as well.
                         // need to set the version information.
                         if (re.getVersionStamp().asVersionTag().getEntryVersion() > 0) {
@@ -4141,6 +4141,8 @@ RETRY_LOOP:
   }
 
   private void checkConflict(LocalRegion owner, EntryEventImpl event, RegionEntry re) {
+    //TODO: Make it property based and return oldValue taken from OldREgionEntry if confict and not
+    // throwing conflictexception
     if (owner.isUsedForPartitionedRegionBucket() && !((BucketRegion)owner).getBucketAdvisor().isPrimary()) {
       return;
     }
@@ -4148,7 +4150,7 @@ RETRY_LOOP:
     if (event.getTXState() != null && event.getTXState().isSnapshot()) {
       TXState localState = event.getTXState().getLocalTXState();
       if(!firstEntry(re)) {
-        if (!localState.checkEntryVersion(event.getRegion(), re)) {
+        if (!TXState.checkEntryInSnapshot(localState, event.getRegion(), re)) {
           throw new ConflictException("The value has been changed.");
         }
       }
@@ -4159,10 +4161,10 @@ RETRY_LOOP:
     return (re.getVersionStamp().getEntryVersion() == 0) && re.isRemoved();
   }
 
-  private boolean shouldCopyOldEntry(LocalRegion owner, EntryEventImpl event) {
+/*  private boolean shouldCopyOldEntry(LocalRegion owner, EntryEventImpl event) {
     return owner.getCache().snapshotEnabled() &&
         owner.concurrencyChecksEnabled && !owner.isUsedForMetaRegion();
-  }
+  }*/
 
   /**
    * If the value in the VM is still REMOVED_PHASE1 Token, then the operation
@@ -4391,7 +4393,7 @@ RETRY_LOOP:
     boolean retVal = false;
     try {
       final int oldSize = _getOwner().calculateRegionEntryValueSize(re);
-      if (shouldCopyOldEntry(_getOwner(), event) /*&& re.getVersionStamp() != null && re.getVersionStamp()
+      if (_getOwner().snapshotEnabledRegion /*&& re.getVersionStamp() != null && re.getVersionStamp()
         .asVersionTag().getEntryVersion() > 0*/) {
         // we need to do the same for secondary as well.
         // check Conflict
@@ -4569,7 +4571,7 @@ RETRY_LOOP:
         // as there is a race.
         if (owner.getCache().snapshotEnabledForTX()) {
           oldRe = NonLocalRegionEntry.newEntryWithoutFaultIn(re, owner, true);
-          if (shouldCopyOldEntry(owner, null) /*&& re.getVersionStamp() != null && re.getVersionStamp()
+          if (owner.snapshotEnabledRegion /*&& re.getVersionStamp() != null && re.getVersionStamp()
             .asVersionTag().getEntryVersion() > 0*/) {
             owner.getCache().addOldEntry(oldRe, re, owner, oldSize);
           }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -653,7 +653,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
         return null;
       }
       for (RegionEntry value : entries) {
-        if (txState.checkEntryVersion(region, value)) {
+        if (TXState.checkEntryInSnapshot(txState, region, value)) {
           oldEntries.add(value);
         }
       }
@@ -721,8 +721,8 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
                 boolean entryFoundInTxState = false;
                 for (TXStateProxy txProxy : getTxManager().getHostedTransactionsInProgress()) {
                   TXState txState = txProxy.getLocalTXState();
-                  if (re.isUpdateInProgress() || (txState != null && !txState.isCommitted() && txState.checkEntryVersion
-                          (region, re))) {
+                  if (re.isUpdateInProgress() || (txState != null && !txState.isCommitted() && TXState.checkEntryInSnapshot
+                      (txState, region, re))) {
                     entryFoundInTxState = true;
                     break;
                   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -875,6 +875,8 @@ public class LocalRegion extends AbstractRegion
     }
 
     this.testCallable = internalRegionArgs.getTestCallable();
+    this.snapshotEnabledRegion = cache.snapshotEnabled() && this.concurrencyChecksEnabled
+        && !isUsedForMetaRegion;
     
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -337,7 +337,7 @@ public class LocalRegion extends AbstractRegion
   public static final ReadEntryUnderLock READ_VALUE = new ReadEntryUnderLock() {
     public final Object readEntry(final ExclusiveSharedLockObject lockObj,
         Object context, int iContext, boolean allowTombstones) {
-      return ((AbstractRegionEntry)lockObj).getValue((LocalRegion)context);
+      return ((RegionEntry)lockObj).getValue((LocalRegion)context);
     }
   };
 
@@ -345,7 +345,7 @@ public class LocalRegion extends AbstractRegion
     @Retained
     public final Object readEntry(final ExclusiveSharedLockObject lockObj,
         Object context, int iContext, boolean allowTombstones) {
-      return ((AbstractRegionEntry)lockObj)._getValueRetain((LocalRegion)context,
+      return ((RegionEntry)lockObj)._getValueRetain((LocalRegion)context,
           false);
     }
   };
@@ -353,7 +353,7 @@ public class LocalRegion extends AbstractRegion
   public static final ReadEntryUnderLock READ_TOKEN = new ReadEntryUnderLock() {
     public final Token readEntry(final ExclusiveSharedLockObject lockObj,
         Object context, int iContext, boolean allowTombstones) {
-      return ((AbstractRegionEntry)lockObj).getValueAsToken();
+      return ((RegionEntry)lockObj).getValueAsToken();
     }
   };
 
@@ -361,14 +361,14 @@ public class LocalRegion extends AbstractRegion
     public final Object readEntry(final ExclusiveSharedLockObject lockObj,
         final Object context, int iContext, boolean allowTombstones) {
       return ((LocalRegion)context)
-          .getREValueForTXRead((AbstractRegionEntry)lockObj);
+          .getREValueForTXRead((RegionEntry)lockObj);
     }
   };
 
   public static final ReadEntryUnderLock GET_VALUE = new ReadEntryUnderLock() {
     public final Object readEntry(final ExclusiveSharedLockObject lockObj,
         final Object context, int iContext, boolean allowTombstones) {
-      return ((LocalRegion)context).getEntryValue((AbstractRegionEntry)lockObj);
+      return ((LocalRegion)context).getEntryValue((RegionEntry)lockObj);
     }
   };
 
@@ -376,7 +376,7 @@ public class LocalRegion extends AbstractRegion
     public final Object readEntry(final ExclusiveSharedLockObject lockObj,
         final Object context, final int iContext, boolean allowTombstones) {
       return ((LocalRegion)context).getDeserialized(
-          (AbstractRegionEntry)lockObj, (iContext & DESER_UPDATE_STATS) != 0,
+          (RegionEntry)lockObj, (iContext & DESER_UPDATE_STATS) != 0,
           (iContext & DESER_DISABLE_COPY_ON_READ) != 0,
           (iContext & DESER_PREFER_CD) != 0);
     }
@@ -2673,7 +2673,7 @@ public class LocalRegion extends AbstractRegion
 
   protected Region.Entry<?, ?> txGetEntryForIterator(KeyInfo keyInfo,
       boolean access, final TXStateInterface tx, boolean allowTombstones) {
-    final AbstractRegionEntry re = (AbstractRegionEntry)keyInfo.getKey();
+    final RegionEntry re = (RegionEntry)keyInfo.getKey();
     return txGetEntry(re, re.getKey(), access, tx, allowTombstones);
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
@@ -47,7 +47,7 @@ import com.gemstone.gemfire.internal.offheap.OffHeapHelper;
 import com.gemstone.gemfire.internal.offheap.annotations.Released;
 import com.gemstone.gemfire.internal.shared.Version;
 
-public class NonLocalRegionEntry implements RegionEntry, VersionStamp, DataSerializable {
+public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
   protected long lastModified;
   protected boolean isRemoved;
   protected Object key;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
@@ -23,6 +23,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
+import com.gemstone.gemfire.DataSerializable;
 import com.gemstone.gemfire.DataSerializer;
 import com.gemstone.gemfire.cache.CacheWriterException;
 import com.gemstone.gemfire.cache.EntryEvent;
@@ -46,7 +47,7 @@ import com.gemstone.gemfire.internal.offheap.OffHeapHelper;
 import com.gemstone.gemfire.internal.offheap.annotations.Released;
 import com.gemstone.gemfire.internal.shared.Version;
 
-public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
+public class NonLocalRegionEntry implements RegionEntry, VersionStamp, DataSerializable {
   protected long lastModified;
   protected boolean isRemoved;
   protected Object key;
@@ -304,6 +305,9 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
   }
 
   public final Object getValue(RegionEntryContext context) {
+    if (Token.isRemoved(this.value)) {
+      return null;
+    }
     return this.value;
   }
   

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
@@ -868,8 +868,6 @@ public final class TXState implements TXStateInterface {
           throw err;
         }
         cleanEx = processCleanupException(t, cleanEx);
-      } finally {
-
       }
     }
     else {
@@ -886,11 +884,10 @@ public final class TXState implements TXStateInterface {
           throw err;
         }
         cleanEx = processCleanupException(t, cleanEx);
-      } finally {
-
       }
     }
   }
+
 
   public final void flushPendingOps(final DM dm) {
     this.proxy.flushPendingOps(dm);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
@@ -46,6 +46,8 @@ import com.gemstone.gemfire.cache.TransactionException;
 import com.gemstone.gemfire.cache.TransactionWriter;
 import com.gemstone.gemfire.cache.TransactionWriterException;
 import com.gemstone.gemfire.cache.UnsupportedOperationInTransactionException;
+import com.gemstone.gemfire.cache.query.internal.IndexUpdater;
+import com.gemstone.gemfire.cache.query.internal.index.IndexManager;
 import com.gemstone.gemfire.distributed.internal.DM;
 import com.gemstone.gemfire.distributed.internal.InternalDistributedSystem;
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
@@ -69,6 +71,7 @@ import com.gemstone.gemfire.internal.cache.versions.RegionVersionHolder;
 import com.gemstone.gemfire.internal.cache.versions.RegionVersionVector;
 import com.gemstone.gemfire.internal.cache.versions.VersionSource;
 import com.gemstone.gemfire.internal.cache.versions.VersionStamp;
+import com.gemstone.gemfire.internal.cache.versions.VersionTag;
 import com.gemstone.gemfire.internal.concurrent.ConcurrentTHashSet;
 import com.gemstone.gemfire.internal.concurrent.CustomEntryConcurrentHashMap;
 import com.gemstone.gemfire.internal.concurrent.MapCallback;
@@ -104,7 +107,9 @@ public final class TXState implements TXStateInterface {
   // in this VM.
   private final ConcurrentTHashSet<TXRegionState> regions;
 
-  private final BlockingQueue<RegionEntry> regionEntryRef = new LinkedBlockingQueue<RegionEntry>();
+  private final BlockingQueue<Object> committedEntryReference = new LinkedBlockingQueue<Object>();
+  private final BlockingQueue<RegionEntry> unCommittedEntryReference = new LinkedBlockingQueue<RegionEntry>();
+  private final BlockingQueue<LocalRegion> regionReference = new LinkedBlockingQueue<LocalRegion>();
 
   static final TXRegionState[] ZERO_REGIONS = new TXRegionState[0];
 
@@ -852,18 +857,50 @@ public final class TXState implements TXStateInterface {
     }
     // lock the TXRegionStates against GII and TXState
     lockTXRSAndTXState();
-
+    TransactionException cleanEx = null;
     final TransactionObserver observer = getObserver();
     if (observer != null) {
       observer.duringIndividualRollback(this.proxy, callbackArg);
       try {
         cleanup(false, observer);
+
       } finally {
         observer.afterIndividualRollback(this.proxy, callbackArg);
+      }
+
+      try {
+        rollBackUncommittedEntries();
+      } catch (Throwable t) {
+        Error err;
+        if (t instanceof Error && SystemFailure.isJVMFailureError(
+            err = (Error)t)) {
+          SystemFailure.initiateFailure(err);
+          // If this ever returns, rethrow the error. We're poisoned
+          // now, so don't let this thread continue.
+          throw err;
+        }
+        cleanEx = processCleanupException(t, cleanEx);
+      } finally {
+
       }
     }
     else {
       cleanup(false, null);
+      try {
+        rollBackUncommittedEntries();
+      } catch (Throwable t) {
+        Error err;
+        if (t instanceof Error && SystemFailure.isJVMFailureError(
+            err = (Error)t)) {
+          SystemFailure.initiateFailure(err);
+          // If this ever returns, rethrow the error. We're poisoned
+          // now, so don't let this thread continue.
+          throw err;
+        }
+        cleanEx = processCleanupException(t, cleanEx);
+      } finally {
+
+      }
     }
   }
 
@@ -1112,43 +1149,7 @@ public final class TXState implements TXStateInterface {
         }
       }
 
-      // No need to check for snapshot if we want to enable it for RC.
-      if (cache.snapshotEnabled()) {
-        if (isSnapshot() || cache.snapshotEnabledForTX()) {
-          // first take a lock at cache level so that we don't go into deadlock or sort array before
-          // This is for tx RC, for snapshot just record all the versions from the queue
-          cache.acquireWriteLockOnSnapshotRvv();
-          try {
-            for (VersionInformation vi : queue) {
-              if (TXStateProxy.LOG_FINE) {
-                logger.info(LocalizedStrings.DEBUG, "Recording version " + vi + " from snapshot to " +
-                    "region.");
-              }
-              ((LocalRegion)vi.region).getVersionVector().
-                  recordVersionForSnapshot((VersionSource)vi.member, vi.version, null);
-            }
-          } finally {
-            cache.releaseWriteLockOnSnapshotRvv();
-          }
-        } else {
-          // doing it for tx and non tx case.
-          // tx may not record version in snapshot so non tx reads while taking
-          // snapshot may miss it. in case of commit just copy the rvv to snapshot so that
-          // any future non tx read will get all the entries
-          cache.acquireWriteLockOnSnapshotRvv();
-          try {
-            for (TXRegionState txr : finalRegions) {
-              final LocalRegion dataRegion = txr.region;
-              final RegionVersionVector<?> rvv = dataRegion.getVersionVector();
-              if (rvv != null) {
-                rvv.reInitializeSnapshotRvv();
-              }
-            }
-          } finally {
-            cache.releaseWriteLockOnSnapshotRvv();
-          }
-        }
-      }
+      publishRecordedVersions();
       if (reuseEV) {
         cbEvent.release();
       }
@@ -1157,6 +1158,49 @@ public final class TXState implements TXStateInterface {
       }
     }
     return eventsToFree;
+  }
+
+  private void publishRecordedVersions() {
+    final TXRegionState[] finalRegions = this.finalizeRegions;
+    GemFireCacheImpl cache = GemFireCacheImpl.getExisting();
+    final LogWriterI18n logger = getTxMgr().getLogger();
+    // No need to check for snapshot if we want to enable it for RC.
+    if (cache.snapshotEnabled()) {
+      if (isSnapshot() || cache.snapshotEnabledForTX()) {
+        // first take a lock at cache level so that we don't go into deadlock or sort array before
+        // This is for tx RC, for snapshot just record all the versions from the queue
+        cache.acquireWriteLockOnSnapshotRvv();
+        try {
+          for (VersionInformation vi : queue) {
+            if (TXStateProxy.LOG_FINE) {
+              logger.info(LocalizedStrings.DEBUG, "Recording version " + vi + " from snapshot to " +
+                  "region.");
+            }
+            ((LocalRegion)vi.region).getVersionVector().
+                recordVersionForSnapshot((VersionSource)vi.member, vi.version, null);
+          }
+        } finally {
+          cache.releaseWriteLockOnSnapshotRvv();
+        }
+      } else {
+        // doing it for tx and non tx case.
+        // tx may not record version in snapshot so non tx reads while taking
+        // snapshot may miss it. in case of commit just copy the rvv to snapshot so that
+        // any future non tx read will get all the entries
+        cache.acquireWriteLockOnSnapshotRvv();
+        try {
+          for (TXRegionState txr : finalRegions) {
+            final LocalRegion dataRegion = txr.region;
+            final RegionVersionVector<?> rvv = dataRegion.getVersionVector();
+            if (rvv != null) {
+              rvv.reInitializeSnapshotRvv();
+            }
+          }
+        } finally {
+          cache.releaseWriteLockOnSnapshotRvv();
+        }
+      }
+    }
   }
 
   final void initBaseEventOffsetsForCommit() {
@@ -1345,6 +1389,101 @@ public final class TXState implements TXStateInterface {
     if (cleanEx != null) {
       throw cleanEx;
     }
+  }
+
+  //rollback can be done locally for snapshot just as commit is done
+  private void rollBackUncommittedEntries() throws RegionClearedException {
+    // we need to take entry lock on primary otherwise the following can happen
+    // on primary : we replace uncommitted entry with committed entry
+    // on primary new write comes, which goes to secondary
+    // on secondary : we replace the new entry with old committed entry
+    // to avoid this we can compare the version or keep the uncommitted RE reference too in
+    // the txStateand don't conflict on secondary.
+
+    Iterator<RegionEntry> itr1 = unCommittedEntryReference.iterator();
+    Iterator<Object> itr2 = committedEntryReference.iterator();
+    Iterator<LocalRegion> itr3 = regionReference.iterator();
+
+    GemFireCacheImpl.getInstance().getLogger().info("Rolling back the changes.. " + unCommittedEntryReference.size()
+        + " " + committedEntryReference.size() + " " + regionReference.size());
+    RegionEntry uncommitted;
+    RegionEntry committed;
+    VersionStamp originalStamp, stamp;
+    VersionTag originalStampAsTag;
+    EntryEventImpl event = EntryEventImpl.createVersionTagHolder();
+    while (itr1.hasNext() && itr2.hasNext()) {
+      uncommitted = itr1.next();
+      Object entr = itr2.next();
+      if (!(entr instanceof Token)) {
+        committed = (RegionEntry)entr;
+      }
+      else {
+        committed = null;
+      }
+      LocalRegion region = itr3.next();
+      synchronized (uncommitted) {
+        if (committed != null) {
+          originalStamp = committed.getVersionStamp();
+          stamp = uncommitted.getVersionStamp();
+          if (stamp.getEntryVersion() > originalStamp.getEntryVersion() + 1) {
+            // some modification has already happened,
+            // if this is secondary and the change must have come through primary.
+            // TODO: TEST
+            // actually this should never happen!
+            continue;
+          }
+
+          originalStampAsTag = null;
+          if (originalStamp != null) {
+            originalStampAsTag = originalStamp.asVersionTag();
+          }
+          if (stamp != null && originalStampAsTag != null) {
+            stamp.setVersions(originalStampAsTag);
+            stamp.setMemberID(originalStampAsTag.getMemberID());
+          }
+          event.setVersionTag(originalStampAsTag);
+          event.setRegion(region);
+          // we need to do this under the region entry lock
+          // This has to handle index changes too.
+          // set originRemote so that version is not generated but used from event
+          //Suranjan TODO: This case can lead to two copies of same row in the index.
+          // as one will be pointing two RE in RegionMap
+          // and other will be pointing to oldRe in oldReMap.
+          //How to make it atomic? Not supporting for rowtable.
+          event.setOriginRemote(true);
+          event.setNewValue(committed._getValue());
+          if (uncommitted.isTombstone()) {
+            event.setOperation(Operation.CREATE);
+            event.putNewEntry(region, uncommitted);
+          } else {
+            event.setOperation(Operation.UPDATE);
+            event.setEntryLastModified(uncommitted.getLastModified());
+            event.setPutDML(true);
+            final int oldSize = region.calculateRegionEntryValueSize(uncommitted);
+            event.putExistingEntry(region, uncommitted, oldSize);
+            //uncommitted.setValueWithTombstoneCheck(committed._getValue(), event);
+          }
+        } else {
+          // we need to just delete the entry in regionMap and set the version back
+          originalStampAsTag = VersionTag.create(uncommitted.getVersionStamp().
+              asVersionTag().getMemberID());
+          event.setVersionTag(originalStampAsTag);
+          event.setRegion(region);
+          event.setOriginRemote(true);
+          event.setOperation(Operation.DESTROY);
+          uncommitted.destroy(region, event, false, true, null, false, false);
+        }
+      }
+
+      // also to make sure that it happens only if the version of uncommited hasn't changed.
+      // so we will have to store the version of uncommitted too?
+      // We can get it from version that we store in TXState. We need to map RE with the version
+      // What if multiple updates on same RE.
+      GemFireCacheImpl.getInstance().getLogger().info("SKKS rolling back the changes.. ");
+    }
+    // we need to take RVV lock and record the recorded version in the snapshot so that
+    // there are no unnecessary exceptions recorded due to rollback
+    publishRecordedVersions();
   }
 
   public void cleanupCachedLocalState(boolean hasListeners) {
@@ -2291,11 +2430,19 @@ public final class TXState implements TXStateInterface {
    *         acquisition
    */
   static final Object lockEntryForRead(final LockingPolicy lockPolicy,
-      final RegionEntry entry, final Object key, final LocalRegion dataRegion,
+      RegionEntry entry, final Object key, final LocalRegion dataRegion,
       final TXId txId, final TXState txState, final int iContext,
       final boolean markPending, final boolean allowTombstones,
       final Boolean checkForTXFinish, final ReadEntryUnderLock reader) {
     final LockMode mode = lockPolicy.getReadLockMode();
+    if (lockPolicy == LockingPolicy.SNAPSHOT) {
+      if (dataRegion.getVersionVector() != null) {
+        if (!checkEntryVersion(txState, dataRegion, entry)) {
+          entry = (RegionEntry)getOldVersionedEntry(txState, dataRegion, key, entry);
+        }
+      }
+    }
+
     final Object lockResult = lockPolicy.lockForRead(entry, mode, txId,
         dataRegion, iContext, null, allowTombstones, reader);
     if (lockResult != LockingPolicy.Locked) {
@@ -3880,6 +4027,54 @@ public final class TXState implements TXStateInterface {
     }
   }
 
+  // Writer should add old entry with tombstone with region version in the common map
+  // wait till writer has written to common old entry map.
+  private static Object getOldVersionedEntry(TXState tx,LocalRegion dataRegion, Object key, RegionEntry re) {
+
+    Object oldEntry = dataRegion.getCache().readOldEntry(dataRegion, key, tx.getCurrentSnapshot(),
+        true, re, tx);
+    if (oldEntry != null) {
+      return oldEntry;
+    } else {
+      // wait till it is populated..
+      // The update/destroy guy can update the region version first and then modify the RE
+      // later copy it to running tx so that when tx misses the entry it is sure that
+      // it will be copied by writer thread
+      // If we copy first and then update the region version and RE then there is a window where
+      // concurrent tx can miss the old entry.
+      // 1. Copy of the old value
+      // 2. New tx starts and takes the snapshot
+      // 3. old tx increments the regionVersion
+      // 4. New tx scans and misses the changed RE as its version is higher than the snapshot.
+      // 5. old tx changes the RE
+
+      // For Transaction NONE we can get locally. For tx isolation level RC/RR
+      // we will have to get from a common DS.
+      oldEntry = dataRegion.getCache().readOldEntry(dataRegion, key, tx.getCurrentSnapshot(), true, re, tx);
+      int numtimes = 0;
+      while (oldEntry == null) {
+        if (TXStateProxy.LOG_FINE) {
+          LogWriterI18n logger = dataRegion.getLogWriterI18n();
+          logger.info(LocalizedStrings.DEBUG, " Waiting for older entry for this snapshot to arrive " +
+              "for key " + key + " re " + re + " for region " + dataRegion.getFullPath());
+        }
+        try {
+          //TODO: Suranjan Should we wait indefinitely? or throw warning and return the current entry.
+          // As
+          if (numtimes < 10) {
+            Thread.sleep(10);
+            numtimes++;
+          } else {
+            Thread.sleep(100 * numtimes);
+          }
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+        oldEntry = dataRegion.getCache().readOldEntry(dataRegion, key, tx.getCurrentSnapshot(), true, re, tx);
+      }
+      return oldEntry;
+    }
+  }
   /**
    * Test to see if this vector has seen the given version.
    * It should also include any changes done by this tx.
@@ -3961,6 +4156,46 @@ public final class TXState implements TXStateInterface {
     return true;
   }
 
+  public static boolean checkEntryVersion(TXStateInterface tx, Region region, RegionEntry entry) {
+    if (tx.isSnapshot() && ((LocalRegion)region).concurrencyChecksEnabled) {
+      VersionStamp stamp = entry.getVersionStamp();
+      VersionSource id = stamp.getMemberID();
+      final LogWriterI18n logger = ((LocalRegion)region).getLogWriterI18n();
+
+      if (id == null) {
+        if (((LocalRegion)region).getVersionVector().isDiskVersionVector()) {
+          id = ((LocalRegion)region).getDiskStore().getDiskStoreID();
+        } else {
+          id = InternalDistributedSystem.getAnyInstance().getDistributedMember();
+        }
+        if (TXStateProxy.LOG_FINEST) {
+          logger.info(LocalizedStrings.DEBUG, "checkEntryVersion: for region "
+              + region.getFullPath() + " RegionEntry(" + entry + ")" + " id not set in Entry, setting id to: " +
+              id);
+        }
+      }
+      // if rvv is not present then
+      TXState state = tx.getLocalTXState();
+      if (state.getCurrentRvvSnapShot() != null) {
+        if (state.isVersionInSnapshot(region, id, stamp.getRegionVersion())) {
+          if (TXStateProxy.LOG_FINEST) {
+            logger.info(LocalizedStrings.DEBUG, "getLocalEntry: for region "
+                + region.getFullPath() + " RegionEntry(" + entry  + ") with version " + stamp
+                .getRegionVersion() + " id: " + id + " , returning true.");
+          }
+          return true;
+        }
+      }
+      if (TXStateProxy.LOG_FINE) {
+        logger.info(LocalizedStrings.DEBUG, "getLocalEntry: for region "
+            + region.getFullPath() + " RegionEntry(" + entry + ") with version " + stamp
+            .getRegionVersion() + " id: " + id + " , returning false.");
+      }
+      return false;
+    }
+    return true;
+  }
+
   public Map<String, Map<VersionSource, RegionVersionHolder>> getCurrentSnapshot() {
     return snapshot;
   }
@@ -3970,7 +4205,7 @@ public final class TXState implements TXStateInterface {
    * This method is only for test purpose to check the current Rvv
    * @param region
    */
-  public Map<String, Map<VersionSource,RegionVersionHolder>> getCurrentRvvSnapShot(Region region) {
+  public Map<String, Map<VersionSource,RegionVersionHolder>> getCurrentRvvSnapShot() {
 
     if (snapshot != null) {
       return snapshot;
@@ -4093,10 +4328,10 @@ public final class TXState implements TXStateInterface {
     }
   }
 
-  public void addRegionEntryReference(RegionEntry re) {
-    regionEntryRef.add(re);
+  public void addCommittedRegionEntryReference(Object re, RegionEntry newRe, LocalRegion region) {
+    committedEntryReference.add(re);
+    unCommittedEntryReference.add(newRe);
+    regionReference.add(region);
   }
-  public boolean containsRegionEntryReference(RegionEntry re) {
-    return regionEntryRef.contains(re);
-  }
+
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateProxy.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateProxy.java
@@ -177,7 +177,7 @@ public class TXStateProxy extends NonReentrantReadWriteLock implements
   private final long beginTime;
 
   /** True if operations related to transactions have to be logged globally. */
-  private static boolean VERBOSE = VERBOSE_ON();
+  private static boolean VERBOSE = true;//VERBOSE_ON();
   private static boolean VERBOSEVERBOSE = VERBOSEVERBOSE_ON();
   public static boolean LOG_FINE = VERBOSE | VERBOSEVERBOSE;
   public static boolean LOG_FINEST = VERBOSEVERBOSE;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateProxy.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateProxy.java
@@ -177,7 +177,7 @@ public class TXStateProxy extends NonReentrantReadWriteLock implements
   private final long beginTime;
 
   /** True if operations related to transactions have to be logged globally. */
-  private static boolean VERBOSE = true;//VERBOSE_ON();
+  private static boolean VERBOSE = VERBOSE_ON();
   private static boolean VERBOSEVERBOSE = VERBOSEVERBOSE_ON();
   public static boolean LOG_FINE = VERBOSE | VERBOSEVERBOSE;
   public static boolean LOG_FINEST = VERBOSEVERBOSE;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -36,6 +36,7 @@ import javax.annotation.Nonnull;
 import com.gemstone.gemfire.DataSerializer;
 import com.gemstone.gemfire.cache.CacheException;
 import com.gemstone.gemfire.cache.EvictionAttributes;
+import com.gemstone.gemfire.cache.IsolationLevel;
 import com.gemstone.gemfire.cache.Region;
 import com.gemstone.gemfire.cache.control.RebalanceOperation;
 import com.gemstone.gemfire.cache.control.ResourceManager;
@@ -2460,6 +2461,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
         GfxdSystemProcedureMessage.SysProcMethod.setNanoTimerType, false, true);
   }
 
+  // TODO: send to all nodes after doing local commit
   public static void COMMIT_SNAPSHOT_TXID(String txId) throws SQLException, StandardException {
     TXStateInterface txState = null;
     LanguageConnectionContext lcc = ConnectionUtil.getCurrentLCC();
@@ -2469,7 +2471,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
       StringTokenizer st = new StringTokenizer(txId, ":");
       if (GemFireXDUtils.TraceExecution) {
         SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
-            "in procedure COMMIT_SNAPSHOT_TXID() " + txId + " for connid " + tc.getConnectionID()
+            "in procedure COMMIT_SNAPSHOT_TXID() SURANJAN " + txId + " for connid " + tc.getConnectionID()
                 + " TxManager " + TXManagerImpl.getCurrentTXId()
                 + " snapshot tx : " + TXManagerImpl.snapshotTxState.get());
       }
@@ -2492,7 +2494,46 @@ public class GfxdSystemProcedures extends SystemProcedures {
     }
     if (GemFireXDUtils.TraceExecution) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
-          "in procedure COMMIT_SNAPSHOT_TXID() afer commit" + txId + " for connid " + tc.getConnectionID()
+          "in procedure COMMIT_SNAPSHOT_TXID() SURANJAN afer commit" + txId + " for connid " + tc.getConnectionID()
+              + " TxManager " + TXManagerImpl.getCurrentTXId()
+              + " snapshot tx : " + TXManagerImpl.snapshotTxState.get());
+    }
+  }
+
+  //TODO: send to all nodes after doing local commit
+  public static void ROLLBACK_SNAPSHOT_TXID(String txId) throws SQLException, StandardException {
+    TXStateInterface txState = null;
+    LanguageConnectionContext lcc = ConnectionUtil.getCurrentLCC();
+    GemFireTransaction tc = (GemFireTransaction) lcc.getTransactionExecute();
+
+    if (!txId.equals("null")) {
+      StringTokenizer st = new StringTokenizer(txId, ":");
+      if (GemFireXDUtils.TraceExecution) {
+        SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
+            "in procedure ROLLBACK_SNAPSHOT_TXID() SURANJAN " + txId + " for connid " + tc.getConnectionID()
+                + " TxManager " + TXManagerImpl.getCurrentTXId()
+                + " snapshot tx : " + TXManagerImpl.snapshotTxState.get());
+      }
+
+      long memberId = Long.parseLong(st.nextToken());
+      int uniqId = Integer.parseInt(st.nextToken());
+      TXId txId1 = TXId.valueOf(memberId, uniqId);
+
+      txState = tc.getTransactionManager().getHostedTXState(txId1);
+    }
+
+    tc.clearActiveTXState(false, true);
+    // this is being done because txState is being shared across conn
+    if (txState != null && txState.isInProgress()) {
+      tc.getTransactionManager().masqueradeAs(txState);
+      tc.getTransactionManager().rollback();
+    } else {
+      TXManagerImpl.snapshotTxState.set(null);
+      TXManagerImpl.getOrCreateTXContext().clearTXState();
+    }
+    if (GemFireXDUtils.TraceExecution) {
+      SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
+          "in procedure ROLLBACK_SNAPSHOT_TXID() SURANJAN afer commit" + txId + " for connid " + tc.getConnectionID()
               + " TxManager " + TXManagerImpl.getCurrentTXId()
               + " snapshot tx : " + TXManagerImpl.snapshotTxState.get());
     }
@@ -2526,6 +2567,35 @@ public class GfxdSystemProcedures extends SystemProcedures {
     TXManagerImpl.snapshotTxState.set(null);
   }
 
+  public static void START_SNAPSHOT_TXID(String[] txid) throws SQLException, StandardException {
+    assert(TXManagerImpl.getCurrentSnapshotTXState() == null);
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    LanguageConnectionContext lcc = ConnectionUtil.getCurrentLCC();
+    GemFireTransaction tc = (GemFireTransaction)lcc.getTransactionExecute();
+    tc.setActiveTXState(TXManagerImpl.snapshotTxState.get(), false);
+
+    if (GemFireXDUtils.TraceExecution) {
+      SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
+          "in procedure START_SNAPSHOT_TXID() SURANJAN for conn " + tc.getConnectionID() + " tc id" + tc.getTransactionIdString()
+              + " TxManager " + TXManagerImpl.getCurrentTXId()
+              + " snapshot tx : " + TXManagerImpl.snapshotTxState.get());
+    }
+
+    TXStateInterface tx = TXManagerImpl.snapshotTxState.get();
+    if ( tx != null) {
+      txid[0] = tx.getTransactionId().stringFormat();
+    } else {
+      txid[0] = "null";
+    }
+    /*// tc commit will clear all the artifacts but will not commit actual txState
+    // that should be committed in COMMIT procedure*/
+    // start may be called on different conn
+    //tc.resetActiveTXState(true);
+    //TXManagerImpl.getOrCreateTXContext().clearTXState();
+    //TXManagerImpl.snapshotTxState.set(null);
+  }
+
   public static void USE_SNAPSHOT_TXID(String txId) throws SQLException {
     StringTokenizer st = new StringTokenizer(txId, ":");
     long memberId = Long.parseLong(st.nextToken());
@@ -2538,7 +2608,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
     if (state == null) {
       if (GemFireXDUtils.TraceExecution) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
-          "in procedure USE_SNAPSHOT_TXID() creating a txState for conn " + tc.getConnectionID() + " tc id" + tc.getTransactionIdString()
+          "in procedure USE_SNAPSHOT_TXID() SURANJAN creating a txState for conn " + tc.getConnectionID() + " tc id" + tc.getTransactionIdString()
               + " txId  " +txId);
       }
       // if state is null then create txstate and use
@@ -2552,7 +2622,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
     if (TXManagerImpl.snapshotTxState.get() != null) {
       if (GemFireXDUtils.TraceExecution) {
         SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
-            "in procedure USE_SNAPSHOT_TXID(), for txid  " + txId1 + " txState : " + state + " connId" + tc.getConnectionID());
+            "in procedure USE_SNAPSHOT_TXID() SURANJAN for txid  " + txId1 + " txState : " + state + " connId" + tc.getConnectionID());
       }
     }
   }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdConnectionWrapper.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdConnectionWrapper.java
@@ -919,6 +919,10 @@ public final class GfxdConnectionWrapper {
       tran.setActiveTXState(tx, true);
       return;
     }
+    if (tx.isSnapshot()) {
+      tran.setActiveTXState(tx, false);
+      return;
+    }
     if (currentIsolationLevel != Connection.TRANSACTION_NONE) {
       // tx boundaries are changing, so this is definitely a new transaction
       // On data store node we should be calling tx.commit while changing

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/GemFireInsertResultSet.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/GemFireInsertResultSet.java
@@ -29,6 +29,7 @@ import com.gemstone.gemfire.internal.cache.TXManagerImpl;
 import com.gemstone.gemfire.internal.cache.TXStateInterface;
 import com.gemstone.gemfire.internal.cache.VMIdAdvisor;
 
+import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.GemFireXDQueryObserver;
 import com.pivotal.gemfirexd.internal.engine.GemFireXDQueryObserverHolder;
@@ -139,9 +140,10 @@ public final class GemFireInsertResultSet extends AbstractGemFireResultSet {
         .getLanguageConnectionContext();
 
     TXStateInterface tx = this.gfContainer.getActiveTXState(this.tran);
+    // TOOD: decide on autocommit or this flag: Discuss
     if (false && tx == null /*&& this.gfContainer.isRowBuffer()*/) {
       this.tran.getTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
-      ((GemFireTransaction)lcc.getTransactionExecute()).setActiveTXState(TXManagerImpl.getCurrentTXState(), true);
+      ((GemFireTransaction)lcc.getTransactionExecute()).setActiveTXState(TXManagerImpl.getCurrentTXState(), false);
       this.tran.setImplicitSnapshotTxStarted(true);
     }
     tx = this.gfContainer.getActiveTXState(this.tran);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/NonLocalRowLocationRegionEntry.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/NonLocalRowLocationRegionEntry.java
@@ -314,7 +314,8 @@ public final class NonLocalRowLocationRegionEntry extends NonLocalRegionEntry
    */
   @Override
   public DataValueDescriptor getClone() {
-    throw new UnsupportedOperationException("unexpected invocation");
+    return this;
+    //throw new UnsupportedOperationException("unexpected invocation");
   }
 
   /**
@@ -322,7 +323,8 @@ public final class NonLocalRowLocationRegionEntry extends NonLocalRegionEntry
    */
   @Override
   public DataValueDescriptor recycle() {
-    throw new UnsupportedOperationException("unexpected invocation");
+    return this;
+    //throw new UnsupportedOperationException("unexpected invocation");
   }
 
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedConnection.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedConnection.java
@@ -3142,7 +3142,8 @@ public abstract class EmbedConnection implements EngineConnection
 	 */
 	protected final void commitIfNeeded() throws SQLException 
     {
-		if (autoCommit && needCommit) 
+		if ((autoCommit && needCommit) ||
+				((GemFireTransaction)getTR().getLcc().getTransactionExecute()).getImplcitSnapshotTxStarted())
         {
             try
             {
@@ -3174,7 +3175,8 @@ public abstract class EmbedConnection implements EngineConnection
 	 */
 	protected final void commitIfAutoCommit() throws SQLException 
     {
-		if (autoCommit) 
+		if (autoCommit ||
+				((GemFireTransaction)getLanguageConnection().getTransactionExecute()).getImplcitSnapshotTxStarted())
         {
             try
             {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedStatement.java
@@ -2291,7 +2291,7 @@ public class EmbedStatement extends ConnectionChild
 						  a.reset(false);
 						}
 						if (!distribute)
-						  if (!origAutoCommit) {
+						  if (!origAutoCommit && !tran.getImplcitSnapshotTxStarted()) {
 						    if (!tran.isTransactional() && !isPreparedBatch && (act == null || !(act instanceof LockTableConstantAction))) {
 						      tran.releaseAllLocks(
 						          false, false);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/TransactionResourceImpl.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/TransactionResourceImpl.java
@@ -598,7 +598,8 @@ public final class TransactionResourceImpl
 					** rollback in the cleanupOnError above, but we still
 					** may hold locks from the stmt.
 					*/
-					if (autoCommit && rollbackOnAutoCommit)
+
+					if (autoCommit && rollbackOnAutoCommit || ((GemFireTransaction)lcc.getTransactionExecute()).getImplcitSnapshotTxStarted())
 					{
 						se.setSeverity(ExceptionSeverity.TRANSACTION_SEVERITY);
 					}

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -504,7 +504,7 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
           throw StandardException.newException(SQLState.NOT_IMPLEMENTED,
               "Cannot execute DDL statements in the middle of transaction "
                   + "that has data changes "
-                  + "(commit or rollback the transaction first)");
+                  + "(commit or rollback the transaction first) " + tx);
         }
       }
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -1634,7 +1634,24 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
         String[] argNames = new String[]{"txId"};
         TypeDescriptor[] argTypes = new TypeDescriptor[]{
             DataTypeDescriptor.getCatalogType(Types.VARCHAR)};
+        super.createSystemProcedureOrFunction("START_SNAPSHOT_TXID", sysUUID,
+            argNames,argTypes, 1, 0, RoutineAliasInfo.NO_SQL, null, newlyCreatedRoutines,
+            tc, GFXD_SYS_PROC_CLASSNAME, true);
+      }
+
+      {
+        String[] argNames = new String[]{"txId"};
+        TypeDescriptor[] argTypes = new TypeDescriptor[]{
+            DataTypeDescriptor.getCatalogType(Types.VARCHAR)};
         super.createSystemProcedureOrFunction("COMMIT_SNAPSHOT_TXID", sysUUID,
+            argNames,argTypes, 0, 0, RoutineAliasInfo.NO_SQL, null, newlyCreatedRoutines,
+            tc, GFXD_SYS_PROC_CLASSNAME, true);
+      }
+      {
+        String[] argNames = new String[]{"txId"};
+        TypeDescriptor[] argTypes = new TypeDescriptor[]{
+            DataTypeDescriptor.getCatalogType(Types.VARCHAR)};
+        super.createSystemProcedureOrFunction("ROLLBACK_SNAPSHOT_TXID", sysUUID,
             argNames,argTypes, 0, 0, RoutineAliasInfo.NO_SQL, null, newlyCreatedRoutines,
             tc, GFXD_SYS_PROC_CLASSNAME, true);
       }

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapShotTxDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapShotTxDUnit.java
@@ -673,7 +673,8 @@ public class SnapShotTxDUnit extends DistributedSQLTestBase {
 
   }
 
-  public void testNoConflict() throws Exception {
+  // There would be conflict now after write write conflict detection
+  public void testConflict() throws Exception {
     
     startVMs(0, 2);
     Properties props = new Properties();
@@ -733,10 +734,10 @@ public class SnapShotTxDUnit extends DistributedSQLTestBase {
 
         r.getCache().getCacheTransactionManager().commit();
 
-        assertEquals(2, r.get(1));
-        assertEquals(4, r.get(2));
-        assertEquals(6, r.get(3));
-        assertEquals(8, r.get(4));
+        assertEquals(1, r.get(1));
+        assertEquals(2, r.get(2));
+        assertEquals(3, r.get(3));
+        assertEquals(4, r.get(4));
       }
     });
 
@@ -747,10 +748,10 @@ public class SnapShotTxDUnit extends DistributedSQLTestBase {
         //take an snapshot again//gemfire level
         final Region r = cache.getRegion(regionName);
         r.getCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
-        assertEquals(2, r.get(1));
-        assertEquals(4, r.get(2));
-        assertEquals(6, r.get(3));
-        assertEquals(8, r.get(4));
+        assertEquals(1, r.get(1));
+        assertEquals(2, r.get(2));
+        assertEquals(3, r.get(3));
+        assertEquals(4, r.get(4));
 
         TXStateInterface txstate = TXManagerImpl.getCurrentTXState();
         Iterator txitr = txstate.getLocalEntriesIterator(null, false, false, true, (LocalRegion)r);

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapShotTxDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapShotTxDUnit.java
@@ -736,8 +736,9 @@ public class SnapShotTxDUnit extends DistributedSQLTestBase {
 
         assertEquals(1, r.get(1));
         assertEquals(2, r.get(2));
-        assertEquals(3, r.get(3));
-        assertEquals(4, r.get(4));
+        // non tx put so no conflict
+        assertEquals(6, r.get(3));
+        assertEquals(8, r.get(4));
       }
     });
 
@@ -750,8 +751,8 @@ public class SnapShotTxDUnit extends DistributedSQLTestBase {
         r.getCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
         assertEquals(1, r.get(1));
         assertEquals(2, r.get(2));
-        assertEquals(3, r.get(3));
-        assertEquals(4, r.get(4));
+        assertEquals(6, r.get(3));
+        assertEquals(8, r.get(4));
 
         TXStateInterface txstate = TXManagerImpl.getCurrentTXState();
         Iterator txitr = txstate.getLocalEntriesIterator(null, false, false, true, (LocalRegion)r);

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
@@ -10,13 +10,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.gemstone.gemfire.cache.AttributesFactory;
-import com.gemstone.gemfire.cache.IsolationLevel;
-import com.gemstone.gemfire.cache.PartitionAttributes;
-import com.gemstone.gemfire.cache.PartitionAttributesFactory;
-import com.gemstone.gemfire.cache.Region;
-import com.gemstone.gemfire.cache.RegionFactory;
-import com.gemstone.gemfire.cache.RegionShortcut;
+import com.gemstone.gemfire.cache.*;
 import com.gemstone.gemfire.internal.cache.*;
 import com.gemstone.gemfire.internal.cache.persistence.DiskStoreID;
 import com.gemstone.gemfire.internal.cache.versions.DiskRegionVersionVector;
@@ -25,6 +19,7 @@ import com.gemstone.gemfire.internal.cache.versions.VersionSource;
 import com.gemstone.org.jgroups.oswego.concurrent.CyclicBarrier;
 import com.pivotal.gemfirexd.TestUtil;
 import com.pivotal.gemfirexd.internal.engine.Misc;
+import com.pivotal.gemfirexd.internal.iapi.types.SQLInteger;
 import com.pivotal.gemfirexd.jdbc.JdbcTestBase;
 import io.snappydata.test.dunit.SerializableRunnable;
 
@@ -56,7 +51,6 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
   public void tearDown() throws Exception {
     System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "false");
     super.tearDown();
-
   }
 
   public void testRVVSnapshotContains() throws Exception {
@@ -98,6 +92,120 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
 
     System.out.println("SKSK Contains " + rvv.contains(id1, 758));
 
+  }
+
+  public void testAutoCommitWithRCConflict() throws Exception {
+    Connection conn= getConnection();
+    Statement st = conn.createStatement();
+    st.execute("Create table tran.t1 (c1 int not null , c2 int not null, primary key(c1)) replicate"+getSuffix());
+    conn.commit();
+    conn.setTransactionIsolation(Connection.TRANSACTION_NONE);
+    conn.setAutoCommit(true);
+    final TXManagerImpl txMgrImpl = (TXManagerImpl)Misc.getGemFireCache()
+        .getCacheTransactionManager();
+    // Region r= cache.getRegion("APP/T1");
+    final Region<Object, Object> r = Misc.getRegionForTable("TRAN.T1", true);
+    final Object key = getGemFireKey(10, r);
+    this.gotConflict = false;
+    Thread thread = new Thread(new Runnable() {
+
+      @Override
+      public void run() {
+        assertNotNull(r);
+        txMgrImpl.begin(IsolationLevel.SNAPSHOT, null);
+        r.put(key, new SQLInteger(20)); // create a conflict here.
+        TXStateInterface txi = txMgrImpl.internalSuspend();
+        assertNotNull(txi);
+        txMgrImpl.resume(txi);
+        txMgrImpl.commit();
+      }
+    });
+    thread.start();
+    thread.join();
+
+
+    st.execute("insert into tran.t1 values (10, 20)");
+
+    //st.execute("insert into t1 values (20, 20)");
+
+    //Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    ResultSet rs = st.executeQuery("Select * from tran.t1 where c2 = 10");
+    int numRows = 0;
+    while (rs.next()) {
+      numRows++;
+    }
+    assertEquals("ResultSet should contain two rows ", 1, numRows);
+
+    rs.close();
+   // conn.setTransactionIsolation(Connection.TRANSACTION_NONE);
+    //Misc.getGemFireCache().getCacheTransactionManager().commit();
+    conn.commit();
+
+    // Close connection, resultset etc...
+
+    st.close();
+    conn.close();
+  }
+
+
+  public void testAutoCommitWithIndexRC() throws Exception {
+    Connection conn= getConnection();
+    Statement st = conn.createStatement();
+    st.execute("Create table t1 (c1 int not null , c2 int not null, primary key(c1)) replicate"+getSuffix());
+    conn.commit();
+    conn.setTransactionIsolation(Connection.TRANSACTION_NONE);
+    conn.setAutoCommit(true);
+
+    st.execute("insert into t1 values (10, 10)");
+
+    //st.execute("insert into t1 values (20, 20)");
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    ResultSet rs = st.executeQuery("Select * from t1 where t1.c2 = 10");
+    int numRows = 0;
+    while (rs.next()) {
+      numRows++;
+    }
+    assertEquals("ResultSet should contain two rows ", 1, numRows);
+
+    rs.close();
+    conn.setTransactionIsolation(Connection.TRANSACTION_NONE);
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+    conn.commit();
+
+    // Close connection, resultset etc...
+
+    st.close();
+    conn.close();
+  }
+
+  public void testAutoCommitWithIndex() throws Exception {
+    Connection conn= getConnection();
+    Statement st = conn.createStatement();
+    st.execute("Create table t1 (c1 int not null , c2 int not null, primary key(c1)) replicate"+getSuffix());
+    conn.commit();
+    conn.setAutoCommit(true);
+    conn.setTransactionIsolation(getIsolationLevel());
+
+
+    st.execute("insert into t1 values (10, 10)");
+
+    //st.execute("insert into t1 values (20, 20)");
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    ResultSet rs = st.executeQuery("Select * from t1 where t1.c2 = 10");
+    int numRows = 0;
+    while (rs.next()) {
+      numRows++;
+    }
+    assertEquals("ResultSet should contain two rows ", 1, numRows);
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+    conn.commit();
+
+    // Close connection, resultset etc...
+    rs.close();
+    st.close();
+    conn.close();
   }
 
   public void testSnapshotInsertTableAPI() throws Exception {
@@ -1011,6 +1119,416 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
     t.join();
   }
 
+  public void testCommitWithConflicts() throws Exception {
+    Connection conn = getConnection();
+    Statement st = conn.createStatement();
+    st.execute("create schema tran");
+    st.execute("Create table tran.t1 (c1 int not null , c2 int not null, "
+        + "primary key(c1)) replicate persistent enable concurrency checks" +getSuffix());
+    conn.commit();
+
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    st.execute("insert into tran.t1 values (10, 1)");
+
+    Cache cache = Misc.getGemFireCache();
+    final TXManagerImpl txMgrImpl = (TXManagerImpl)cache
+        .getCacheTransactionManager();
+
+    final Region<Object, Object> r = Misc.getRegionForTable("TRAN.T1", true);
+    final Object key = getGemFireKey(10, r);
+    this.gotConflict = false;
+    Thread thread = new Thread(new Runnable() {
+
+      @Override
+      public void run() {
+        assertNotNull(r);
+        txMgrImpl.begin(IsolationLevel.SNAPSHOT, null);
+        try {
+          r.put(key, new SQLInteger(20)); // create a conflict here.
+          fail("expected a conflict here");
+        } catch (ConflictException ce) {
+          gotConflict = true;
+        }
+        assertNull(r.get(key));
+        TXStateInterface txi = txMgrImpl.internalSuspend();
+        assertNotNull(txi);
+
+        txMgrImpl.resume(txi);
+        txMgrImpl.commit();
+      }
+    });
+    thread.start();
+    thread.join();
+    txMgrImpl.commit();
+    conn.commit();
+    st.close();
+
+    assertTrue("expected conflict", this.gotConflict);
+    this.gotConflict = false;
+
+    // Important : Remove the key - value pair.
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    r.destroy(key);
+    txMgrImpl.commit();
+
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    Statement st2 = conn.createStatement();
+    st2.execute("insert into tran.t1 values (10, 10)");
+    txMgrImpl.commit();
+    conn.commit();
+
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    ResultSet rs = st2.executeQuery("select * from tran.t1");
+    int numRow = 0;
+    while (rs.next()) {
+      numRow++;
+      assertEquals("Primary Key coloumns should be 10 ", 10, rs.getInt(1));
+      assertEquals("Second columns should be 10 , ", 10, rs.getInt(2));
+    }
+    assertEquals("ResultSet should have two rows ", 1, numRow);
+    txMgrImpl.commit();
+
+    rs.close();
+    st2.close();
+    conn.commit();
+    conn.close();
+  }
+
+  public void testConflictWrite() throws Exception {
+    Connection conn = getConnection();
+    Statement st = conn.createStatement();
+    ResultSet rs;
+    int numRows = 0;
+    st.execute("Create table t1 (c1 int not null , c2 int not null, primary key(c1)) replicate persistent enable concurrency checks " + getSuffix());
+    conn.commit();
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    for (int i = 0; i < 10; i++) {
+      st.execute("insert into t1 values (" + i + ", " + i + ")");
+    }
+
+    Cache cache = Misc.getGemFireCache();
+    final TXManagerImpl txMgrImpl = (TXManagerImpl)cache
+        .getCacheTransactionManager();
+    this.gotConflict = false;
+
+    Thread thread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          Connection newConn = TestUtil.getConnection();
+          Statement st2 = newConn.createStatement();
+          txMgrImpl.begin(IsolationLevel.SNAPSHOT, null);
+          try {
+            for (int i = 8; i < 10; i++) {
+              st2.execute("insert into t1 values (" + i + ", " + i + ")");
+            }
+            fail("expected a conflict here");
+          } catch (ConflictException ce) {
+            gotConflict = true;
+          } catch (SQLException se) {
+            if (!(se.getCause() instanceof ConflictException)) {
+              threadEx = se;
+              se.printStackTrace();
+            } else {
+              txMgrImpl.rollback();
+              newConn.rollback();
+            }
+          }
+        } catch (Throwable t) {
+          threadEx = t;
+          fail("unexpected exception", t);
+        }
+      }
+    });
+    thread.start();
+    thread.join();
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().commit();
+    conn.commit();
+
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    rs = st.executeQuery("Select * from t1 where t1.c2 >= 0");
+    numRows = 0;
+    while (rs.next()) {
+      numRows++;
+    }
+    assertEquals("ResultSet should contain 10 rows ", 10, numRows);
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+    conn.commit();
+
+  }
+
+  public void testSnapshotGet() throws Exception {
+    Connection conn = getConnection();
+    Statement st = conn.createStatement();
+    ResultSet rs;
+    int numRows = 0;
+    st.execute("Create table t1 (c1 int not null , c2 int not null, primary key(c1)) replicate persistent enable concurrency checks " + getSuffix());
+    conn.commit();
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    for (int i = 0; i < 10; i++) {
+      st.execute("insert into t1 values (" + i + ", " + i + ")");
+    }
+
+    Cache cache = Misc.getGemFireCache();
+    final TXManagerImpl txMgrImpl = (TXManagerImpl)cache
+        .getCacheTransactionManager();
+    this.gotConflict = false;
+
+    Thread thread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          Connection newConn = TestUtil.getConnection();
+          Statement st2 = newConn.createStatement();
+          txMgrImpl.begin(IsolationLevel.SNAPSHOT, null);
+          for(int i=0; i< 10; i++) {
+            ResultSet rs = st2.executeQuery("Select * from t1 where t1.c1 = " + i + "");
+            int num = 0;
+            while (rs.next()) {
+              num++;
+            }
+            assertEquals(0, num);
+            rs.close();
+          }
+        } catch (Throwable t) {
+          threadEx = t;
+          fail("unexpected exception", t);
+        }
+
+      }
+    });
+    thread.start();
+    thread.join();
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().commit();
+    conn.commit();
+
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    rs = st.executeQuery("Select * from t1 where t1.c2 >= 0");
+    numRows = 0;
+    while (rs.next()) {
+      numRows++;
+    }
+    assertEquals("ResultSet should contain 10 rows ", 10, numRows);
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+    conn.commit();
+    rs.close();
+    st.close();
+    conn.close();
+  }
+
+  public void testSnapshotGetAll() throws Exception {
+
+  }
+
+  public void testSnapshotCommitLocalIndexMultiThread() throws Exception {
+
+  }
+
+  public void testSnapshotRollbackLocalIndexMultiThread() throws Exception {
+
+  }
+
+// Add conflict for write now
+// do simple region.get
+// do single region.getAll
+// do put/destroy and check if it is transactional.
+
+// Add snapshot for primary based read and getAll
+
+  /**
+   * in this case row is deleted from oldEntryMap
+   */
+  public void testSnapshotInsertRollback() throws Exception {
+    Connection conn = getConnection();
+    Statement st = conn.createStatement();
+    ResultSet rs;
+    int numRows = 0;
+    st.execute("Create table t1 (c1 int not null , c2 int not null, primary key(c1)) replicate persistent enable concurrency checks " + getSuffix());
+    conn.commit();
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    for (int i = 0; i < 10; i++) {
+      st.execute("insert into t1 values (" + i + ", " + i + ")");
+    }
+
+    conn.commit();
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().commit();
+
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    for (int i = 10; i < 20; i++) {
+      st.execute("insert into t1 values (" + i + ", " + i + ")");
+    }
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().rollback();
+    conn.rollback();
+    try {
+      Thread.sleep(10000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    rs = st.executeQuery("Select * from t1 where t1.c2 > 9");
+    numRows = 0;
+    while (rs.next()) {
+      numRows++;
+    }
+    assertEquals("ResultSet should contain 0 rows ", 0, numRows);
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+    conn.commit();
+
+    // assert region size
+    // assert getAll/get
+
+    // Close connection, resultset etc...
+    rs.close();
+    st.close();
+    conn.commit();
+    conn.close();
+
+  }
+  /**
+   * in this case row is deleted from oldEntryMap
+   */
+  public void testSnapshotUpdateRollback() throws Exception {
+    Connection conn= getConnection();
+    Statement st = conn.createStatement();
+    ResultSet rs;
+    int numRows = 0;
+    st.execute("Create table t1 (c1 int not null , c2 int not null, primary key(c1)) replicate persistent enable concurrency checks "+getSuffix());
+    conn.commit();
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    for(int i=0; i< 100; i++) {
+      st.execute("insert into t1 values (" + i + ", " +i + ")");
+    }
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().commit();
+    conn.commit();
+
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    for(int i=100; i< 200; i++) {
+      st.execute("insert into t1 values (" + i + ", " +i + ")");
+    }
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().rollback();
+    conn.rollback();
+    try {
+      Thread.sleep(10000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    rs = st.executeQuery("Select * from t1 where t1.c2 > 100");
+    numRows = 0;
+    while (rs.next()) {
+      // Checking number of rows returned, since ordering of results
+      // is not guaranteed. We can write an order by query for this (another test).
+      numRows++;
+    }
+    assertEquals("ResultSet should contain 0 rows ", 0, numRows);
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+    conn.commit();
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    rs = st.executeQuery("Select * from t1 where t1.c1 > 100");
+    numRows = 0;
+    while (rs.next()) {
+      // Checking number of rows returned, since ordering of results
+      // is not guaranteed. We can write an order by query for this (another test).
+      numRows++;
+    }
+    assertEquals("ResultSet should contain 0 rows ", 0, numRows);
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+    conn.commit();
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    st.execute("update t1 set c2 = 20 where c1 >50");
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().rollback();
+    conn.rollback();
+
+    try {
+      Thread.sleep(10000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    rs = st.executeQuery("Select * from t1 where t1.c2 = 20");
+    numRows = 0;
+    while (rs.next()) {
+      numRows++;
+      getLogger().info("The value is " + rs.getInt(1) + " " + rs.getInt(2));
+    }
+    assertEquals("ResultSet should contain 1 rows ", 1, numRows);
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+    conn.commit();
+
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    st.execute("update t1 set c2 = 20 where c1 >= 50");
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().commit();
+    conn.commit();
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    rs = st.executeQuery("Select * from t1 where t1.c2 = 20");
+    numRows = 0;
+    while (rs.next()) {
+      numRows++;
+      getLogger().info("The value is " + rs.getInt(1) + " " + rs.getInt(2));
+    }
+    assertEquals("ResultSet should contain 1 rows ", 51, numRows);
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+    conn.commit();
+
+    // Close connection, resultset etc...
+    rs.close();
+    st.close();
+    conn.commit();
+    conn.close();
+  }
+
+  public void testDeleteRollback() throws Exception {
+    Connection conn= getConnection();
+    Statement st = conn.createStatement();
+    ResultSet rs;
+    int numRows = 0;
+    st.execute("Create table t1 (c1 int not null , c2 int not null, primary key(c1)) replicate persistent enable concurrency checks "+getSuffix());
+    //st.execute("Create index c2Index on t1(c2)");
+    conn.commit();
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    for(int i=0; i< 100; i++) {
+      st.execute("insert into t1 values (" + i + ", " +i + ")");
+    }
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+    conn.commit();
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    st.execute("delete from t1 where c1 = 10");
+    Misc.getGemFireCache().getCacheTransactionManager().rollback();
+    conn.rollback();
+
+    Thread.sleep(10000);
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    rs = st.executeQuery("Select * from t1 where t1.c1 = 10");
+    numRows = 0;
+    while (rs.next()) {
+      numRows++;
+    }
+    assertEquals("ResultSet should contain two rows ", 1, numRows);
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    rs = st.executeQuery("Select * from t1 where t1.c2 = 10");
+    numRows = 0;
+    while (rs.next()) {
+      numRows++;
+    }
+    assertEquals("ResultSet should contain two rows ", 1, numRows);
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+
+    // Close connection, resultset etc...
+    rs.close();
+    st.close();
+    conn.commit();
+    conn.close();
+  }
+
   private void doInsertOpsInTx() throws Exception, InterruptedException {
     final Connection conn2 = getConnection();
     final Exception[] tx = new Exception[1];
@@ -1029,8 +1547,6 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
           st.execute("insert into t1 values (30, 30)");
           st.execute("insert into t1 values (40, 30)");
           st.execute("insert into t1 values (50, 30)");
-
-
 
           // conn2.commit();
           ResultSet rs = st.executeQuery("Select * from t1");
@@ -1071,8 +1587,6 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
           st.execute("insert into t1 values (105, 30)");
           st.execute("insert into t1 values (106, 30)");
           st.execute("insert into t1 values (107, 30)");
-
-
 
          // conn2.commit();
           ResultSet rs = st.executeQuery("Select * from t1");
@@ -1164,29 +1678,6 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
     if(tx[0] != null) {
       throw tx[0];
     }
-  }
-
-
-  /**
-   * Check supported isolation levels.
-   */
-  public void testIsolationLevels() throws Exception {
-    // try {
-    Connection conn = getConnection();
-    conn.setTransactionIsolation(Connection.TRANSACTION_NONE);
-    conn.setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
-    conn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
-    conn.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
-
-    try {
-      conn.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
-      fail("expected failure in unsupported isolation-level SERIALIZABLE");
-    } catch (SQLException ex) {
-      if (!ex.getSQLState().equalsIgnoreCase("XJ045")) {
-        throw ex;
-      }
-    }
-    conn.close();
   }
 
 
@@ -1319,8 +1810,7 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
     long version = 0l;
 
     Map<String, Map<VersionSource,RegionVersionHolder>> expectedSnapshot = txState
-        .getCurrentRvvSnapShot
-            (region);
+        .getCurrentRvvSnapShot();
     version = expectedSnapshot.get(region.getFullPath()).values().iterator().next()
         .getVersion();
     return version;


### PR DESCRIPTION
## Changes proposed in this pull request
* Implemented Rollback and write confict in case of snapshot mode. In case of rollback, put the entry back into ABRM. Also record the events so that no exception list is maintained.
* Changes needed for smart connector. Added some procedure required for snapshot tx write operation from snappy.
* We use the txId to either start/masqueradeAs/commit/rollback a transaction on a given connection.

## Patch testing

precheckin and tet

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
