### PR TITLE
Waiting for external catalog to get initialized in the put thread.

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -480,7 +480,8 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
     int cnt = -1;
     // Retrying after sleep of some millisecs to reduce the worst case
     // of delaying that put for a large period of time
-    while((ret = Misc.getMemStore().getExternalCatalog()) == null && cnt <= 20) {
+    while ((ret = Misc.getMemStore().getExternalCatalog()) == null
+        && cnt < GfxdConstants.HA_NUM_RETRIES) {
       GemFireXDUtils.sleepForRetry(cnt++);
     }
     return ret;

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/IndexPersistenceDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/IndexPersistenceDUnit.java
@@ -578,36 +578,38 @@ public class IndexPersistenceDUnit extends DistributedSQLTestBase {
       File[] files = currDir.listFiles();
       getGlobalLogger().info("current dir is: " + currDir.getCanonicalPath());
 
-      for (File f : files) {
-        if (f.getAbsolutePath().contains("BACKUPGFXD-DEFAULT-DISKSTORE")) {
-          getGlobalLogger().info("deleting file: " + f + " from dir: " + currDir);
-          f.delete();
-        }
-        if (f.isDirectory()) {
-          File newDir = new File(f.getCanonicalPath());
-          File[] newFiles = newDir.listFiles();
-          for (File nf : newFiles) {
-            if (nf.getAbsolutePath().contains("BACKUPGFXD-DEFAULT-DISKSTORE")) {
-              getGlobalLogger().info(
-                  "deleting file: " + nf + " from dir: " + newDir);
-              nf.delete();
+      if (files != null) {
+        for (File f : files) {
+          if (f.getAbsolutePath().contains("BACKUPGFXD-DEFAULT-DISKSTORE")) {
+            getGlobalLogger().info("deleting file: " + f + " from dir: " + currDir);
+            f.delete();
+          }
+          if (f.isDirectory()) {
+            File newDir = new File(f.getCanonicalPath());
+            File[] newFiles = newDir.listFiles();
+            for (File nf : newFiles) {
+              if (nf.getAbsolutePath().contains("BACKUPGFXD-DEFAULT-DISKSTORE")) {
+                getGlobalLogger().info(
+                    "deleting file: " + nf + " from dir: " + newDir);
+                nf.delete();
+              }
             }
           }
         }
-      }
-      for (File f : files) {
-        if (f.getAbsolutePath().contains("GFXD-DD-DISKSTORE")) {
-          getGlobalLogger().info("deleting file: " + f + " from dir: " + currDir);
-          f.delete();
-        }
-        if (f.isDirectory()) {
-          File newDir = new File(f.getCanonicalPath());
-          File[] newFiles = newDir.listFiles();
-          for (File nf : newFiles) {
-            if (nf.getAbsolutePath().contains("GFXD-DD-DISKSTORE")) {
-              getGlobalLogger().info(
-                  "deleting file: " + nf + " from dir: " + newDir);
-              nf.delete();
+        for (File f : files) {
+          if (f.getAbsolutePath().contains("GFXD-DD-DISKSTORE")) {
+            getGlobalLogger().info("deleting file: " + f + " from dir: " + currDir);
+            f.delete();
+          }
+          if (f.isDirectory()) {
+            File newDir = new File(f.getCanonicalPath());
+            File[] newFiles = newDir.listFiles();
+            for (File nf : newFiles) {
+              if (nf.getAbsolutePath().contains("GFXD-DD-DISKSTORE")) {
+                getGlobalLogger().info(
+                    "deleting file: " + nf + " from dir: " + newDir);
+                nf.delete();
+              }
             }
           }
         }


### PR DESCRIPTION
## Changes proposed in this pull request

The issue was that when a put is coming to a node which is still getting initialized but the hive metastore client instance is still not initialized then accessing that can cause NPE. Now the putter thread waits for the node to come up if ddl replay is still in progress.

## Patch testing

hydra test which reproduced it consistently is being used to verify the fix.

## ReleaseNotes changes

None.

## Other PRs 

No.