### PR TITLE
[SNAP-1869] Added a safe check before accounting memory.

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -1436,6 +1436,7 @@ public final class FabricDatabase implements ModuleControl,
         for (GemFireContainer c : allIndexes) {
           if (c.isLocalIndex()) {
             c.getSkipListMap().clear();
+            c.resetInitialAccounting();
           }
         }
       }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -6484,6 +6484,10 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
     }
   }
 
+  public void resetInitialAccounting(){
+    intialAccounting = 0;
+  }
+
   public void accountIndexMemory(boolean askMemoryManager, boolean isDestroy) {
     if (!doAccounting()) {
       return;
@@ -6510,11 +6514,8 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
         if (askMemoryManager) {
           // Only acquire memory while initial index creation. Rest all index accounting will be done by
           // region put/delete
-          Misc.getCacheLogWriter().info("Total overhead computed = "+ sum + " intialAccounting="+intialAccounting);
-          // Negative value means index is being recreated. Kind of hackish but safe and wont stop server from crashing due to
-          // assertion error
-          long totalMemToBeAsked = sum - intialAccounting < 0 ? sum : (sum - intialAccounting);
-          baseRegion.acquirePoolMemory(0, totalMemToBeAsked,
+          Misc.getCacheLogWriter().info("Total overhead computed = "+ sum + " intialAccounting = "+intialAccounting);
+          baseRegion.acquirePoolMemory(0, sum - intialAccounting,
               false, null, false);
           intialAccounting = sum;
           sizeAccountedByIndex.set(sum);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -6510,8 +6510,11 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
         if (askMemoryManager) {
           // Only acquire memory while initial index creation. Rest all index accounting will be done by
           // region put/delete
-          Misc.getCacheLogWriter().info("Total overhead computed="+ sum + "intialAccounting="+intialAccounting);
-          baseRegion.acquirePoolMemory(0, sum - intialAccounting,
+          Misc.getCacheLogWriter().info("Total overhead computed = "+ sum + " intialAccounting="+intialAccounting);
+          // Negative value means index is being recreated. Kind of hackish but safe and wont stop server from crashing due to
+          // assertion error
+          long totalMemToBeAsked = sum - intialAccounting < 0 ? sum : (sum - intialAccounting);
+          baseRegion.acquirePoolMemory(0, totalMemToBeAsked,
               false, null, false);
           intialAccounting = sum;
           sizeAccountedByIndex.set(sum);


### PR DESCRIPTION


## Changes proposed in this pull request
Sometimes index recovery is not consistent with the region and index is rebuilt again.
In such cases, the intialAccounting variable contains stale data. Hence changed it to ignore any intialAccounting if that takes the total memory to less than 0.

## Patch testing

selective dunits. (DDLRoutingDunit test)

## ReleaseNotes changes

NA

## Other PRs 
NA