### PR TITLE
Added serialization info for the DefaultGfxdLockable class.

### DIFF
--- a/gemfire-junit/src/main/resources/com/gemstone/gemfire/codeAnalysis/sanctionedDataSerializables.txt
+++ b/gemfire-junit/src/main/resources/com/gemstone/gemfire/codeAnalysis/sanctionedDataSerializables.txt
@@ -1,3 +1,7 @@
+com/pivotal/gemfirexd/internal/engine/locks/DefaultGfxdLockable,2
+fromData,9,2a2bb80007b50002b1
+toData,9,2ab400022bb80006b1
+
 com/gemstone/gemfire/admin/RegionSubRegionSnapshot,2
 fromData,62,2a2bb80023b500082a2bb900240100b5000b2a2bb80025b500052ab40005b9002601004d2cb9002701009900132cb900280100c000292ab6001ba7ffeab1
 toData,30,2ab400082bb800202b2ab4000bb9002102002ab40005c000032bb80022b1

--- a/gemfirexd/tools/src/test/resources/codeAnalysis/sanctionedDataSerializables.txt
+++ b/gemfirexd/tools/src/test/resources/codeAnalysis/sanctionedDataSerializables.txt
@@ -1,3 +1,7 @@
+com/pivotal/gemfirexd/internal/engine/locks/DefaultGfxdLockable,2
+fromData,9,2a2bb80007b50002b1
+toData,9,2ab400022bb80006b1
+
 com/gemstone/gemfire/admin/RegionSubRegionSnapshot,2
 fromData,62,2a2bb80023b500082a2bb900240100b5000b2a2bb80025b500052ab40005b9002601004d2cb9002701009900132cb900280100c000292ab6001ba7ffeab1
 toData,30,2ab400082bb800202b2ab4000bb9002102002ab40005c000032bb80022b1


### PR DESCRIPTION
## Changes proposed in this pull request

This class was recently made DataSerializable. So the AnalyzeSerializableTest found this class for which corresponding toData and fromData was not htere in the sanctionedDataSerializables.txt file.

## Patch testing

Ran the junit test.

## ReleaseNotes changes

None

## Other PRs 

No