### PR TITLE
[SNAP-1989] don't conflict for column deltas

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
@@ -4136,7 +4136,9 @@ RETRY_LOOP:
     if (event.getTXState() != null && event.getTXState().isSnapshot()) {
       TXState localState = event.getTXState().getLocalTXState();
       if (!firstEntry(re)) {
-        if (!TXState.checkEntryInSnapshot(localState, event.getRegion(), re)) {
+        // deltas will be merged and will not conflict
+        if (!TXState.checkEntryInSnapshot(localState, event.getRegion(), re)
+            && !event.hasColumnDelta()) {
           throw new ConflictException("The value has changed.");
         }
       }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/EntryEventImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/EntryEventImpl.java
@@ -2319,6 +2319,10 @@ public class EntryEventImpl extends KeyInfo implements
     return (this.delta != null);
   }
 
+  public final boolean hasColumnDelta() {
+    return this.delta instanceof SerializedDiskBuffer;
+  }
+
   /**
    * Return true for an internal Delta that requires an old value in region.
    */


### PR DESCRIPTION
## Changes proposed in this pull request

Skip the conflict check code for column deltas. The deltas will automatically get merged
in final apply on region (EntryEventImpl.applyDelta) in the order of their commits.

## Patch testing

precheckin

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/822