### PR TITLE
Added a fix for UMM deadlock.

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/CustomEntryConcurrentHashMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/CustomEntryConcurrentHashMap.java
@@ -778,7 +778,7 @@ RETRYLOOP:
       } finally {
         releaseWriteLock();
         // This means rehash has happened
-        if(oldCapacity > 0 && oldCapacity < MAXIMUM_CAPACITY){
+        if (oldCapacity > 0 && oldCapacity < MAXIMUM_CAPACITY) {
           accountMapOverhead(oldCapacity);
         }
       }
@@ -879,7 +879,7 @@ RETRYLOOP:
       } finally {
         releaseWriteLock();
         // This means rehash has happened
-        if(oldCapacity > 0 && oldCapacity < MAXIMUM_CAPACITY){
+        if (oldCapacity > 0 && oldCapacity < MAXIMUM_CAPACITY) {
           accountMapOverhead(oldCapacity);
         }
       }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/CustomEntryConcurrentHashMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/CustomEntryConcurrentHashMap.java
@@ -746,10 +746,11 @@ RETRYLOOP:
     final V put(final K key, final int hash, final V value,
         final boolean onlyIfAbsent) {
       attemptWriteLock(-1);
+      int oldCapacity = -1;
       try {
         int c = this.count;
         if (c++ > this.threshold) {
-          rehash();
+          oldCapacity = rehash();
         }
         final HashEntry<K, V>[] tab = this.table;
         final int index = hash & (tab.length - 1);
@@ -776,6 +777,10 @@ RETRYLOOP:
         return oldValue;
       } finally {
         releaseWriteLock();
+        // This means rehash has happened
+        if(oldCapacity > 0 && oldCapacity < MAXIMUM_CAPACITY){
+          accountMapOverhead(oldCapacity);
+        }
       }
     }
 
@@ -784,6 +789,7 @@ RETRYLOOP:
     final <C, P> V create(final K key, final int hash,
         final MapCallback<K, V, C, P> valueCreator, final C context,
         final P createParams, final boolean lockForRead) {
+      int oldCapacity = -1;
       // TODO: This can be optimized by having a special lock implementation
       // that will allow upgrade from read to write lock atomically. This can
       // cause a deadlock if two readers try to simultaneously upgrade, so the
@@ -820,7 +826,7 @@ RETRYLOOP:
       try {
         int c = this.count;
         if (c++ > this.threshold) {
-          rehash();
+          oldCapacity = rehash();
         }
         final HashEntry<K, V>[] tab = this.table;
         final int index = hash & (tab.length - 1);
@@ -872,6 +878,10 @@ RETRYLOOP:
         }
       } finally {
         releaseWriteLock();
+        // This means rehash has happened
+        if(oldCapacity > 0 && oldCapacity < MAXIMUM_CAPACITY){
+          accountMapOverhead(oldCapacity);
+        }
       }
     }
 
@@ -906,24 +916,26 @@ RETRYLOOP:
           null, true, false);
     }
 
-// End GemStone additions
-
-    final void rehash() {
-      final HashEntry<K, V>[] oldTable = this.table;
-      final int oldCapacity = oldTable.length;
-      if (oldCapacity >= MAXIMUM_CAPACITY) {
-        return;
-      }
-
+    final void accountMapOverhead(int oldCapacity) {
       // update the acquired memory storage; this will always increase
       // monotonically. Not throwing any exception if memory could not be allocated from
       // memory manager as this is the last step of a region operation.
-      if (LocalRegion.regionPath.get() != null){
+      if (LocalRegion.regionPath.get() != null) {
         CallbackFactoryProvider.getStoreCallbacks().acquireStorageMemory(
             LocalRegion.regionPath.get(),
             oldCapacity * ReflectionSingleObjectSizer.REFERENCE_SIZE,
             null, true, false);
         LocalRegion.regionPath.remove();
+      }
+    }
+
+// End GemStone additions
+
+    final int rehash() {
+      final HashEntry<K, V>[] oldTable = this.table;
+      final int oldCapacity = oldTable.length;
+      if (oldCapacity >= MAXIMUM_CAPACITY) {
+        return oldCapacity;
       }
 
       /*
@@ -1024,6 +1036,7 @@ RETRYLOOP:
         }
       }
       this.table = newTable;
+      return oldCapacity;
     }
 
     /**


### PR DESCRIPTION
## Changes proposed in this pull request

This deadlock happens when two or more threads simultaneously inserts. If one of them re-hashes the map,  and other is trying to evict, hence calling sizeInVM(). The first one has taken a segment level lock and the second one has taken the object level lock at UMM. 

The change in this fix is to take UMM lock after the segment lock has been released. The only problem with this approach is we will be accounting after re-hash has happened, rather than before. We don't raise an exception if memory acquisition fails in re-hash of the map. Hence IMO it should be ok. 
## Patch testing

pre-checkin pending

## ReleaseNotes changes

NA

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
