### PR TITLE
Snapshot cleanup

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegion.java
@@ -180,8 +180,6 @@ public abstract class AbstractRegion implements Region, RegionAttributes,
   
   protected volatile boolean concurrencyChecksEnabled;
 
-  protected boolean snapshotEnabledRegion;
-
   protected boolean earlyAck;
 
   protected final boolean isPdxTypesRegion;
@@ -2248,4 +2246,5 @@ public abstract class AbstractRegion implements Region, RegionAttributes,
     }
     return criteria;
   }
+
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
@@ -2259,14 +2259,6 @@ RETRY_LOOP:
         else {
           cbEvent = null;
         }
-        if (owner.getCache().snapshotEnabledForTX()) {
-          oldRe = NonLocalRegionEntry.newEntryWithoutFaultIn(re, owner, true);
-          oldRe.setUpdateInProgress(true);
-          if (owner.snapshotEnabledRegion /*&& re.getVersionStamp() != null && re.getVersionStamp()
-            .asVersionTag().getEntryVersion() > 0*/) {
-            owner.getCache().addOldEntry(oldRe, re, owner, oldSize);
-          }
-        }
         txRemoveOldIndexEntry(Operation.DESTROY, re);
         boolean clearOccured = false;
         try {
@@ -2323,14 +2315,6 @@ RETRY_LOOP:
         }
         else {
           cbEvent = null;
-        }
-        if (owner.getCache().snapshotEnabledForTX()) {
-          oldRe = NonLocalRegionEntry.newEntryWithoutFaultIn(re, owner, true);
-          if (owner.snapshotEnabledRegion /*&& re.getVersionStamp()!=null && re.getVersionStamp()
-            .asVersionTag().getEntryVersion()>0*/) {
-            owner.getCache().addOldEntry(oldRe, re, owner, 0);
-          }
-
         }
         try {
           EntryEventImpl txEvent = null;
@@ -3951,7 +3935,7 @@ RETRY_LOOP:
                   // check if the event is loaded from HDFS and bucket is secondary then don't set
                   
                   setOldValueInEvent(event, re, cacheWrite, requireOldValue);
-                  if (owner.snapshotEnabledRegion && re.getVersionStamp() != null ) {
+                  if (owner.isSnapshotEnabledRegion() && re.getVersionStamp() != null ) {
                     checkConflict(owner, event, re);
                   }
                   if (!continueUpdate(re, event, ifOld, replaceOnClient)) {
@@ -3975,7 +3959,7 @@ RETRY_LOOP:
                     RegionEntry oldRe = null;
                     try {
                       final int oldSize = event.getLocalRegion().calculateRegionEntryValueSize(re);
-                      if (owner.snapshotEnabledRegion && re.getVersionStamp() != null ) {
+                      if (owner.isSnapshotEnabledRegion() && re.getVersionStamp() != null ) {
                         // we need to do the same for secondary as well.
                         // need to set the version information.
                         if (re.getVersionStamp().asVersionTag().getEntryVersion() > 0) {
@@ -4149,9 +4133,9 @@ RETRY_LOOP:
     // Don't do conflict detection on secondary.
     if (event.getTXState() != null && event.getTXState().isSnapshot()) {
       TXState localState = event.getTXState().getLocalTXState();
-      if(!firstEntry(re)) {
+      if (!firstEntry(re)) {
         if (!TXState.checkEntryInSnapshot(localState, event.getRegion(), re)) {
-          throw new ConflictException("The value has been changed.");
+          throw new ConflictException("The value has changed.");
         }
       }
     }
@@ -4393,7 +4377,7 @@ RETRY_LOOP:
     boolean retVal = false;
     try {
       final int oldSize = _getOwner().calculateRegionEntryValueSize(re);
-      if (_getOwner().snapshotEnabledRegion /*&& re.getVersionStamp() != null && re.getVersionStamp()
+      if (_getOwner().isSnapshotEnabledRegion() /*&& re.getVersionStamp() != null && re.getVersionStamp()
         .asVersionTag().getEntryVersion() > 0*/) {
         // we need to do the same for secondary as well.
         // check Conflict
@@ -4567,16 +4551,6 @@ RETRY_LOOP:
       boolean clearOccured = false;
       boolean isCreate = false;
       try {
-        // Put the copy to into common place instead of all the running tx.
-        // as there is a race.
-        if (owner.getCache().snapshotEnabledForTX()) {
-          oldRe = NonLocalRegionEntry.newEntryWithoutFaultIn(re, owner, true);
-          if (owner.snapshotEnabledRegion /*&& re.getVersionStamp() != null && re.getVersionStamp()
-            .asVersionTag().getEntryVersion() > 0*/) {
-            owner.getCache().addOldEntry(oldRe, re, owner, oldSize);
-          }
-        }
-
         re.setValue(owner, re.prepareValueForCache(owner, newValue, !putOp.isCreate(), false));
         if (putOp.isCreate()) {
           isCreate = true;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -3387,4 +3387,12 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     
   }
 
+  @Override
+  public boolean isSnapshotEnabledRegion() {
+    // concurrency checks is by default true in column table
+    return super.isSnapshotEnabledRegion() ||
+        (getPartitionedRegion().needsBatching() || getPartitionedRegion().columnTable());
+
+  }
+
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -224,8 +224,8 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   public boolean DEFAULT_SNAPSHOT_ENABLED = SystemProperties.getServerInstance().getBoolean(
       "cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", false);
 
-  private final boolean DEFAULT_SNAPSHOT_ENABLED_TX = SystemProperties.getServerInstance().getBoolean(
-      "cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TX", false);
+  private final boolean DEFAULT_SNAPSHOT_ENABLED_TEST = SystemProperties.getServerInstance().getBoolean(
+      "cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", false);
 
   /**
    * Property set to true if resource manager heap percentage is set and query monitor is required
@@ -1411,12 +1411,12 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   public boolean snapshotEnabled() {
     // if rowstore return false
     // if snappy return true
-    return DEFAULT_SNAPSHOT_ENABLED;
+    return snapshotEnabledForTest() || DEFAULT_SNAPSHOT_ENABLED;
   }
 
-  public boolean snapshotEnabledForTX() {
+  public boolean snapshotEnabledForTest() {
     // snapshot should be enabled and if LockingPolicy is RC/RR then it should not be disabled
-    return snapshotEnabled() &&  DEFAULT_SNAPSHOT_ENABLED_TX;
+    return DEFAULT_SNAPSHOT_ENABLED_TEST;
   }
 
   // currently it will wait for a long time

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -875,9 +875,6 @@ public class LocalRegion extends AbstractRegion
     }
 
     this.testCallable = internalRegionArgs.getTestCallable();
-    this.snapshotEnabledRegion = cache.snapshotEnabled() && this.concurrencyChecksEnabled
-        && !isUsedForMetaRegion;
-    
   }
 
   private HdfsRegionManager initHDFSManager() {
@@ -14535,10 +14532,14 @@ public class LocalRegion extends AbstractRegion
     }
   }
 
+  //why is always false?
   public boolean isInternalColumnTable() {
     return isInternalColumnTable;
   }
 
   private boolean isInternalColumnTable = false;
 
+  public boolean isSnapshotEnabledRegion() {
+    return (getCache().snapshotEnabledForTest() && !isUsedForMetaRegion() && concurrencyChecksEnabled);
+  }
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
@@ -2510,6 +2510,7 @@ public class PartitionedRegion extends LocalRegion implements
 
 
   private volatile Boolean columnBatching;
+  private volatile Boolean columnStoreTable;
   public boolean needsBatching() {
     final Boolean columnBatching = this.columnBatching;
     if (columnBatching != null) {
@@ -2529,6 +2530,20 @@ public class PartitionedRegion extends LocalRegion implements
       this.columnBatching = needsBatching;
       return needsBatching;
     }
+  }
+
+  public boolean columnTable() {
+    final Boolean columnTable = this.columnStoreTable;
+    if (columnTable != null) {
+      return columnTable;
+    }
+    // Find all the child region and see if they anyone of them has name ending
+    // with _SHADOW_
+    if (this.getName().toUpperCase().endsWith(StoreCallbacks.SHADOW_TABLE_SUFFIX)) {
+      this.columnStoreTable = true;
+      return true;
+    }
+    return false;
   }
 
   private void handleSendOrWaitException(Exception ex,

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import com.gemstone.gemfire.CancelException;
 import com.gemstone.gemfire.SystemFailure;
@@ -401,7 +400,7 @@ public final class TXState implements TXStateInterface {
 
     // We don't know the semantics for RR, so ideally there shouldn't be snapshot for it.
     // Need to disable it.
-    if (getCache().snapshotEnabled() && (isSnapshot() || getCache().snapshotEnabledForTX())) {
+    if (isSnapshot() && getCache().snapshotEnabled()) {
       takeSnapshot();
     } else {
       this.snapshot = null;
@@ -1151,7 +1150,7 @@ public final class TXState implements TXStateInterface {
     final LogWriterI18n logger = getTxMgr().getLogger();
     // No need to check for snapshot if we want to enable it for RC.
     if (cache.snapshotEnabled()) {
-      if (isSnapshot() || cache.snapshotEnabledForTX()) {
+      if (isSnapshot() || cache.snapshotEnabledForTest()) {
         // first take a lock at cache level so that we don't go into deadlock or sort array before
         // This is for tx RC, for snapshot just record all the versions from the queue
         //TODO: this is performance issue: Need to make the lock granular at region level.
@@ -3973,7 +3972,7 @@ public final class TXState implements TXStateInterface {
   }
 
   private boolean shouldGetOldEntry(LocalRegion region) {
-    return (region.getCache().snapshotEnabled() && (isSnapshot() || region.getCache().snapshotEnabledForTX()));
+    return region.isSnapshotEnabledRegion();
   }
 
   // Writer should add old entry with tombstone with region version in the common map

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateProxy.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateProxy.java
@@ -2989,7 +2989,7 @@ public class TXStateProxy extends NonReentrantReadWriteLock implements
     DistributionAdvisor advisor = null;
     long viewVersion = -1;
     if (dataRegion != null) {
-      if (hasPossibleRecipients) {
+      if (hasPossibleRecipients && !isSnapshot()) {
         advisor = dataRegion.getDistributionAdvisor();
         viewVersion = advisor.startOperation();
         if (LOG_VERSIONS) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateProxy.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateProxy.java
@@ -596,7 +596,7 @@ public class TXStateProxy extends NonReentrantReadWriteLock implements
     this.isJCA = false;
     if (flags == null) {
       this.lockPolicy = LockingPolicy.fromIsolationLevel(isolationLevel, false);
-      this.enableBatching = ENABLE_BATCHING;
+      this.enableBatching = (this.lockPolicy == LockingPolicy.SNAPSHOT)? false: ENABLE_BATCHING;
       this.syncCommits = (this.lockPolicy == LockingPolicy.SNAPSHOT)?  true: false;
     }
     else {
@@ -606,7 +606,7 @@ public class TXStateProxy extends NonReentrantReadWriteLock implements
         this.enableBatching = false;
       }
       else {
-        this.enableBatching = ENABLE_BATCHING;
+        this.enableBatching = (this.lockPolicy == LockingPolicy.SNAPSHOT)? false: ENABLE_BATCHING;
       }
       this.syncCommits = (this.lockPolicy == LockingPolicy.SNAPSHOT) ? true :
           flags.contains(TransactionFlag.SYNC_COMMITS);
@@ -739,8 +739,8 @@ public class TXStateProxy extends NonReentrantReadWriteLock implements
 
   public final boolean batchingEnabled() {
     final TXManagerImpl.TXContext context;
-    return this.enableBatching || ((context = TXManagerImpl.currentTXContext())
-        != null && context.forceBatching);
+    return !isSnapshot() && (this.enableBatching || ((context = TXManagerImpl.currentTXContext())
+        != null && context.forceBatching));
   }
 
   public final boolean skipBatchFlushOnCoordinator() {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/versions/RegionVersionVector.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/versions/RegionVersionVector.java
@@ -750,7 +750,7 @@ public abstract class RegionVersionVector<T extends VersionSource<?>> implements
       TXStateInterface tx = event.getTXState();
 
       if (tx != null) {
-        if (!tx.isSnapshot() && !cache.snapshotEnabledForTX()) {
+        if (!tx.isSnapshot()) {
           return;
         }
         boolean committed = false;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/GemFireTransaction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/GemFireTransaction.java
@@ -3270,7 +3270,7 @@ public final class GemFireTransaction extends RawTransaction implements
       }
       final GemFireTransaction tran = (GemFireTransaction)lcc
           .getTransactionExecute();
-      if (tran != null && tran.state != ACTIVE) {
+      if (tran != null && ((TXManagerImpl.getCurrentSnapshotTXState() != null) || tran.state != ACTIVE)) {
         try {
           tran.setActiveStateForTransaction();
         } catch (StandardException se) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/heap/MemHeapScanController.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/heap/MemHeapScanController.java
@@ -407,15 +407,16 @@ public class MemHeapScanController implements MemScanController, RowCountable,
         restoreBatching = this.localTXState.getProxy().remoteBatching(true);
       }
     }
-    else if (Misc.getGemFireCache().snapshotEnabled()) {
+    else if (this.gfContainer.isRowBuffer() ||
+        (region.getCache().snapshotEnabledForTest() && region.getConcurrencyChecksEnabled())) {
+
       // Start snapshot tx only for read operations.but not for read_only mode
-      boolean forReadOnly = (this.openMode & GfxdConstants
-          .SCAN_OPENMODE_FOR_READONLY_LOCK) != 0;
+      //boolean forReadOnly = (this.openMode & GfxdConstants
+      //    .SCAN_OPENMODE_FOR_READONLY_LOCK) != 0;
       if (region.getConcurrencyChecksEnabled() &&
-          region.getCache().snapshotEnabled() &&
           (region.getCache().getCacheTransactionManager().getTXState() == null)
-          && (this.forUpdate == 0)
-          && !forReadOnly) {
+          /*&& (this.forUpdate == 0)*/
+          /*&& !forReadOnly*/) {
 
         if (GemFireXDUtils.TraceQuery) {
           SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_QUERYDISTRIB,
@@ -565,7 +566,7 @@ public class MemHeapScanController implements MemScanController, RowCountable,
       // clear the txState so that other thread local is cleared.
       TXManagerImpl.getOrCreateTXContext().clearTXState();
       // gemfire tx shouldn't be cleared in case of row buffer scan
-      if (!(this.getGemFireContainer().isRowBuffer() && lcc.isSkipConstraintChecks())) {
+      if (!(this.getGemFireContainer().isRowBuffer() /*&& lcc.isSkipConstraintChecks()*/)) {
         if (GemFireXDUtils.TraceQuery) {
           SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_QUERYDISTRIB,
               "MemHeapScanController::positionAtInitScan bucketSet: " + " lcc.isSkipConstraintChecks " + lcc.isSkipConstraintChecks() +

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/GfxdIndexManager.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/GfxdIndexManager.java
@@ -651,7 +651,11 @@ public final class GfxdIndexManager implements Dependent, IndexUpdater,
       // No constraint checking for destroy since that is done by
       // ReferencedKeyCheckerMessage if required.
       // Also check if foreign key constraint check is really required.
-      final TXStateInterface tx = event.getTXState(owner);
+      TXStateInterface tx = event.getTXState(owner);
+      if (tx != null && tx.isSnapshot()) {
+        tx = null;
+      }
+
       final RowLocation rl = entry instanceof RowLocation ? (RowLocation)entry
           : null;
       final boolean skipDistribution;
@@ -1044,7 +1048,10 @@ public final class GfxdIndexManager implements Dependent, IndexUpdater,
     }
     final Operation op = event.getOperation();
     //try {
-    final TXStateInterface tx = event.getTXState(owner);
+    TXStateInterface tx = event.getTXState(owner);
+    if (tx != null && tx.isSnapshot()) {
+      tx = null;
+    }
     if (success && tx == null /* txnal ops will update this at commit */) {
       if (!(op.isUpdate() && event.hasDelta())) {
         this.container.updateNumRows(op.isDestroy());

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdConnectionWrapper.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdConnectionWrapper.java
@@ -914,13 +914,13 @@ public final class GfxdConnectionWrapper {
     }
     final int reqIsolationLevel = tx.getIsolationLevel()
         .getJdbcIsolationLevel();
+    if (tx.isSnapshot()) {
+      tran.setActiveTXState(tx, false);
+      return;
+    }
     if (reqIsolationLevel == currentIsolationLevel) {
       // GFE TX could have changed so set the new one in the GFXD transaction
       tran.setActiveTXState(tx, true);
-      return;
-    }
-    if (tx.isSnapshot()) {
-      tran.setActiveTXState(tx, false);
       return;
     }
     if (currentIsolationLevel != Connection.TRANSACTION_NONE) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/GemFireInsertResultSet.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/GemFireInsertResultSet.java
@@ -141,7 +141,7 @@ public final class GemFireInsertResultSet extends AbstractGemFireResultSet {
 
     TXStateInterface tx = this.gfContainer.getActiveTXState(this.tran);
     // TOOD: decide on autocommit or this flag: Discuss
-    if (false && tx == null /*&& this.gfContainer.isRowBuffer()*/) {
+    if (tx == null && (this.gfContainer.isRowBuffer() || reg.getCache().snapshotEnabledForTest())) {
       this.tran.getTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
       ((GemFireTransaction)lcc.getTransactionExecute()).setActiveTXState(TXManagerImpl.getCurrentTXState(), false);
       this.tran.setImplicitSnapshotTxStarted(true);

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/MVCCDUnitTest.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/MVCCDUnitTest.java
@@ -51,11 +51,11 @@ public class MVCCDUnitTest extends DistributedSQLTestBase {
 
   @Override
   public void setUp() throws Exception {
-    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "true");
+    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "true");
     invokeInEveryVM(new SerializableRunnable() {
       @Override
       public void run() {
-        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "true");
+        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "true");
       }
     });
     super.setUp();
@@ -63,11 +63,11 @@ public class MVCCDUnitTest extends DistributedSQLTestBase {
 
   @Override
   public void tearDown2() throws Exception {
-    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "false");
+    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "false");
     invokeInEveryVM(new SerializableRunnable() {
       @Override
       public void run() {
-        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "false");
+        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "false");
       }
     });
     super.tearDown2();
@@ -118,7 +118,7 @@ public class MVCCDUnitTest extends DistributedSQLTestBase {
 
         try {
           final GemFireCacheImpl cache = GemFireCacheImpl.getInstance();
-          //final Region r = cache.getRegion(regionName);
+          //final Region r = cache.getRegion(tableName);
           cache.getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
           Connection conn = TestUtil.getConnection();
           conn.setTransactionIsolation(Connection.TRANSACTION_NONE);

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapShotTxDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapShotTxDUnit.java
@@ -59,11 +59,11 @@ public class SnapShotTxDUnit extends DistributedSQLTestBase {
 
   @Override
   public void setUp() throws Exception {
-    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "true");
+    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "true");
     invokeInEveryVM(new SerializableRunnable() {
       @Override
       public void run() {
-        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "true");
+        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "true");
       }
     });
     super.setUp();
@@ -71,11 +71,11 @@ public class SnapShotTxDUnit extends DistributedSQLTestBase {
 
   @Override
   public void tearDown2() throws Exception {
-    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "false");
+    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "false");
     invokeInEveryVM(new SerializableRunnable() {
       @Override
       public void run() {
-        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "false");
+        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "false");
       }
     });
     super.tearDown2();

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapshotTransactionDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapshotTransactionDUnit.java
@@ -1,5 +1,6 @@
 package com.pivotal.gemfirexd.transactions;
 
+import java.sql.BatchUpdateException;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLTransactionRollbackException;
@@ -774,7 +775,8 @@ public class SnapshotTransactionDUnit extends DistributedSQLTestBase {
           }
           stmt.executeBatch();
         } catch (Exception e) {
-          exception[0] = e;
+          if(!(e instanceof BatchUpdateException))
+            exception[0] = e;
           e.printStackTrace();
         }
       }
@@ -820,9 +822,7 @@ public class SnapshotTransactionDUnit extends DistributedSQLTestBase {
         stmt.addBatch(stmtString);
       }
       stmt.executeBatch();
-      //fail("Expected some exception, primary key violation");
     } catch (Exception e) {
-      // fail with some exception
     }
 
     server1.invoke(
@@ -871,13 +871,13 @@ public class SnapshotTransactionDUnit extends DistributedSQLTestBase {
       while (rs.next()) {
         num++;
       }
-      assertTrue("Expected 50 but was " + num, num == 50);
+      assertTrue("Expected 100 but was " + num, num == 100);
 
     } catch (Exception e) {
       exception[0] = e;
       e.printStackTrace();
     }
-    if (exception != null) {
+    if (exception[0] != null) {
       throw exception[0];
     }
   }
@@ -988,7 +988,8 @@ public class SnapshotTransactionDUnit extends DistributedSQLTestBase {
           }
           stmt.executeBatch();
         } catch (Exception e) {
-          exception[0] = e;
+          if(!(e instanceof BatchUpdateException))
+            exception[0] = e;
           e.printStackTrace();
         }
       }
@@ -1034,9 +1035,10 @@ public class SnapshotTransactionDUnit extends DistributedSQLTestBase {
         stmt.addBatch(stmtString);
       }
       stmt.executeBatch();
-      //fail("Expected some exception, primary key violation");
     } catch (Exception e) {
-      // fail with some exception
+      if (!(e instanceof BatchUpdateException))
+        exception[0] = e;
+      e.printStackTrace();
     }
 
     server1.invoke(
@@ -1084,13 +1086,13 @@ public class SnapshotTransactionDUnit extends DistributedSQLTestBase {
       while (rs.next()) {
         num++;
       }
-      assertTrue("Expected 50 but was " + num, num == 100);
+      assertTrue("Expected 100 but was " + num, num == 100);
 
     } catch (Exception e) {
       exception[0] = e;
       e.printStackTrace();
     }
-    if (exception != null) {
+    if (exception[0] != null) {
       throw exception[0];
     }
 
@@ -1104,7 +1106,7 @@ public class SnapshotTransactionDUnit extends DistributedSQLTestBase {
       while (rs.next()) {
         num++;
       }
-      assertTrue("Expected 50 but was " + num, num == 100);
+      assertTrue("Expected 100 but was " + num, num == 100);
 
     } catch (Exception e) {
       exception[0] = e;
@@ -1123,7 +1125,7 @@ public class SnapshotTransactionDUnit extends DistributedSQLTestBase {
       while (rs.next()) {
         num++;
       }
-      assertTrue("Expected 50 but was " + num, num == 100);
+      assertTrue("Expected 100 but was " + num, num == 100);
 
     } catch (Exception e) {
       exception[0] = e;

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapshotTransactionDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapshotTransactionDUnit.java
@@ -1,0 +1,1141 @@
+package com.pivotal.gemfirexd.transactions;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLTransactionRollbackException;
+import java.sql.Statement;
+import java.util.Collection;
+import java.util.Properties;
+
+import com.gemstone.gemfire.cache.ConflictException;
+import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
+import com.gemstone.gemfire.internal.cache.TXManagerImpl;
+import com.gemstone.gemfire.internal.cache.TXStateProxy;
+import com.gemstone.gemfire.internal.cache.TransactionObserver;
+import com.gemstone.gemfire.internal.cache.TransactionObserverAdapter;
+import com.pivotal.gemfirexd.DistributedSQLTestBase;
+import com.pivotal.gemfirexd.TestUtil;
+import com.pivotal.gemfirexd.internal.engine.Misc;
+import io.snappydata.test.dunit.SerializableRunnable;
+import io.snappydata.test.dunit.VM;
+
+public class SnapshotTransactionDUnit extends DistributedSQLTestBase {
+
+  String tableName = "APP.TABLE1";
+  boolean testBatchInsert = false;
+
+  public SnapshotTransactionDUnit(String name) {
+    super(name);
+  }
+
+  @Override
+  protected String reduceLogging() {
+    return "fine";
+  }
+
+
+  @Override
+  public void setUp() throws Exception {
+    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "true");
+    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "true");
+    invokeInEveryVM(new SerializableRunnable() {
+      @Override
+      public void run() {
+        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "true");
+        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "true");
+      }
+    });
+    super.setUp();
+  }
+
+  @Override
+  public void tearDown2() throws Exception {
+    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "false");
+    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "false");
+    invokeInEveryVM(new SerializableRunnable() {
+      @Override
+      public void run() {
+        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "false");
+        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "false");
+      }
+    });
+    super.tearDown2();
+  }
+
+  // test for default jdbc snapshot insert
+
+  public void testDefaultJDBCSnapshotInsert() throws Exception {
+    Exception[] exception = new Exception[1];
+    startVMs(1, 2);
+    Properties props = new Properties();
+    final Connection conn = TestUtil.getConnection(props);
+    clientSQLExecute(1, "create table " + tableName + " (intcol int not null, text varchar" +
+        "(100) not null) partition by column(intcol)  buckets 7 redundancy 1 persistent enable concurrency checks");
+
+    VM server1 = this.serverVMs.get(0);
+    VM server2 = this.serverVMs.get(1);
+    server1.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if(!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    server2.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if(!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    Thread t = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          final Connection conn = TestUtil.getConnection();
+          Statement stmt = conn.createStatement();
+          for (int i = 0; i < 5; i++) {
+            String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+            stmt.addBatch(stmtString);
+          }
+          stmt.executeBatch();
+        } catch (Exception e) {
+          exception[0] = e;
+          e.printStackTrace();
+        }
+      }
+    });
+    t.start();
+    Thread.sleep(1000);
+
+    server1.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Connection conn2 = TestUtil.getConnection();
+              Statement stmt2 = conn2.createStatement();
+              ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+              assert (!rs.next());
+            } catch (Exception e) {
+              exception[0] = e;
+              e.printStackTrace();
+            }
+          }
+        });
+    server2.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Connection conn2 = TestUtil.getConnection();
+              Statement stmt2 = conn2.createStatement();
+              ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+              assert (!rs.next());
+            } catch (Exception e) {
+              exception[0] = e;
+              e.printStackTrace();
+            }
+          }
+        });
+
+    server1.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+
+    server2.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+
+    t.join();
+
+    try {
+      Statement stmt2 = conn.createStatement();
+      ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+      int num = 0;
+      while (rs.next()) {
+        num++;
+      }
+      assertTrue("Expected 5 but was " + num, num == 5);
+
+    } catch (Exception e) {
+      exception[0] = e;
+      e.printStackTrace();
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+  }
+
+  // test for default jdbc snapshot insert with conflict
+  public void testDefaultJDBCSnapshotInsertWithConflict() throws Exception {
+    Exception[] exception = new Exception[1];
+    startVMs(1, 2);
+    Properties props = new Properties();
+    final Connection conn = TestUtil.getConnection(props);
+    clientSQLExecute(1, "create table " + tableName + " (intcol int not null, text varchar" +
+        "(100) not null) partition by column(intcol)  buckets 7 redundancy 1 persistent enable concurrency checks");
+
+    Statement stmt = conn.createStatement();
+    for (int i = 0; i < 100; i++) {
+      String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+      stmt.addBatch(stmtString);
+    }
+    stmt.executeBatch();
+
+    VM server1 = this.serverVMs.get(0);
+    VM server2 = this.serverVMs.get(1);
+    server1.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if(!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    server2.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if(!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    Thread t = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          final Connection conn = TestUtil.getConnection();
+          Statement stmt = conn.createStatement();
+          stmt.executeUpdate("update " + tableName + " set text= 'suranjan' where intcol > 50");
+        } catch (Exception e) {
+          exception[0] = e;
+          e.printStackTrace();
+        }
+      }
+    });
+    t.start();
+    Thread.sleep(1000);
+
+    try {
+      stmt = conn.createStatement();
+      stmt.executeUpdate("update " + tableName + " set text= 'kumar' where intcol > 30");
+      fail("Expected conflict exception");
+    } catch (Exception e) {
+      if (!(e instanceof SQLTransactionRollbackException)) {
+        exception[0] = e;
+        e.printStackTrace();
+      }
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+    server2.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Connection conn2 = TestUtil.getConnection();
+              Statement stmt2 = conn2.createStatement();
+              ResultSet rs = stmt2.executeQuery("select * from " + tableName + " where text='suranjan'");
+              assert (!rs.next());
+            } catch (Exception e) {
+              exception[0] = e;
+              e.printStackTrace();
+            }
+          }
+        });
+
+    server1.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+
+    server2.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+
+    t.join();
+
+    try {
+      Statement stmt2 = conn.createStatement();
+      ResultSet rs = stmt2.executeQuery("select * from " + tableName + " where text='suranjan'");
+      int num = 0;
+      while (rs.next()) {
+        num++;
+      }
+      assertTrue("Expected 49 but was " + num, num == 49);
+
+    } catch (Exception e) {
+      exception[0] = e;
+      e.printStackTrace();
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+  }
+
+
+  // test rollback due to conflict of update/delete
+  // test for default jdbc snapshot insert with conflict
+  public void testDefaultJDBCSnapshotUpdateDeleteConflict() throws Exception {
+    Exception[] exception = new Exception[1];
+    startVMs(1, 2);
+    Properties props = new Properties();
+    final Connection conn = TestUtil.getConnection(props);
+    clientSQLExecute(1, "create table " + tableName + " (intcol int not null, text varchar" +
+        "(100) not null) partition by column(intcol)  buckets 7 redundancy 1 persistent enable concurrency checks");
+
+    Statement stmt = conn.createStatement();
+    for (int i = 0; i < 100; i++) {
+      String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+      stmt.addBatch(stmtString);
+    }
+    stmt.executeBatch();
+
+    VM server1 = this.serverVMs.get(0);
+    VM server2 = this.serverVMs.get(1);
+    server1.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if(!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    server2.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if(!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    Thread t = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          final Connection conn = TestUtil.getConnection();
+          Statement stmt = conn.createStatement();
+          stmt.executeUpdate("update " + tableName + " set text= 'suranjan' where intcol > 50");
+        } catch (Exception e) {
+          exception[0] = e;
+          e.printStackTrace();
+        }
+      }
+    });
+    t.start();
+    Thread.sleep(5000);
+    getLogWriter().info("Did update which must be blocked ");
+
+    try {
+      stmt = conn.createStatement();
+      stmt.executeUpdate("delete from " + tableName + " where intcol > 30");
+      fail("Expected conflict exception");
+    } catch (Exception e) {
+      if (!(e instanceof SQLTransactionRollbackException)) {
+        exception[0] = e;
+        e.printStackTrace();
+      }
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+
+    getLogWriter().info("Did delete ops.. ");
+    server2.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Connection conn2 = TestUtil.getConnection();
+              Statement stmt2 = conn2.createStatement();
+              ResultSet rs = stmt2.executeQuery("select * from " + tableName + " where text='suranjan'");
+              assert (!rs.next());
+            } catch (Exception e) {
+              exception[0] = e;
+              e.printStackTrace();
+            }
+          }
+        });
+    getLogWriter().info("SKSK Did select in both vm ");
+    server1.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+
+
+    server2.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+    getLogWriter().info("SKSK Did notify in both the vm. ");
+
+    t.join();
+
+    getLogWriter().info("SKSK update completed. ");
+
+    try {
+      Statement stmt2 = conn.createStatement();
+      ResultSet rs = stmt2.executeQuery("select * from " + tableName + " where text='suranjan'");
+      int num = 0;
+      while (rs.next()) {
+        num++;
+      }
+      assertTrue("Expected 49 but was " + num, num == 49);
+
+    } catch (Exception e) {
+      exception[0] = e;
+      e.printStackTrace();
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+    getLogWriter().info("SKSK Test completed successfully.");
+  }
+
+//test rollback due to conflict
+
+  public void testRollbackDueToConflict() throws Exception {
+    Exception[] exception = new Exception[2];
+    startVMs(1, 2);
+    Properties props = new Properties();
+    final Connection conn = TestUtil.getConnection(props);
+
+    clientSQLExecute(1, "create table " + tableName + " (intcol int not null, text varchar" +
+        "(100) not null, primary key (intcol))  partition by column(intcol)  buckets 7 redundancy 1 persistent enable concurrency checks");
+
+    VM server1 = this.serverVMs.get(0);
+    VM server2 = this.serverVMs.get(1);
+    server1.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if(!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    server2.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if(!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    Thread t = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          final Connection conn = TestUtil.getConnection();
+          Statement stmt = conn.createStatement();
+          for (int i = 0; i < 50; i++) {
+            String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+            stmt.addBatch(stmtString);
+          }
+          stmt.executeBatch();
+        } catch (Exception e) {
+          exception[0] = e;
+          e.printStackTrace();
+        }
+      }
+    });
+    t.start();
+    Thread.sleep(1000);
+
+    server1.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Connection conn2 = TestUtil.getConnection();
+              Statement stmt2 = conn2.createStatement();
+              ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+              assert (!rs.next());
+            } catch (Exception e) {
+              exception[0] = e;
+              e.printStackTrace();
+            }
+          }
+        });
+    server2.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Connection conn2 = TestUtil.getConnection();
+              Statement stmt2 = conn2.createStatement();
+              ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+              assert (!rs.next());
+            } catch (Exception e) {
+              exception[0] = e;
+              e.printStackTrace();
+            }
+          }
+        });
+
+    try {
+      Statement stmt = conn.createStatement();
+      for (int i = 40; i < 100; i++) {
+        String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+        stmt.addBatch(stmtString);
+      }
+      stmt.executeBatch();
+      //fail("Expected some exception, primary key violation");
+    } catch (Exception e) {
+      // fail with some exception
+    }
+
+    server1.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+
+    server2.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+
+    t.join();
+
+    try {
+      Connection conn2 = TestUtil.getConnection();
+      Statement stmt2 = conn.createStatement();
+      ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+      int num = 0;
+      while (rs.next()) {
+        num++;
+      }
+      assertTrue("Expected 50 but was " + num, num == 50);
+
+    } catch (Exception e) {
+      exception[0] = e;
+      e.printStackTrace();
+    }
+    if (exception != null) {
+      throw exception[0];
+    }
+  }
+
+  // test for rollback (persistent table with rollback) restart after LULL period should see only committed data
+  public void testRollbackDueToConflictRestart() throws Exception {
+    Exception[] exception = new Exception[2];
+    startVMs(1, 2);
+    Properties props = new Properties();
+    final Connection conn = TestUtil.getConnection(props);
+
+    clientSQLExecute(1, "create table " + tableName + " (intcol int not null, text varchar" +
+        "(100) not null, primary key (intcol))  partition by column(intcol)  buckets 7 redundancy 1 persistent enable concurrency checks");
+
+    VM server1 = this.serverVMs.get(0);
+    VM server2 = this.serverVMs.get(1);
+    server1.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if (!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    server2.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if (!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    Thread t = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          final Connection conn = TestUtil.getConnection();
+          Statement stmt = conn.createStatement();
+          for (int i = 0; i < 50; i++) {
+            String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+            stmt.addBatch(stmtString);
+          }
+          stmt.executeBatch();
+        } catch (Exception e) {
+          exception[0] = e;
+          e.printStackTrace();
+        }
+      }
+    });
+    t.start();
+    Thread.sleep(2000);
+
+    server1.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Connection conn2 = TestUtil.getConnection();
+              Statement stmt2 = conn2.createStatement();
+              ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+              assert (!rs.next());
+            } catch (Exception e) {
+              exception[0] = e;
+              e.printStackTrace();
+            }
+          }
+        });
+    server2.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Connection conn2 = TestUtil.getConnection();
+              Statement stmt2 = conn2.createStatement();
+              ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+              assert (!rs.next());
+            } catch (Exception e) {
+              exception[0] = e;
+              e.printStackTrace();
+            }
+          }
+        });
+
+    try {
+      Statement stmt = conn.createStatement();
+      for (int i = 40; i < 100; i++) {
+        String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+        stmt.addBatch(stmtString);
+      }
+      stmt.executeBatch();
+      //fail("Expected some exception, primary key violation");
+    } catch (Exception e) {
+      // fail with some exception
+    }
+
+    server1.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+
+    server2.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+
+    t.join();
+
+    try {
+      Statement stmt2 = conn.createStatement();
+      ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+      int num = 0;
+      while (rs.next()) {
+        num++;
+      }
+      assertTrue("Expected 50 but was " + num, num == 100);
+
+    } catch (Exception e) {
+      exception[0] = e;
+      e.printStackTrace();
+    }
+    if (exception != null) {
+      throw exception[0];
+    }
+
+    startServerVMs(1, 0, null);
+    VM server3 = this.serverVMs.get(2);
+
+    try {
+      Statement stmt2 = conn.createStatement();
+      ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+      int num = 0;
+      while (rs.next()) {
+        num++;
+      }
+      assertTrue("Expected 50 but was " + num, num == 100);
+
+    } catch (Exception e) {
+      exception[0] = e;
+      e.printStackTrace();
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+
+    stopVMNum(-1);
+    stopVMNum(-2);
+    try {
+      Statement stmt2 = conn.createStatement();
+      ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+      int num = 0;
+      while (rs.next()) {
+        num++;
+      }
+      assertTrue("Expected 50 but was " + num, num == 100);
+
+    } catch (Exception e) {
+      exception[0] = e;
+      e.printStackTrace();
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+  }
+
+
+
+}
+
+

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapshotTransactionPersistenTableDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapshotTransactionPersistenTableDUnit.java
@@ -1,0 +1,707 @@
+package com.pivotal.gemfirexd.transactions;
+
+import java.sql.BatchUpdateException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLTransactionRollbackException;
+import java.sql.Statement;
+import java.util.Collection;
+import java.util.Properties;
+
+import com.gemstone.gemfire.cache.IsolationLevel;
+import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
+import com.gemstone.gemfire.internal.cache.TXManagerImpl;
+import com.gemstone.gemfire.internal.cache.TXStateProxy;
+import com.gemstone.gemfire.internal.cache.TransactionObserver;
+import com.gemstone.gemfire.internal.cache.TransactionObserverAdapter;
+import com.pivotal.gemfirexd.DistributedSQLTestBase;
+import com.pivotal.gemfirexd.TestUtil;
+import com.pivotal.gemfirexd.internal.engine.Misc;
+import io.snappydata.test.dunit.SerializableRunnable;
+import io.snappydata.test.dunit.VM;
+
+public class SnapshotTransactionPersistenTableDUnit extends DistributedSQLTestBase {
+
+  String tableName = "APP.TABLE1";
+  boolean testBatchInsert = false;
+
+  private final static String DISKSTORE = "SnapshotTransactionPersistenTableDUnit";
+
+
+  public SnapshotTransactionPersistenTableDUnit(String name) {
+    super(name);
+  }
+
+  @Override
+  protected String reduceLogging() {
+    return "fine";
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "true");
+    invokeInEveryVM(new SerializableRunnable() {
+      @Override
+      public void run() {
+        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "true");
+      }
+    });
+    super.setUp();
+  }
+
+  @Override
+  public void tearDown2() throws Exception {
+    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "false");
+    invokeInEveryVM(new SerializableRunnable() {
+      @Override
+      public void run() {
+        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "false");
+      }
+    });
+    super.tearDown2();
+  }
+
+  public String getSuffix() throws Exception {
+    String suffix = " PERSISTENT " + "'" + DISKSTORE + "'";
+    return suffix;
+  }
+
+  public void createDiskStore(boolean useClient, int vmNum) throws Exception {
+    SerializableRunnable csr = getDiskStoreCreator(DISKSTORE);
+    if (useClient) {
+      if (vmNum == 1) {
+        csr.run();
+      } else {
+        clientExecute(vmNum, csr);
+      }
+    } else {
+      serverExecute(vmNum, csr);
+    }
+  }
+
+  public void testNodeRecycleBatchConflict() throws Exception {
+    Exception[] exception = new Exception[2];
+    startVMs(1, 2);
+    createDiskStore(true, 1);
+
+    Properties props = new Properties();
+    final Connection conn = TestUtil.getConnection(props);
+
+    clientSQLExecute(1, "create table " + tableName + " (intcol int not null, text varchar" +
+        "(100) not null, primary key (intcol))  partition by column(intcol)  buckets 7 redundancy 1 " + getSuffix() + " enable concurrency checks");
+
+    VM server1 = this.serverVMs.get(0);
+    VM server2 = this.serverVMs.get(1);
+
+    server1.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if (!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    server2.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if (!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    Thread t = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          final Connection conn = TestUtil.getConnection();
+          Statement stmt = conn.createStatement();
+          for (int i = 0; i < 50; i++) {
+            String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+
+            stmt.addBatch(stmtString);
+            getLogWriter().info("Inserting " + i);
+          }
+          getLogWriter().info("Executing btach first time");
+          stmt.executeBatch();
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      }
+    });
+    t.start();
+    Thread.sleep(5000);
+
+    try {
+      Statement stmt = conn.createStatement();
+      for (int i = 40; i < 100; i++) {
+        String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+        stmt.addBatch(stmtString);
+        getLogWriter().info("Inserting ..second " + i);
+      }
+      getLogWriter().info("Executing btach  second time ");
+      stmt.executeBatch();
+      //fail("Expected some exception, primary key violation");
+    } catch (Exception e) {
+      // fail with some exception
+    }
+
+    server1.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+
+    server2.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+    t.join();
+
+    try {
+      Statement stmt2 = conn.createStatement();
+      ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+      int num = 0;
+      while (rs.next()) {
+        num++;
+      }
+      assertTrue("Expected 50 but was " + num, num == 100);
+
+    } catch (Exception e) {
+      exception[0] = e;
+      e.printStackTrace();
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+
+    restartVMNums(-1, -2);
+
+    try {
+      Statement stmt2 = conn.createStatement();
+      ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+      int num = 0;
+      while (rs.next()) {
+        num++;
+      }
+      assertTrue("Expected 50 but was " + num, num == 100);
+
+    } catch (Exception e) {
+      exception[0] = e;
+      e.printStackTrace();
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+  }
+
+  public void testDefaultJDBCSnapshotUpdateDeleteConflict() throws Exception {
+    Exception[] exception = new Exception[1];
+    startVMs(1, 2);
+    createDiskStore(true, 1);
+    Properties props = new Properties();
+    final Connection conn = TestUtil.getConnection(props);
+    clientSQLExecute(1, "create table " + tableName + " (intcol int not null, text varchar" +
+        "(100) not null) partition by column(intcol)  buckets 7 redundancy 1 " + getSuffix() + " enable concurrency checks");
+
+    Statement stmt = conn.createStatement();
+    for (int i = 0; i < 100; i++) {
+      String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+      stmt.addBatch(stmtString);
+    }
+    stmt.executeBatch();
+
+    VM server1 = this.serverVMs.get(0);
+    VM server2 = this.serverVMs.get(1);
+    server1.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if(!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    server2.invoke(new SerializableRunnable() {
+      @Override
+      public void run() {
+        TXManagerImpl txMgr = GemFireCacheImpl.getExisting()
+            .getCacheTransactionManager();
+        txMgr.setObserver(new TransactionObserverAdapter() {
+          Object lock1 = new Object();
+          Object lock2 = new Object();
+          boolean alreadyWaiting = false;
+          @Override
+          public void duringIndividualCommit(TXStateProxy tx,
+              Object callbackArg) {
+
+            if (callbackArg == "test") {
+              synchronized (lock1) {
+                lock1.notify();
+              }
+              return;
+            }
+            if(!alreadyWaiting) {
+              alreadyWaiting = true;
+              try {
+                synchronized (lock1) {
+                  lock1.wait();
+                }
+              } catch (InterruptedException ie) {
+                // ignore
+              }
+            }
+          }
+
+          public void notifyCommit() {
+            synchronized (lock1) {
+              lock1.notify();
+            }
+          }
+        });
+      }
+    });
+
+    Thread t = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          final Connection conn = TestUtil.getConnection();
+          Statement stmt = conn.createStatement();
+          stmt.executeUpdate("update " + tableName + " set text= 'suranjan' where intcol > 50");
+        } catch (Exception e) {
+          exception[0] = e;
+          e.printStackTrace();
+        }
+      }
+    });
+    t.start();
+    Thread.sleep(5000);
+    getLogWriter().info("Did update which must be blocked ");
+
+    try {
+      stmt = conn.createStatement();
+      stmt.executeUpdate("delete from " + tableName + " where intcol > 30");
+      fail("Expected conflict exception");
+    } catch (Exception e) {
+      if (!(e instanceof SQLTransactionRollbackException)) {
+        exception[0] = e;
+        e.printStackTrace();
+      }
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+
+    getLogWriter().info("Did delete ops.. ");
+    server2.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Connection conn2 = TestUtil.getConnection();
+              Statement stmt2 = conn2.createStatement();
+              ResultSet rs = stmt2.executeQuery("select * from " + tableName + " where text='suranjan'");
+              assert (!rs.next());
+            } catch (Exception e) {
+              exception[0] = e;
+              e.printStackTrace();
+            }
+          }
+        });
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+    getLogWriter().info("SKSK Did select in both vm ");
+    server1.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+
+    server2.invoke(
+        new SerializableRunnable() {
+          @Override
+          public void run() {
+            try {
+              Collection<TXStateProxy> proxies = Misc.getGemFireCache().getCacheTransactionManager().getHostedTransactionsInProgress();
+              for (TXStateProxy tx : proxies) {
+                if (tx.isSnapshot()) {
+                  final TransactionObserver observer = tx.getObserver();
+                  observer.duringIndividualCommit(tx, "test");
+                }
+              }
+            } catch (Exception e) {
+              exception[0] = e;
+            }
+          }
+        });
+    getLogWriter().info("SKSK Did notify in both the vm. ");
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+    t.join();
+
+    getLogWriter().info("SKSK update completed. ");
+
+    try {
+      Statement stmt2 = conn.createStatement();
+      ResultSet rs = stmt2.executeQuery("select * from " + tableName + " where text='suranjan'");
+      int num = 0;
+      while (rs.next()) {
+        num++;
+      }
+      assertTrue("Expected 49 but was " + num, num == 49);
+
+    } catch (Exception e) {
+      exception[0] = e;
+      e.printStackTrace();
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+
+    restartVMNums(-1, -2);
+
+    try {
+      Statement stmt2 = conn.createStatement();
+      ResultSet rs = stmt2.executeQuery("select * from " + tableName + " where text='suranjan'");
+      int num = 0;
+      while (rs.next()) {
+        num++;
+      }
+      assertTrue("Expected 49 but was " + num, num == 49);
+
+    } catch (Exception e) {
+      exception[0] = e;
+      e.printStackTrace();
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+    getLogWriter().info("SKSK Test completed successfully.");
+  }
+
+
+
+  public void testNodeRecycle() throws  Exception {
+    {
+      Exception[] exception = new Exception[2];
+      startVMs(1, 2);
+      createDiskStore(true, 1);
+
+      Properties props = new Properties();
+      final Connection conn = TestUtil.getConnection(props);
+
+      clientSQLExecute(1, "create table " + tableName + " (intcol int not null, text varchar" +
+          "(100) not null, primary key (intcol))  partition by column(intcol)  buckets 7 redundancy 1 " + getSuffix() + " enable concurrency checks");
+
+      Thread t = new Thread(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            final Connection conn = TestUtil.getConnection();
+            Statement stmt = conn.createStatement();
+            for (int i = 0; i < 50; i++) {
+              String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+
+              stmt.addBatch(stmtString);
+              getLogWriter().info("Inserting " + i);
+            }
+            getLogWriter().info("Executing btach first time");
+            stmt.executeBatch();
+          } catch (Exception e) {
+            exception[0] = e;
+            e.printStackTrace();
+          }
+        }
+      });
+      t.start();
+      Thread.sleep(5000);
+      t.join();
+
+      try {
+        Statement stmt = conn.createStatement();
+        for (int i = 99; i > 40; i--) {
+          String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+          stmt.addBatch(stmtString);
+          getLogWriter().info("Inserting ..second " + i);
+        }
+        getLogWriter().info("Executing btach  second time ");
+        stmt.executeBatch();
+        //fail("Expected some exception, primary key violation");
+      } catch (Exception e) {
+        // fail with some exception
+      }
+
+      try {
+        Statement stmt2 = conn.createStatement();
+        ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+        int num = 0;
+        while (rs.next()) {
+          num++;
+        }
+        assertTrue("Expected 50 but was " + num, num == 100);
+
+      } catch (Exception e) {
+        exception[0] = e;
+        e.printStackTrace();
+      }
+      if (exception[0] != null) {
+        throw exception[0];
+      }
+
+      restartVMNums(-1, -2);
+
+      try {
+        Statement stmt2 = conn.createStatement();
+        ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+        int num = 0;
+        while (rs.next()) {
+          num++;
+        }
+        assertTrue("Expected 50 but was " + num, num == 100);
+
+      } catch (Exception e) {
+        exception[0] = e;
+        e.printStackTrace();
+      }
+      if (exception[0] != null) {
+        throw exception[0];
+      }
+    }
+  }
+
+  public void testAutoCommitFalse() throws Exception {
+    Exception[] exception = new Exception[2];
+    startVMs(1, 2);
+    createDiskStore(true, 1);
+
+    Properties props = new Properties();
+    final Connection conn = TestUtil.getConnection(props);
+
+    clientSQLExecute(1, "create table " + tableName + " (intcol int not null, text varchar" +
+        "(100) not null, primary key (intcol))  partition by column(intcol)  buckets 7 redundancy 1 " + getSuffix() + " enable concurrency checks");
+
+    VM server1 = this.serverVMs.get(0);
+    VM server2 = this.serverVMs.get(1);
+
+    try {
+      Statement stmt = conn.createStatement();
+      for (int i = 0; i < 10; i++) {
+        String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+        stmt.addBatch(stmtString);
+        getLogWriter().info("Inserting ..second " + i);
+      }
+      getLogWriter().info("Executing batch first time ");
+      stmt.executeBatch();
+    } catch (Exception e) {
+    }
+
+    Thread t = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        boolean success= false;
+        try {
+          final Connection conn = TestUtil.getConnection();
+          Statement stmt = conn.createStatement();
+          Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+          for (int i = 20; i > 5; i--) {
+            String stmtString = "insert into " + tableName + " values(" + i + ",'test" + i + "')";
+            stmt.addBatch(stmtString);
+          }
+          getLogWriter().info("Executing batch second time");
+          stmt.executeBatch();
+          success = true;
+        } catch (Exception e) {
+          if(!(e instanceof BatchUpdateException)) {
+            exception[0] = e;
+            e.printStackTrace();
+          }
+        }
+        finally {
+          if(success)
+            Misc.getGemFireCache().getCacheTransactionManager().commit();
+          else
+            Misc.getGemFireCache().getCacheTransactionManager().rollback();
+        }
+      }
+    });
+    t.start();
+    t.join();
+    try {
+      Statement stmt2 = conn.createStatement();
+      ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+      int num = 0;
+      while (rs.next()) {
+        num++;
+      }
+      assertTrue("Expected 10 but was " + num, num == 10);
+
+    } catch (Exception e) {
+      exception[0] = e;
+      e.printStackTrace();
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+
+    restartVMNums(-1, -2);
+
+    try {
+      Statement stmt2 = conn.createStatement();
+      ResultSet rs = stmt2.executeQuery("select * from " + tableName);
+      int num = 0;
+      while (rs.next()) {
+        num++;
+      }
+      assertTrue("Expected 10 but was " + num, num == 10);
+
+    } catch (Exception e) {
+      exception[0] = e;
+      e.printStackTrace();
+    }
+    if (exception[0] != null) {
+      throw exception[0];
+    }
+  }
+}

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapshotTxGIIDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapshotTxGIIDUnit.java
@@ -72,11 +72,11 @@ public class SnapshotTxGIIDUnit extends DistributedSQLTestBase {
 
   @Override
   public void setUp() throws Exception {
-    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "true");
+    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "true");
     invokeInEveryVM(new SerializableRunnable() {
       @Override
       public void run() {
-        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "true");
+        System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "true");
         System.setProperty("snappydata.snapshot.isolation.gii.lock", "true");
       }
     });
