### PR TITLE
SNAP-1876 Grant/revoke on column table may not work after restart

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/TablePrivilegeInfo.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/TablePrivilegeInfo.java
@@ -231,6 +231,9 @@ public class TablePrivilegeInfo extends PrivilegeInfo
 		doExecuteGrantRevoke(activation, grant, grantees, columnBitSets, actionAllowed, true, td);
 		GemFireStore ms = Misc.getMemStore();
 		ExternalCatalog ec = ms.getExternalCatalog(); // This may be null during restart
+		if (ec == null && !Misc.initialDDLReplayInProgress()) {
+			throw new IllegalStateException("External catalog not initialized.");
+		}
 		String cbTable = CallbackFactoryProvider.getStoreCallbacks().columnBatchTableName(td
 				.getName());
 		if (ms.isSnappyStore() && Misc.isSecurityEnabled() && ((ec != null && ec.isColumnTable(td

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/TablePrivilegeInfo.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/TablePrivilegeInfo.java
@@ -42,6 +42,7 @@ package com.pivotal.gemfirexd.internal.impl.sql.execute;
 
 import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
 import com.pivotal.gemfirexd.Attribute;
+import com.pivotal.gemfirexd.internal.catalog.ExternalCatalog;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
 import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
@@ -229,10 +230,11 @@ public class TablePrivilegeInfo extends PrivilegeInfo
 	{
 		doExecuteGrantRevoke(activation, grant, grantees, columnBitSets, actionAllowed, true, td);
 		GemFireStore ms = Misc.getMemStore();
-		if (ms.isSnappyStore() && Misc.isSecurityEnabled()
-			&& ms.getExternalCatalog().isColumnTable(td.getSchemaName(), td.getName(), true)) {
-			String cbTable = CallbackFactoryProvider.getStoreCallbacks().columnBatchTableName(td
-					.getName());
+		ExternalCatalog ec = ms.getExternalCatalog(); // This may be null during restart
+		String cbTable = CallbackFactoryProvider.getStoreCallbacks().columnBatchTableName(td
+				.getName());
+		if (ms.isSnappyStore() && Misc.isSecurityEnabled() && ((ec != null && ec.isColumnTable(td
+				.getSchemaName(), td.getName(), true)) || Misc.getRegion(cbTable,false, true) != null)) {
 			DataDictionary dd = activation.getLanguageConnectionContext().getDataDictionary();
 			TableDescriptor ttd = dd.getTableDescriptor(cbTable, td.getSchemaDescriptor(), activation
 					.getLanguageConnectionContext().getTransactionExecute());


### PR DESCRIPTION
## Changes proposed in this pull request
* If external catalog is not available, check if cached batch table exists.
  If yes, grant/revoke the same permissions on it as well.

## Patch testing
precheckin pending

## ReleaseNotes changes
NA

## Other PRs 
https://github.com/SnappyDataInc/snappydata/pull/759