### PR TITLE
Snap 2014 : Column table size is wrong in UI after truncate table

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -2723,7 +2723,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
       this.partitionedRegion.getPrStats().incDataStoreEntryCount(-sizeBeforeClear);
       prDs.updateMemoryStats(-oldMemValue);
     }
-    // explicitly clear overflow counters if no diskRegion is present
+    // explicitly clear overflow counters 
     // (for latter the counters are cleared by DiskRegion.statsClear)
     this.numOverflowOnDisk.set(0);
     this.numOverflowBytesOnDisk.set(0);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -2725,10 +2725,8 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     }
     // explicitly clear overflow counters if no diskRegion is present
     // (for latter the counters are cleared by DiskRegion.statsClear)
-    if (getDiskRegion() == null) {
-      this.numOverflowOnDisk.set(0);
-      this.numOverflowBytesOnDisk.set(0);
-    }
+    this.numOverflowOnDisk.set(0);
+    this.numOverflowBytesOnDisk.set(0);
   }
 
   

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -2726,10 +2726,12 @@ public class BucketRegion extends DistributedRegion implements Bucket {
       this.partitionedRegion.getPrStats().incDataStoreEntryCount(-sizeBeforeClear);
       prDs.updateMemoryStats(-oldMemValue);
     }
-    // explicitly clear overflow counters 
+    // explicitly clear overflow counters if no diskRegion is present
     // (for latter the counters are cleared by DiskRegion.statsClear)
-    this.numOverflowOnDisk.set(0);
-    this.numOverflowBytesOnDisk.set(0);
+    if (getDiskRegion() == null) {
+      this.numOverflowOnDisk.set(0);
+      this.numOverflowBytesOnDisk.set(0);
+    }
   }
 
   

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskRegion.java
@@ -556,10 +556,13 @@ public class DiskRegion extends AbstractDiskRegion {
       BucketRegion owner=(BucketRegion)region;
       long curInVM = owner.getNumEntriesInVM()*-1;
       long curOnDisk = owner.getNumOverflowOnDisk()*-1;
+      long curBytesOnDisk = owner.getNumOverflowBytesOnDisk()*-1;
       incNumEntriesInVM(curInVM);
       incNumOverflowOnDisk(curOnDisk);
+      incNumOverflowBytesOnDisk(curBytesOnDisk);
       owner.incNumEntriesInVM(curInVM);
       owner.incNumOverflowOnDisk(curOnDisk);
+      owner.incNumOverflowBytesOnDisk(curBytesOnDisk);
     } else {
       // set them both to zero
       incNumEntriesInVM(getNumEntriesInVM()*-1);


### PR DESCRIPTION
## Changes proposed in this pull request

- Reseting numOverflowOnDisk & numOverflowBytesOnDisk to zero in BucketRegion.updateSizeOnClearRegion method.

## Patch testing

- Tested manually

## ReleaseNotes changes

 - None

## Other PRs 

 - None