### PR TITLE
Fix for SNAP-352 -- Simpler status message

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
@@ -205,7 +205,13 @@ public class CacheServerLauncher  {
    */
   protected void status(final String[] args) throws Exception {
     workingDir = (File) getStopOptions(args).get(DIR);
-    System.out.println(getStatus());
+    Status s = getStatus();
+    if (args.length >= 1 && args[1].equalsIgnoreCase("verbose")) {
+      System.out.println(s);
+    }
+    else {
+      System.out.println(s.shortStatus());
+    }
     if (DONT_EXIT_AFTER_LAUNCH) {
       return;
     }
@@ -614,7 +620,8 @@ public class CacheServerLauncher  {
     options.put(DIR, new File("."));
 
     for (final String arg : args) {
-      if (arg.equals("stop") || arg.equals("status") || arg.equals("wait")) {
+      if (arg.equals("stop") || arg.equals("status") || arg.equals("wait")
+              || arg.equals("verbose")) {
         // expected
       }
       else if (arg.startsWith("-dir=")) {
@@ -1281,6 +1288,15 @@ public class CacheServerLauncher  {
     @Override
     public String toString() {
       final StringBuilder buffer = new StringBuilder();
+      buffer.append(shortStatus());
+      if (this.dsMsg != null) {
+        buffer.append('\n').append(this.dsMsg);
+      }
+      return buffer.toString();
+    }
+
+    public String shortStatus() {
+      final StringBuilder buffer = new StringBuilder();
       buffer.append(this.baseName).append(" pid: ").append(pid).append(" status: ");
       switch (state) {
         case SHUTDOWN:
@@ -1314,11 +1330,8 @@ public class CacheServerLauncher  {
         }
         if ((state != WAITING && state != RUNNING) || msg == null) {
           buffer.append(" - ").append(LocalizedStrings
-              .CacheServerLauncher_SEE_LOG_FILE_FOR_DETAILS.toLocalizedString());
+                  .CacheServerLauncher_SEE_LOG_FILE_FOR_DETAILS.toLocalizedString());
         }
-      }
-      if (this.dsMsg != null) {
-        buffer.append('\n').append(this.dsMsg);
       }
       return buffer.toString();
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
@@ -1330,7 +1330,7 @@ public class CacheServerLauncher  {
         }
         if ((state != WAITING && state != RUNNING) || msg == null) {
           buffer.append(" - ").append(LocalizedStrings
-                  .CacheServerLauncher_SEE_LOG_FILE_FOR_DETAILS.toLocalizedString());
+              .CacheServerLauncher_SEE_LOG_FILE_FOR_DETAILS.toLocalizedString());
         }
       }
       return buffer.toString();


### PR DESCRIPTION
Fix for SNAP-352

## Changes proposed in this pull request

Having a short status string for normal status reporting which will be used for locator, leader, server status reporting if verbose arg is not given. Added a verbose arg as well.

## Patch testing

Manual.

## ReleaseNotes changes

None.

## Other PRs 

No.