### PR TITLE
SNAP-1744: UI itself needs to consistently refer to itself as "SnappyData Pulse"

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/MemberLogsMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/MemberLogsMessage.java
@@ -55,6 +55,11 @@ public class MemberLogsMessage extends MemberExecutorMessage {
 
   private MemberLogsMessage(final MemberLogsMessage other) {
     super(other);
+    this.memberId = other.getMemberId();
+    this.logFileName = other.getLogFileName();
+    this.logDirectory = other.getLogDirectory();
+    this.byteLength = other.getByteLength();
+    this.offset = other.getOffset();
   }
 
   public String getMemberId() {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/MemberStatisticsMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/MemberStatisticsMessage.java
@@ -1,6 +1,5 @@
 package com.pivotal.gemfirexd.internal.engine.sql.execute;
 
-import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collection;
@@ -26,8 +25,6 @@ import com.gemstone.gemfire.internal.VMStatsContract;
 import com.gemstone.gemfire.internal.WindowsSystemStats;
 import com.gemstone.gemfire.internal.cache.DiskStoreImpl;
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
-import com.gemstone.gemfire.internal.process.PidUnavailableException;
-import com.gemstone.gemfire.internal.process.ProcessUtils;
 import com.gemstone.gemfire.internal.shared.NativeCalls;
 import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
 import com.gemstone.gemfire.internal.stats50.VMStats50;
@@ -46,7 +43,7 @@ import org.apache.log4j.FileAppender;
 import org.apache.log4j.Logger;
 
 public class MemberStatisticsMessage extends MemberExecutorMessage {
-  private Logger logger = Logger.getLogger(MemberStatisticsMessage.class);
+
   private static final long MBFactor = 1024 * 1024;
 
   private GemFireCacheImpl gemFireCache;


### PR DESCRIPTION
## Changes proposed in this pull request

  - Code refactoring and code clean up.
  - Feedback changes related to PR (https://github.com/SnappyDataInc/snappy-store/pull/233). 

## Patch testing

- Tested Manually.

## ReleaseNotes changes

- none

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
