### PR TITLE
[SNAP-1935] InitialImage not releasing snapshot locks.

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/InitialImageOperation.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/InitialImageOperation.java
@@ -2237,7 +2237,7 @@ public class InitialImageOperation  {
 //          logger.fine("RequestImageMessage: wrapping up, sendFailureMessage = " 
 //              + sendFailureMessage);
 //        }
-        if (giiRegion != null && giiRegion instanceof BucketRegion) {
+        if (giiRegion instanceof BucketRegion) {
           ((BucketRegion)giiRegion).releaseSnapshotGIIWriteLock();
         }
         if (sendFailureMessage) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/InitialImageOperation.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/InitialImageOperation.java
@@ -1969,9 +1969,11 @@ public class InitialImageOperation  {
       if (lclAbortTest) abortTest = false;
       logger.info(LocalizedStrings.DEBUG, "processing GII for "+regionPath);
       boolean sendFailureMessage = true;
+      DistributedRegion giiRegion = null;
       try {
         Assert.assertTrue(this.regionPath != null, "Region path is null.");
         final DistributedRegion rgn = (DistributedRegion)getGIIRegion(dm, this.regionPath, this.targetReinitialized);
+        giiRegion = rgn;
         if (rgn == null) {
           return;
         }
@@ -2184,9 +2186,7 @@ public class InitialImageOperation  {
             ((HARegion)rgn).endServingGIIRequest();
           }
           flowControl.unregister();
-          if (rgn instanceof BucketRegion) {
-            ((BucketRegion)rgn).releaseSnapshotGIIWriteLock();
-          }
+
         }
         // This should never happen in production code!!!!
         
@@ -2237,6 +2237,9 @@ public class InitialImageOperation  {
 //          logger.fine("RequestImageMessage: wrapping up, sendFailureMessage = " 
 //              + sendFailureMessage);
 //        }
+        if (giiRegion != null && giiRegion instanceof BucketRegion) {
+          ((BucketRegion)giiRegion).releaseSnapshotGIIWriteLock();
+        }
         if (sendFailureMessage) {
           // if we get here then send reply possibly with an exception
           ReplyException rex = null;


### PR DESCRIPTION


## Changes proposed in this pull request
The release call of the lock was not taking care of cases where there were no data and the InitialImageOperation call was returning much earlier.

In this fix, I have moved the release call to the outer finally call. 

## Patch testing

pre-checkin pending. New test added for the issue. 

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/795
