### PR TITLE
[SNAP-2012] skip RegionEntries in eviction that are already locked

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ allprojects {
     antVersion = '1.9.7'
     pxfVersion = '2.5.1.0'
     osgiVersion = '6.0.0'
-    jettyVersion = '9.2.16.v20160414'
+    jettyVersion = '9.2.22.v20170606'
     hadoopVersion = '2.7.3'
     protobufVersion = '2.6.1'
     kryoVersion = '4.0.0'

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/ByteBufferDataOutput.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/ByteBufferDataOutput.java
@@ -24,7 +24,6 @@ import java.io.UTFDataFormatException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.ExecutorService;
 import javax.annotation.Nonnull;
 
 import com.gemstone.gemfire.DataSerializer;
@@ -38,7 +37,6 @@ import com.gemstone.gemfire.internal.shared.ClientSharedUtils;
 import com.gemstone.gemfire.internal.shared.OutputStreamChannel;
 import com.gemstone.gemfire.internal.shared.Version;
 import com.gemstone.gemfire.internal.shared.unsafe.ChannelBufferUnsafeDataOutputStream;
-import com.gemstone.gemfire.internal.snappy.CallbackFactoryProvider;
 
 /**
  * A {@link SerializedDiskBuffer} that implements {@link DataOutput} writing
@@ -113,16 +111,10 @@ public final class ByteBufferDataOutput extends SerializedDiskBuffer
   }
 
   @Override
-  protected synchronized void releaseBuffer(boolean async) {
+  protected synchronized void releaseBuffer() {
     final ByteBuffer buffer = this.buffer;
     this.buffer = null;
-    ExecutorService asyncPool;
-    if (async && (asyncPool = CallbackFactoryProvider.getStoreCallbacks()
-        .poolForAsyncOperation()) != null) {
-      asyncPool.execute(() -> allocator.release(buffer));
-    } else {
-      this.allocator.release(buffer);
-    }
+    this.allocator.release(buffer);
   }
 
   @Override

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
@@ -1419,7 +1419,7 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
       Object oldVal = getValueField();
       if (oldVal != val && oldVal instanceof SerializedDiskBuffer) {
         setValueField(val);
-        ((SerializedDiskBuffer)oldVal).release(true);
+        ((SerializedDiskBuffer)oldVal).release();
         return;
       }
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
@@ -739,7 +739,7 @@ public interface DiskEntry extends RegionEntry {
         final SerializedDiskBuffer buffer = this.buffer;
         if (buffer != null && buffer.needsRelease()) {
           this.buffer = null;
-          buffer.release(true);
+          buffer.release();
         }
       }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RegionEvictorTask.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RegionEvictorTask.java
@@ -16,8 +16,6 @@
  */
 package com.gemstone.gemfire.internal.cache;
 
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -101,7 +99,7 @@ public class RegionEvictorTask implements Callable<Object> {
             LocalRegion region = iter.next();
             try {
               bytesEvicted = ((AbstractLRURegionMap)region.entries)
-                  .centralizedLruUpdateCallback(false);
+                  .centralizedLruUpdateCallback(false, false);
               if (bytesEvicted == 0) {
                 iter.remove();
               }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/store/SerializedDiskBuffer.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/store/SerializedDiskBuffer.java
@@ -98,11 +98,6 @@ public abstract class SerializedDiskBuffer extends ByteBufferReference {
     }
   }
 
-  @Override
-  public final void release() {
-    release(false);
-  }
-
   /**
    * An optional explicit release of the underlying data. The buffer may no
    * longer be usable after this call and return empty data.
@@ -112,14 +107,15 @@ public abstract class SerializedDiskBuffer extends ByteBufferReference {
    * Typically this means using NIO DirectByteBuffers for data which will
    * release automatically in the GC cycles when no references remain.
    */
-  public void release(boolean async) {
+  @Override
+  public void release() {
     while (true) {
       final int refCount = refCountUpdate.get(this);
       if (refCount > 0) {
         if (refCountUpdate.compareAndSet(this, refCount, refCount - 1)) {
           if (refCount == 1) {
             // reference count has gone down to zero so release the buffer
-            releaseBuffer(async);
+            releaseBuffer();
           }
           break;
         }
@@ -144,7 +140,7 @@ public abstract class SerializedDiskBuffer extends ByteBufferReference {
     return retain() ? this : null;
   }
 
-  protected abstract void releaseBuffer(boolean async);
+  protected abstract void releaseBuffer();
 
   /**
    * For buffers which are stored in region, set its DiskId.

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/store/WrappedBytes.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/store/WrappedBytes.java
@@ -60,7 +60,7 @@ public final class WrappedBytes extends SerializedDiskBuffer {
   }
 
   @Override
-  public void release(boolean async) {
+  public void release() {
   }
 
   @Override
@@ -69,7 +69,7 @@ public final class WrappedBytes extends SerializedDiskBuffer {
   }
 
   @Override
-  protected void releaseBuffer(boolean async) {
+  protected void releaseBuffer() {
   }
 
   @Override

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
@@ -20,7 +20,6 @@ package com.gemstone.gemfire.internal.snappy;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
 import com.gemstone.gemfire.internal.cache.BucketRegion;
 import com.gemstone.gemfire.internal.snappy.memory.MemoryManagerStats;
@@ -97,11 +96,6 @@ public abstract class CallbackFactoryProvider {
     @Override
     public void releaseStorageMemory(String objectName,
         long numBytes, boolean offHeap) {
-    }
-
-    @Override
-    public ExecutorService poolForAsyncOperation() {
-      return null;
     }
 
     @Override

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
@@ -19,7 +19,6 @@ package com.gemstone.gemfire.internal.snappy;
 
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
 import com.gemstone.gemfire.internal.cache.BucketRegion;
 import com.gemstone.gemfire.internal.snappy.memory.MemoryManagerStats;
@@ -75,12 +74,6 @@ public interface StoreCallbacks {
       UMMMemoryTracker buffer, boolean shouldEvict, boolean offHeap);
 
   void releaseStorageMemory(String objectName, long numBytes, boolean offHeap);
-
-  /**
-   * Get the pool for an async acquire/release operation, or null if
-   * pool cannot be used and operation should be in the same thread.
-   */
-  ExecutorService poolForAsyncOperation();
 
   void dropStorageMemory(String objectName, long ignoreBytes);
 


### PR DESCRIPTION
As suggested by @rishitesh now using Unsafe API to try acquire monitor on RegionEntry
in evictor and skip if it cannot (with one retry).

## Changes proposed in this pull request

- pass an additional flag to AbstractLRURegionMap.centralizedLruUpdateCallback to tell
  whether to skip already locked RegionEntries
- use Unsafe.tryMonitorEnter to acquire RegionEntry lock in getLRUEntry and if it fails then skip
  and continue to other RegionEntries
- revert async cleanup changes done for SNAP-2007
- update jetty to latest 9.2.x version in an attempt to fix occasional "bad request" errors
  seen on dashboard currently

## Patch testing

precheckin

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/839