### PR TITLE
[SNAP-1955] fixes for issues seen in parallel runs

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -1295,23 +1295,20 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     }
   }
 
-  private volatile Boolean rowBuffer = null;
+  private volatile Boolean rowBuffer = false;
 
   public boolean isRowBuffer() {
     final Boolean rowBuffer = this.rowBuffer;
-    if (rowBuffer != null) {
+    if (rowBuffer || this.getName().toUpperCase().endsWith(StoreCallbacks.SHADOW_TABLE_SUFFIX)) {
       return rowBuffer;
     }
-    List<PartitionedRegion> childRegions = ColocationHelper.getColocatedChildRegions(
-        this.getPartitionedRegion());
+    boolean isRowBuffer = false;
+    List<PartitionedRegion> childRegions = ColocationHelper.getColocatedChildRegions(this.getPartitionedRegion());
     for (PartitionedRegion pr : childRegions) {
-      if (pr.getName().toUpperCase().endsWith(StoreCallbacks.SHADOW_TABLE_SUFFIX)) {
-        this.rowBuffer = true;
-        return true;
-      }
+      isRowBuffer |= pr.getName().toUpperCase().endsWith(StoreCallbacks.SHADOW_TABLE_SUFFIX);
     }
-    this.rowBuffer = false;
-    return false;
+    this.rowBuffer = isRowBuffer;
+    return isRowBuffer;
   }
 
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -736,9 +736,8 @@ public class LocalRegion extends AbstractRegion
     Assert.assertTrue(regionName != null, "regionName must not be null");
     this.sharedDataView = buildDataView();
     this.regionName = regionName;
-    if (regionName.toUpperCase().endsWith(StoreCallbacks.SHADOW_TABLE_SUFFIX)) {
-      this.isInternalColumnTable = true;
-    }
+    this.isInternalColumnTable = regionName.toUpperCase().endsWith(
+        StoreCallbacks.SHADOW_TABLE_SUFFIX);
     this.parentRegion = parentRegion;
     this.fullPath = calcFullPath(regionName, parentRegion);
     final GemFireCacheImpl.StaticSystemCallbacks sysCb =
@@ -14532,12 +14531,11 @@ public class LocalRegion extends AbstractRegion
     }
   }
 
-  //why is always false?
   public boolean isInternalColumnTable() {
     return isInternalColumnTable;
   }
 
-  private boolean isInternalColumnTable = false;
+  private final boolean isInternalColumnTable;
 
   public boolean isSnapshotEnabledRegion() {
     return (getCache().snapshotEnabledForTest() && !isUsedForMetaRegion() && concurrencyChecksEnabled);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RemoteOperationMessage.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RemoteOperationMessage.java
@@ -28,7 +28,6 @@ import com.gemstone.gemfire.DataSerializer;
 import com.gemstone.gemfire.SystemFailure;
 import com.gemstone.gemfire.cache.CacheClosedException;
 import com.gemstone.gemfire.cache.CacheException;
-import com.gemstone.gemfire.cache.CacheFactory;
 import com.gemstone.gemfire.cache.LowMemoryException;
 import com.gemstone.gemfire.cache.Operation;
 import com.gemstone.gemfire.cache.RegionDestroyedException;
@@ -232,7 +231,7 @@ public abstract class RemoteOperationMessage extends AbstractOperationMessage
                 .toLocalizedString(dm.getId()));
         return;
       }
