### PR TITLE
SNAP-1177

### DIFF
--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/jna/POSIXNativeCalls.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/jna/POSIXNativeCalls.java
@@ -114,6 +114,7 @@ class POSIXNativeCalls extends NativeCalls {
   public static native int mlockall(int flags);
 
   private static final int EPERM = 1;
+  private static final int ESRCH = 3;
   private static final int ENOMEM = 12;
   private static final int ENOSPC = 28;
 
@@ -246,8 +247,10 @@ class POSIXNativeCalls extends NativeCalls {
     try {
       return kill(processId, 0) == 0;
     } catch (LastErrorException le) {
-      if (le.getErrorCode() == EPERM) {
-        // Process exists; it probably belongs to another user (bug 27698).
+      int errorCode = le.getErrorCode();
+      if (errorCode == EPERM || errorCode == ESRCH) {
+        // EPERM: Process exists; it probably belongs to another user (bug 27698).
+        // ESRCH: No process could be found but it might exist
         return true;
       }
     }


### PR DESCRIPTION
## Changes proposed in this pull request

In SNAP-1177, the test stops a server and restarts it after checking its status (to make sure that it is actually stopped). However while restarting the server, the test always gives exception "java.lang.IllegalStateException: A SnappyData Server is already running in directory ..."

There is an issue in POSIXNativeCalls#isProcessActive. In this function, if the call to kill() throws an exception with error code other than EPERM, the function returns false indicating that the process does not exist. However from Snappy server logs the process actually exists (the server continues to log different ops). In the test, I am always seeing error code ESRCH which is explained here-
https://unix.stackexchange.com/questions/258955/what-does-esrch-mean
http://www.virtsync.com/c-error-codes-include-errno

The process’s existence is checked in CacheServerLauncher#readStatus (line no 1444). The CacheServerLauncher#stop reads status (line 1195) and since in readStatus process is assumed to be non existent, stop() returns 0 declaring server is stopped.

As a fix returning true for the case of ESRCH 

## Patch testing
Ran tests from northWindHA.bt (used to fail almost every time before the fix)
Precheckin to be run prior to merge.

## ReleaseNotes changes
NA
## Other PRs 
NA