### PR TITLE
SNAP-1830: Pulse dashboard shows incorrect metrics

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/MemberStatisticsMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/MemberStatisticsMessage.java
@@ -99,7 +99,10 @@ public class MemberStatisticsMessage extends MemberExecutorMessage {
     memberStatsMap.put("freeMemory", getFreeMemory());
     memberStatsMap.put("totalMemory", getTotalMemory());
     memberStatsMap.put("usedMemory", getUsedMemory());
-    memberStatsMap.put("cpuActive", getHostCpuUsage());
+
+    int cpuActive = getHostCpuUsage();
+    memberStatsMap.put("cpuActive", cpuActive >= 0 ? cpuActive : 0);
+
     memberStatsMap.put("clients", clientConnectionStats.getConnectionsOpen());
     memberStatsMap.put("diskStoreUUID", getDiskStoreUUID());
     memberStatsMap.put("diskStoreName", getDiskStoreName());


### PR DESCRIPTION
## Changes proposed in this pull request

 - Adding fix to display CPU Usage as zero if cpuActive stats is negative value (maybe in case of MAC OS).

## Patch testing

- Tested Manaully

## ReleaseNotes changes

- None

## Other PRs 

- None
