### PR TITLE
[SNAP-2007] added async release for SerializedDiskBuffer

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
@@ -1419,7 +1419,7 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
       Object oldVal = getValueField();
       if (oldVal != val && oldVal instanceof SerializedDiskBuffer) {
         setValueField(val);
-        ((SerializedDiskBuffer)oldVal).release();
+        ((SerializedDiskBuffer)oldVal).release(true);
         return;
       }
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
@@ -739,7 +739,7 @@ public interface DiskEntry extends RegionEntry {
         final SerializedDiskBuffer buffer = this.buffer;
         if (buffer != null && buffer.needsRelease()) {
           this.buffer = null;
-          buffer.release();
+          buffer.release(true);
         }
       }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/store/WrappedBytes.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/store/WrappedBytes.java
@@ -60,7 +60,7 @@ public final class WrappedBytes extends SerializedDiskBuffer {
   }
 
   @Override
-  public void release() {
+  public void release(boolean async) {
   }
 
   @Override
@@ -69,7 +69,7 @@ public final class WrappedBytes extends SerializedDiskBuffer {
   }
 
   @Override
-  protected void releaseBuffer() {
+  protected void releaseBuffer(boolean async) {
   }
 
   @Override

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
@@ -20,6 +20,7 @@ package com.gemstone.gemfire.internal.snappy;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import com.gemstone.gemfire.internal.cache.BucketRegion;
 import com.gemstone.gemfire.internal.snappy.memory.MemoryManagerStats;
@@ -96,6 +97,11 @@ public abstract class CallbackFactoryProvider {
     @Override
     public void releaseStorageMemory(String objectName,
         long numBytes, boolean offHeap) {
+    }
+
+    @Override
+    public ExecutorService poolForAsyncOperation() {
+      return null;
     }
 
     @Override

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
@@ -19,6 +19,7 @@ package com.gemstone.gemfire.internal.snappy;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import com.gemstone.gemfire.internal.cache.BucketRegion;
 import com.gemstone.gemfire.internal.snappy.memory.MemoryManagerStats;
@@ -74,6 +75,12 @@ public interface StoreCallbacks {
       UMMMemoryTracker buffer, boolean shouldEvict, boolean offHeap);
 
   void releaseStorageMemory(String objectName, long numBytes, boolean offHeap);
+
+  /**
+   * Get the pool for an async acquire/release operation, or null if
+   * pool cannot be used and operation should be in the same thread.
+   */
+  ExecutorService poolForAsyncOperation();
 
   void dropStorageMemory(String objectName, long ignoreBytes);
 


### PR DESCRIPTION
## Changes proposed in this pull request

- added async boolean argument to SerializedDiskBuffer.release to release the buffer
  asynchronously if possible (e.g. if being done under RegionEntry lock)
- corresponding method in StoreCallbacks.poolForAsyncOperation to get the pool
  to use for async operation or null if operation should be done in same thread

## Patch testing

precheckin

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/837