### PR TITLE
SNAP-1874

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -679,7 +679,7 @@ public final class FabricDatabase implements ModuleControl,
       List<String> tablesMissingColumnBuffer = new LinkedList<>();
       for (String storeTable : storeEntry.getValue()) {
         if (Misc.getMemStoreBooting().getExternalCatalog().
-            isColumnTable(storeEntry.getKey(), storeTable, false)) {
+            isColumnTable(storeEntry.getKey(), storeTable, true)) {
           String columnBatchTable = com.gemstone.gemfire.
               internal.snappy.CallbackFactoryProvider.getStoreCallbacks().
               columnBatchTableName(storeEntry.getKey() + "." + storeTable);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -679,7 +679,7 @@ public final class FabricDatabase implements ModuleControl,
       List<String> tablesMissingColumnBuffer = new LinkedList<>();
       for (String storeTable : storeEntry.getValue()) {
         if (Misc.getMemStoreBooting().getExternalCatalog().
-            isColumnTable(storeEntry.getKey(), storeTable, true)) {
+            isColumnTable(storeEntry.getKey(), storeTable, false)) {
           String columnBatchTable = com.gemstone.gemfire.
               internal.snappy.CallbackFactoryProvider.getStoreCallbacks().
               columnBatchTableName(storeEntry.getKey() + "." + storeTable);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/GemFireActivationFactory.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/GemFireActivationFactory.java
@@ -72,7 +72,7 @@ public class GemFireActivationFactory {
     if (qi.isSelect() && qi.isPreparedStatementQuery()) {
       boolean routeQuery = Misc.getMemStore().isSnappyStore() && _lcc.isQueryRoutingEnabled();
       if (routeQuery) {
-        doRoute = SnappyActivation.isColumnTable((DMLQueryInfo) qi, false);
+        doRoute = SnappyActivation.isColumnTable((DMLQueryInfo) qi, true);
         if (GemFireXDUtils.TraceQuery) {
           SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_QUERYDISTRIB,
               "GemFireActivationFactory. Not prepared statement. SQL=" + st.getSource()

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/rules/ColumnTableExecutionEngineRule.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/rules/ColumnTableExecutionEngineRule.java
@@ -25,7 +25,7 @@ class ColumnTableExecutionEngineRule extends ExecutionEngineRule {
 
   @Override
   protected ExecutionEngine findExecutionEngine(DMLQueryInfo qInfo,ExecutionRuleContext context) {
-    if (SnappyActivation.isColumnTable(qInfo, false)) {
+    if (SnappyActivation.isColumnTable(qInfo, true)) {
       return ExecutionEngine.SPARK;
     }
     return ExecutionEngine.NOT_DECIDED;


### PR DESCRIPTION
## Changes proposed in this pull request
As discussed setting skip-locks to true in calls to  isColumnTable().
As seen in SNAP-1874, hive client initialization was failing due to LockTimeoutException (for its internal statement DROP FUNCTION NUCLEUS_ASCII). Refer to[ SNAP-1874](https://jira.snappydata.io/browse/SNAP-1874) for more details.

After this change ran the this failing hydra configuration 35 times and failure was never seen.

## Patch testing
precheckin
northwind hydra tests


## ReleaseNotes changes
NA
## Other PRs 
NA