### PR TITLE
using ClearActiveTXState instead of resetActiveTXState

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -2554,11 +2554,6 @@ public class GfxdSystemProcedures extends SystemProcedures {
       + " snapshot tx : " + TXManagerImpl.snapshotTxState.get());
     }
 
-    //Misc.getGemFireCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
-    //LanguageConnectionContext lcc = ConnectionUtil.getCurrentLCC();
-    //GemFireTransaction tc = (GemFireTransaction)lcc.getTransactionExecute();
-    //tc.setActiveTXState(TXManagerImpl.snapshotTxState.get(), false);
-
     TXStateInterface tx = TXManagerImpl.snapshotTxState.get();
     String txId;
     if ( tx != null) {
@@ -2568,8 +2563,8 @@ public class GfxdSystemProcedures extends SystemProcedures {
     }
     // tc commit will clear all the artifacts but will not commit actual txState
     // that should be committed in COMMIT procedure
-    tc.resetActiveTXState(true);
-    TXManagerImpl.getOrCreateTXContext().clearTXState();
+    tc.clearActiveTXState(true, true);
+    //tc.resetActiveTXState(true);
     TXManagerImpl.snapshotTxState.set(null);
     return txId;
   }


### PR DESCRIPTION
## Changes proposed in this pull request

Using clearActiveTXState instead of resetActiveTXState to clear txState from TransactionController
## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