-      GemFireCacheImpl gfc = (GemFireCacheImpl)CacheFactory.getInstance(dm.getSystem());
+      GemFireCacheImpl gfc = GemFireCacheImpl.getExisting();
       r = gfc.getRegionByPathForProcessing(this.regionPath);
       if (r == null && failIfRegionMissing()) {
         // if the distributed system is disconnecting, don't send a reply saying

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RemotePutAllMessage.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RemotePutAllMessage.java
@@ -287,7 +287,7 @@ public final class RemotePutAllMessage extends
     if (failures != null && failures.size() > 0) {
       throw new RemoteOperationException(
           LocalizedStrings.RemotePutMessage_FAILED_SENDING_0
-              .toLocalizedString(this));
+              .toLocalizedString(toString() + " to " + failures));
     }
     return p;
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/SendQueueOperation.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/SendQueueOperation.java
@@ -117,7 +117,7 @@ public class SendQueueOperation {
       ReplyException rex = null;
       boolean ignored = false;
       try {
-        GemFireCacheImpl gfc = (GemFireCacheImpl)CacheFactory.getInstance(dm.getSystem());
+        GemFireCacheImpl gfc = GemFireCacheImpl.getExisting();
         final LocalRegion lclRgn = gfc.getRegionByPathForProcessing(this.regionPath);
         if (lclRgn != null) {
           lclRgn.waitOnInitialization();

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
@@ -456,6 +456,7 @@ public interface GfxdConstants {
           Attribute.SYS_HDFS_ROOT_DIR,
           Attribute.TABLE_DEFAULT_PARTITIONED,
           com.pivotal.gemfirexd.internal.iapi.reference.Attribute.COLLATE,
+          com.pivotal.gemfirexd.internal.iapi.reference.Attribute.INTERNAL_CONNECTION,
           Attribute.COLLATION,
           Attribute.CREATE_ATTR,
           Attribute.DISABLE_STREAMING,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdReplyMessageProcessor.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdReplyMessageProcessor.java
@@ -45,6 +45,7 @@ import com.pivotal.gemfirexd.internal.shared.common.sanity.SanityManager;
 public abstract class GfxdReplyMessageProcessor extends DirectReplyProcessor {
 
   private GfxdResponseCode responseCode;
+  private DistributedMember responseMember;
 
   private HashMap<DistributedMember, ReplyException> exceptions;
 
@@ -78,6 +79,7 @@ public abstract class GfxdReplyMessageProcessor extends DirectReplyProcessor {
    */
   public synchronized Set<DistributedMember> reset() {
     this.responseCode = GfxdResponseCode.GRANT(1);
+    this.responseMember = null;
     this.exception = null;
     this.exceptions = null;
     return virtualReset();
@@ -85,19 +87,26 @@ public abstract class GfxdReplyMessageProcessor extends DirectReplyProcessor {
 
   protected abstract Set<DistributedMember> virtualReset();
 
-  public final synchronized void setResponseCode(GfxdResponseCode code) {
+  public final synchronized void setResponseCode(GfxdResponseCode code,
+      DistributedMember member) {
     if (!this.responseCode.isException()) {
       if (code.isException() || code.isTimeout()) {
         this.responseCode = code;
+        this.responseMember = member;
       }
       else if (code.isWaiting() && this.responseCode.isGrant()) {
         this.responseCode = code;
+        this.responseMember = member;
       }
     }
   }
 
   public final GfxdResponseCode getResponseCode() {
     return this.responseCode;
+  }
+
+  public final DistributedMember getResponseMember() {
+    return this.responseMember;
   }
 
   public final ReplyException getReplyException() {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdWaitingReplyProcessor.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdWaitingReplyProcessor.java
@@ -140,7 +140,7 @@ public final class GfxdWaitingReplyProcessor extends
             superProcess = false;
             return;
           }
-          setResponseCode(responseCode);
+          setResponseCode(responseCode, reply.getSender());
           if (waiting) {
             checkWaiters();
           }
@@ -176,5 +176,11 @@ public final class GfxdWaitingReplyProcessor extends
       }
     }
     checkWaiters();
+  }
+
+  @Override
+  public String toString() {
+    return super.toString() + " responseCode=" + getResponseCode() +
+        " from " + getResponseMember();
   }
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/locks/DefaultGfxdLockable.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/locks/DefaultGfxdLockable.java
@@ -17,21 +17,28 @@
 
 package com.pivotal.gemfirexd.internal.engine.locks;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import com.gemstone.gemfire.DataSerializable;
+import com.gemstone.gemfire.DataSerializer;
 import com.pivotal.gemfirexd.internal.iapi.services.sanity.SanityManager;
 
 /**
  * A default implementation of {@link GfxdLockable} that can be used to create
  * an {@link GfxdLockable} from a given object that is used as the
  * {@link #getName()} method.
- * 
+ *
  * @author swale
  * @since 6.5
  */
-public final class DefaultGfxdLockable extends AbstractGfxdLockable {
+public final class DefaultGfxdLockable extends AbstractGfxdLockable
+    implements DataSerializable {
 
-  private final Object name;
+  private Object name;
 
-  private final String traceFlag;
+  private transient final String traceFlag;
 
   public DefaultGfxdLockable(Object name, String traceFlag) {
     this.name = name;
@@ -46,10 +53,17 @@ public final class DefaultGfxdLockable extends AbstractGfxdLockable {
 
   @Override
   protected boolean traceThisLock() {
-    if (this.traceFlag != null) {
-      return SanityManager.TRACE_ON(this.traceFlag);
-    }
-    return false;
+    return this.traceFlag != null && SanityManager.TRACE_ON(this.traceFlag);
+  }
+
+  @Override
+  public void toData(DataOutput out) throws IOException {
+    DataSerializer.writeObject(this.name, out);
+  }
+
+  @Override
+  public void fromData(DataInput in) throws IOException, ClassNotFoundException {
+    this.name = DataSerializer.readObject(in);
   }
 
   @Override

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/locks/GfxdDRWLockRequestProcessor.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/locks/GfxdDRWLockRequestProcessor.java
@@ -262,7 +262,8 @@ public final class GfxdDRWLockRequestProcessor extends DLockRequestProcessor {
           processor.addGrantedMember(dm.getDistributionManagerId(), 1);
         }
         else {
-          processor.setResponseCode(GfxdResponseCode.TIMEOUT);
+          processor.setResponseCode(GfxdResponseCode.TIMEOUT,
+              dm.getDistributionManagerId());
         }
       }
       if (grant) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -497,6 +497,7 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
               schemaName, tableName, true));
       if (isPartitioned()) {
         metaData = externalTableMetaData.get();
+        if (metaData == null) return null;
         ((PartitionedRegion)this.region).setColumnBatchSizes(
             metaData.columnBatchSize, metaData.columnMaxDeltaRows,
             GfxdConstants.SNAPPY_MIN_COLUMN_DELTA_ROWS);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedConnection.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedConnection.java
@@ -3383,7 +3383,8 @@ public abstract class EmbedConnection implements EngineConnection
 			
 			// Try to start the service if it doesn't already exist.
 			// Skip boot if internal connection property is set.
-			boolean booted = Boolean.parseBoolean(info.getProperty(Attribute.INTERNAL_CONNECTION));
+			boolean booted = Boolean.parseBoolean(info.getProperty(
+			    Attribute.INTERNAL_CONNECTION));
 			GemFireStore store = booted ? Misc.getMemStoreBooting()
 			    : Misc.getMemStoreBootingNoThrow();
 			if (store == null && !Monitor.startPersistentService(dbname, info)) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedConnection.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedConnection.java
@@ -3381,8 +3381,11 @@ public abstract class EmbedConnection implements EngineConnection
 				info.remove(Attribute.SOFT_UPGRADE_NO_FEATURE_CHECK);
 			}
 			
-			// try to start the service if it doesn't already exist
-			GemFireStore store = Misc.getMemStoreBootingNoThrow();
+			// Try to start the service if it doesn't already exist.
+			// Skip boot if internal connection property is set.
+			boolean booted = Boolean.parseBoolean(info.getProperty(Attribute.INTERNAL_CONNECTION));
+			GemFireStore store = booted ? Misc.getMemStoreBooting()
+			    : Misc.getMemStoreBootingNoThrow();
 			if (store == null && !Monitor.startPersistentService(dbname, info)) {
 				// a false indicates the monitor cannot handle a service
 				// of the type indicated by the protocol within the name.

--- a/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/iapi/reference/Attribute.java
+++ b/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/iapi/reference/Attribute.java
@@ -342,6 +342,7 @@ public interface Attribute {
   String COLLATE = "collate";
 
 // GemStone changes BEGIN
+  String INTERNAL_CONNECTION = "internal-connection";
   // all public client connection only properties are in
   // com.pivotal.gemfirexd.jdbc.ClientAttribute
   /*


### PR DESCRIPTION
This takes care of the store-side changes required for the issues noted in SNAP-1955.

## Changes proposed in this pull request

- Deadlock on CacheFactory.class between RemoteOperationMessage processing
  and if the node is already waiting on the hive-metastore dlock. In that
  case the FabricServerImpl.start has already acquired the CacheFactory.class
  lock (to avoid deadlocks with restarter thread which does the same)
  and this message from other node that has successfully acquired hive-metastore
  lock and is initializing it, cannot proceed.

  Reviewed all messages for similar issue. Most GemFire messages explicitly
  call LocalRegion.setThreadInitLevelRequirement to set a thread-local property
  that skips locking in CacheFactory or Cache region lookup. Only two messages
  RemoteOperationMessage and SendQueueOperation do not use it and
  can cause deadlocks. There are others in old admin API but those can be ignored.
  Have not used the LocalRegion.setThreadInitLevelRequirement way because that whole
  thing is unnecessary (of locking CacheFactory and skipping using thread-local), and instead
  use GemFireCacheImpl.getExisting to get the current booted instance.

- Added an "internal-connection" property for EmbedConnection that will skip
  booting the FabricDatabase and instead fail if it is not booted. This will be
  used by SnappyData layer for pool connections that can otherwise try to re-connect
  and re-boot a node while it is being stopped or restarted.

- Explicitly release all meta-data locks before routing a query to lead because lead
  execution will take the requisite locks (and locks here can cause deadlocks).

- Use a simple DLock for hive meta-store client locking rather than a read-write lock
  to reduce the complication since there are no readers for it. Made DefaultGfxdLockable
  a DataSerializable so it can be used as a DLock object if required.

- Added responseMember for the responseCode in GfxdReplyMessageProcessor to log
  in case of unsuccessful response to tell which member failed the lock or similar request.

- Cleaned up LocalRegion.isInternalColumnTable a bit.

## Patch testing

precheckin

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/805