### PR TITLE
Enable janino debugging

### DIFF
--- a/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/internal/GfxdServerLauncher.java
+++ b/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/internal/GfxdServerLauncher.java
@@ -741,7 +741,7 @@ public class GfxdServerLauncher extends CacheServerLauncher {
           + HeapEvictor.EVICT_HIGH_ENTRY_COUNT_BUCKETS_FIRST_FOR_EVICTOR_PROP
           + "=true");
     }
-
+    vmArgs.add("-Dorg.codehaus.janino.source_debugging.enable=true");
     vmArgs.addAll(incomingVMArgs);
     processedDefaultGCParams = true;
 


### PR DESCRIPTION
## Changes proposed in this pull request

Enabling janino debug mode ensures that in case of an exception correct line numbers are printed in the exception trace. 

To ensure that janino debug mode is not extremely slow, compiled a code of around 1300 lines with janino 1000 times. It is in the range of 45 to 51 seconds with the debug flag and without the debug flag. So, I think we can specify the debug flag by default. Secondly, the directory for java files is by default /tmp. It generates files that are prefixed with janino inside the temp directory. 

## Patch testing

Manual. Precheckin. 

