### PR TITLE
SNAP-2010 Fix junit failure

### DIFF
--- a/gemfirexd/tools/src/test/java/codeAnalysis/AnalyzeSerializablesJUnitTest.java
+++ b/gemfirexd/tools/src/test/java/codeAnalysis/AnalyzeSerializablesJUnitTest.java
@@ -67,7 +67,8 @@ public class AnalyzeSerializablesJUnitTest extends TestCase {
     String gfxdjar = null;
     for (int i=0; i<entries.length; i++) {
       System.out.println("examining '" + entries[i] + "'");
-      if (entries[i].matches(".*snappydata-store-core-[0-9\\.]*(-(SNAPSHOT|BETA))?[0-9]*.jar")) {
+      if (entries[i].matches(".*snappydata-store-core-[0-9\\.]*(-(SNAPSHOT|BETA|rc))?[0-9\\.]*" +
+          ".jar")) {
         gfxdjar = entries[i];
         break;
       }


### PR DESCRIPTION
SNAP-2010 Fix junit failure by updating pattern matching expression for store jar name.
Ran the affected junit test.