### PR TITLE
[SNAP-1854] Uninitialized container throws exception.

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -1931,7 +1931,7 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
           && (indexManager = (GfxdIndexManager)r.getIndexUpdater()) != null) {
         indexManager.drop(tran);
       }
-      if(r == null){
+      if(this.skipListMap != null){
         releaseIndexMemory();
       }
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -1931,7 +1931,7 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
           && (indexManager = (GfxdIndexManager)r.getIndexUpdater()) != null) {
         indexManager.drop(tran);
       }
-      if(this.skipListMap != null){
+      if (this.skipListMap != null) {
         releaseIndexMemory();
       }
     }


### PR DESCRIPTION
## Changes proposed in this pull request
When baseContainer method is invoked for normal tables(non-index tables) it throws an exception .
This method will be called for normal tables also if drop is called before container is initialized properly.
Hence used skipList null check to determine whether this container belongs to an index.
If skiplist is null even for an index that means nothing to account for. Hence can safely skip.

## Patch testing
precheckin pending

## ReleaseNotes changes
NA

## Other PRs 
NA