@@ -86,11 +86,11 @@ public class SnapshotTxGIIDUnit extends DistributedSQLTestBase {
   @Override
   public void tearDown2() throws Exception {
     try {
-      System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "false");
+      System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "false");
       invokeInEveryVM(new SerializableRunnable() {
         @Override
         public void run() {
-          System.clearProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION");
+          System.clearProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST");
           System.clearProperty("snappydata.snapshot.isolation.gii.lock");
           InitialImageOperation.resetAllGIITestHooks();
         }
@@ -450,7 +450,7 @@ public class SnapshotTxGIIDUnit extends DistributedSQLTestBase {
     stopVMNums(-2);
 
     server0.invoke(SnapshotTxGIIDUnit.class, "createPR", new Object[]{regionName, 2, 1});
-    //server2.invoke(SnapshotTxGIIDUnit.class, "createPR", new Object[]{regionName, 2, 1});
+    //server2.invoke(SnapshotTxGIIDUnit.class, "createPR", new Object[]{tableName, 2, 1});
 
     // Put some values to initialize buckets
     server0.invoke(new SerializableRunnable() {

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
@@ -109,7 +109,7 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
     }
     st.executeBatch();
 
-    for (int i = 10; i >4 ; i--) {
+    for (int i = 9; i >4 ; i--) {
       stmtString = "insert into tran.t1"  + " values(" + i + "," + i + ")";
       st.addBatch(stmtString);
     }
@@ -125,7 +125,8 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
     while (rs.next()) {
       numRows++;
     }
-    assertEquals("ResultSet should contain 5 rows ", 5, numRows);
+    //execute batch with autocommit commits one by one
+    assertEquals("ResultSet should contain 10 rows ", 10, numRows);
     Misc.getGemFireCache().getCacheTransactionManager().commit();
 
     Region r = Misc.getRegionForTable("TRAN.T1", true);
@@ -1797,7 +1798,7 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
 
 
   // only insert operations to ignore
-  public void testReadSnapshotOnPartitionedTableInConcurrency() throws Exception {
+  public void _testReadSnapshotOnPartitionedTableInConcurrency() throws Exception {
     Connection conn = getConnection();
     GemFireCacheImpl cache = GemFireCacheImpl.getInstance();
     Statement st = conn.createStatement();

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
@@ -2,6 +2,7 @@ package com.pivotal.gemfirexd.jdbc.transactions.snapshot;
 
 import java.io.IOException;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -43,13 +44,13 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
 
   @Override
   protected void setUp() throws Exception {
-    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "true");
+    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "true");
     super.setUp();
   }
 
   @Override
   public void tearDown() throws Exception {
-    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", "false");
+    System.setProperty("gemfire.cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", "false");
     super.tearDown();
   }
 
@@ -95,11 +96,12 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
   }
 
   // Currently autcommit is disabled
-  public void _testBatchInsertAutoCommitWithConflict() throws Exception {
+  public void testBatchInsertAutoCommitWithConflict() throws Exception {
     Connection conn= getConnection();
     Statement st = conn.createStatement();
-    st.execute("Create table tran.t1 (c1 int not null , c2 int not null, primary key(c1))" +
-        " replicate persistent enable concurrency checks"+getSuffix());
+
+    st.execute("Create table tran.t1 (c1 int not null , c2 int not null, primary key(c1)) partition by column(c1) buckets 7 redundancy 1" +
+        "  persistent enable concurrency checks"+getSuffix());
     String stmtString = "";
     for (int i = 0; i < 5; i++) {
       stmtString = "insert into tran.t1"  + " values(" + i + "," + i + ")";
@@ -107,14 +109,14 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
     }
     st.executeBatch();
 
-    for (int i = 4; i < 10; i++) {
+    for (int i = 10; i >4 ; i--) {
       stmtString = "insert into tran.t1"  + " values(" + i + "," + i + ")";
       st.addBatch(stmtString);
     }
     try {
       st.executeBatch();
     } catch (Exception e) {
-      //e.printStackTrace();
+      e.printStackTrace();
       // will get primary key exception
     }
     Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
@@ -123,7 +125,7 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
     while (rs.next()) {
       numRows++;
     }
-    assertEquals("ResultSet should contain two rows ", 5, numRows);
+    assertEquals("ResultSet should contain 5 rows ", 5, numRows);
     Misc.getGemFireCache().getCacheTransactionManager().commit();
 
     Region r = Misc.getRegionForTable("TRAN.T1", true);
@@ -218,6 +220,56 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
     st.close();
     conn.close();
   }
+
+
+  public void testDeleteCommitSnapshot() throws Exception {
+    Connection conn= getConnection();
+    Statement st = conn.createStatement();
+    st.execute("Create table t1 (c1 int not null , c2 int not null, c3 bigint generated always as identity) partition by column(c3) "+getSuffix());
+    conn.commit();
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    for(int i=0;i<1000;i++)
+      st.execute("insert into t1 (c1, c2) values (" + i + " ," +i +")");
+
+    conn.commit();
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    ResultSet rs = st.executeQuery("Select * from t1 ");
+    int numRows = 0;
+    while (rs.next()) {
+      numRows++;
+    }
+    assertEquals("ResultSet should contain 1000 row ", 1000, numRows);
+    conn.commit();
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+
+
+    for(int i=0; i < 500; i++) {
+      Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+      st.execute("delete from t1 where c1 = " + i);
+      conn.commit();
+      Misc.getGemFireCache().getCacheTransactionManager().commit();
+    }
+
+    Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+     rs = st.executeQuery("Select * from t1 ");
+     numRows = 0;
+    while (rs.next()) {
+      numRows++;
+    }
+    assertEquals("ResultSet should contain 500 row ", 500, numRows);
+    conn.commit();
+    Misc.getGemFireCache().getCacheTransactionManager().commit();
+
+    // Close connection, resultset etc...
+    rs.close();
+    st.close();
+    conn.close();
+  }
+
 
   //index test not valid
   public void _testAutoCommitWithIndex() throws Exception {
@@ -929,6 +981,28 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
     }
     assertEquals("ResultSet should contain two row ", 2, numRows);
     //assert that old value is returned
+  }
+
+  public void testSnapshotAgainstPrepStmt() throws Exception {
+    Connection conn = getConnection();
+    Statement st = conn.createStatement();
+    st.execute("Create table tran.t1 (c1 int not null , c2 int not null, "
+        + "primary key(c1)) partition by column (c1) enable concurrency checks " + getSuffix());
+
+    //conn.commit();
+
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    st.execute("insert into tran.t1 values (10, 1)");
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().commit();
+
+
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    Statement st2 = conn.createStatement();
+    //String sql =
+    st.executeQuery("select * from tran.t1");
+    //PreparedStatement pst = conn.prepareStatement(sql);
+    //pst.executeQuery();
+    GemFireCacheImpl.getInstance().getCacheTransactionManager().commit();
   }
 
   public void _testSnapshotAgainstMultipleTable() throws Exception {
@@ -1723,7 +1797,7 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
 
 
   // only insert operations to ignore
-  public void SURtestReadSnapshotOnPartitionedTableInConcurrency() throws Exception {
+  public void testReadSnapshotOnPartitionedTableInConcurrency() throws Exception {
     Connection conn = getConnection();
     GemFireCacheImpl cache = GemFireCacheImpl.getInstance();
     Statement st = conn.createStatement();

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
@@ -130,7 +130,7 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
     Misc.getGemFireCache().getCacheTransactionManager().commit();
 
     Region r = Misc.getRegionForTable("TRAN.T1", true);
-    assert (r.size() == 5);
+    assert (r.size() == 10);
   }
 
   //auto commit is disabled.


### PR DESCRIPTION
## Changes proposed in this pull request

Disable snapshot isolation for row table.
Fixed some issues found 
1. Pooled connection not getting closed.
2. in case of snapshot unnecessary batch message was being sent
3. 

## Patch testing

precheckin and more tests written for row store

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
