### PR TITLE
Fix for SNAP-1996 -- offline compaction fails

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
@@ -1188,7 +1188,7 @@ public final class Oplog implements CompactableOplog {
   
   private void preblow(OplogFile olf, long maxSize) throws IOException {
     GemFireCacheImpl.StaticSystemCallbacks ssc = GemFireCacheImpl.getInternalProductCallbacks();
-    if (ssc != null && ssc.isSnappyStore() && ssc.isAccessor()
+    if (!getParent().isOfflineCompacting() && ssc != null && ssc.isSnappyStore() && ssc.isAccessor()
         && this.getParent().getName().equals(GemFireCacheImpl.getDefaultDiskStoreName())) {
       logger.warning(LocalizedStrings.SHOULDNT_INVOKE, "Pre blow is invoked on Accessor Node.");
       return;


### PR DESCRIPTION
## Changes proposed in this pull request

Avoid isSnappyStore check etc. which accesses Memstore when cache comes up just for offline compaction.

## Patch testing

Manual.

## ReleaseNotes changes

None.

## Other PRs 

No.