### PR TITLE
[SNAP-2016] Fix for Multiple warning message from memory pool

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
@@ -99,12 +99,12 @@ public abstract class AbstractOplogDiskRegionEntry
   
   @Override
   public final Object getValueInVMOrDiskWithoutFaultIn(LocalRegion owner) {
-    return Helper.getValueInVMOrDiskWithoutFaultIn(this, owner);
+    return Helper.getValueOffHeapOrDiskWithoutFaultIn(this, owner, true);
   }
   @Retained
   @Override
   public Object getValueOffHeapOrDiskWithoutFaultIn(LocalRegion owner) {
-    return Helper.getValueOffHeapOrDiskWithoutFaultIn(this, owner);
+    return Helper.getValueOffHeapOrDiskWithoutFaultIn(this, owner, false);
   }
 
   @Override

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
@@ -538,7 +538,11 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
 
   @Retained
   public  Object getValueInVMOrDiskWithoutFaultIn(LocalRegion owner) {
-   return getValueInVM(owner);
+    Object v = getValueInVM(owner);
+    if (GemFireCacheImpl.hasNewOffHeap() && (v instanceof SerializedDiskBuffer)) {
+      ((SerializedDiskBuffer)v).retain();
+    }
+    return v;
   }
 
   @Retained

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
@@ -1406,7 +1406,7 @@ public interface DiskEntry extends RegionEntry {
       //did.setValueSerializedSize(0);
       // I think the following assertion is true but need to run
       // a regression with it. Reenable this post 6.5
-      Assert.assertTrue(entry._getValue() == null);
+      // Assert.assertTrue(entry._getValue() == null);
       entry.setValueWithContext((RegionEntryContext) region, preparedValue);
       dr.incNumEntriesInVM(1L);
       dr.incNumOverflowOnDisk(-1L);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
@@ -262,6 +262,13 @@ public interface DiskEntry extends RegionEntry {
     @Retained
     static Object getOffHeapValueOnDiskOrBuffer(DiskEntry entry,
         DiskRegionView dr, RegionEntryContext context, boolean faultin) {
+      return getOffHeapValueOnDiskOrBuffer(entry, dr, context, faultin, false);
+    }
+
+    @Retained
+    static Object getOffHeapValueOnDiskOrBuffer(DiskEntry entry,
+        DiskRegionView dr, RegionEntryContext context,
+        boolean faultin, boolean rawValue) {
       DiskId did = entry.getDiskId();
       Object syncObj = did;
       if (syncObj == null) {
@@ -273,7 +280,7 @@ public interface DiskEntry extends RegionEntry {
       try {
         synchronized (syncObj) {
           if (did != null && did.isPendingAsync()) {
-            @Retained Object v = entry._getValueRetain(context, true); // TODO:KIRK:OK Rusty had Object v = entry.getValueWithContext(context);
+            @Retained Object v = getValueRetain(entry, context, rawValue); // TODO:KIRK:OK Rusty had Object v = entry.getValueWithContext(context);
             if (Token.isRemovedFromDisk(v)) {
               v = null;
             }
@@ -287,7 +294,7 @@ public interface DiskEntry extends RegionEntry {
 
           Object v = dr.getDiskStore().getSerializedDataWithoutLock(dr, did,
               faultin);
-          if (!faultin && (v instanceof SerializedDiskBuffer)) {
+          if (!faultin && !rawValue && (v instanceof SerializedDiskBuffer)) {
             // convert to on-heap form to avoid buildup of off-heap data
             ((SerializedDiskBuffer)v).copyToHeap("NO_FAULTIN");
           }
@@ -1040,29 +1047,28 @@ public interface DiskEntry extends RegionEntry {
       }
     }
 
-    public static Object getValueInVMOrDiskWithoutFaultIn(DiskEntry entry, LocalRegion region) {
-      Object result = OffHeapHelper.copyAndReleaseIfNeeded(getValueOffHeapOrDiskWithoutFaultIn(entry, region));
-      if (result instanceof CachedDeserializable) {
-        result = ((CachedDeserializable)result).getDeserializedValue(null, null);
+    private static Object getValueRetain(DiskEntry entry, RegionEntryContext context,
+        boolean rawValue) {
+      @Retained Object v = entry._getValueRetain(context, true);
+      if (rawValue && GemFireCacheImpl.hasNewOffHeap() &&
+          (v instanceof SerializedDiskBuffer)) {
+        ((SerializedDiskBuffer)v).retain();
       }
-      if (result instanceof StoredObject) {
-        ((StoredObject) result).release();
-        throw new IllegalStateException("gfxd tried to use getValueInVMOrDiskWithoutFaultIn");
-      }
-      return result;
+      return v;
     }
 
     @Retained
-    public static Object getValueOffHeapOrDiskWithoutFaultIn(DiskEntry entry, LocalRegion region) {
-      @Retained Object v = entry._getValueRetain(region, true); // TODO:KIRK:OK Object v = entry.getValueWithContext(region);
+    public static Object getValueOffHeapOrDiskWithoutFaultIn(DiskEntry entry,
+        LocalRegion region, boolean rawValue) {
+      @Retained Object v = getValueRetain(entry, region, rawValue); // TODO:KIRK:OK Object v = entry.getValueWithContext(region);
       final boolean isRemovedFromDisk = Token.isRemovedFromDisk(v);
       if ((v == null || isRemovedFromDisk)
           && !region.isIndexCreationThread()) {
         synchronized (entry) {
-          v = entry._getValueRetain(region, true); // TODO:KIRK:OK v = entry.getValueWithContext(region);
+          v = getValueRetain(entry, region, rawValue); // TODO:KIRK:OK v = entry.getValueWithContext(region);
           if (v == null) {
             v = Helper.getOffHeapValueOnDiskOrBuffer(entry,
-                region.getDiskRegion(), region, false);
+                region.getDiskRegion(), region, false, rawValue);
           }
         }
       }
@@ -1400,7 +1406,7 @@ public interface DiskEntry extends RegionEntry {
       //did.setValueSerializedSize(0);
       // I think the following assertion is true but need to run
       // a regression with it. Reenable this post 6.5
-      //Assert.assertTrue(entry._getValue() == null);
+      Assert.assertTrue(entry._getValue() == null);
       entry.setValueWithContext((RegionEntryContext) region, preparedValue);
       dr.incNumEntriesInVM(1L);
       dr.incNumOverflowOnDisk(-1L);
@@ -1543,7 +1549,6 @@ public interface DiskEntry extends RegionEntry {
           change += entry.updateAsyncEntrySize(ccHelper);
           // do the stats when it is actually written to disk
         } else {
-          region.updateSizeOnEvict(entry.getKey(), oldSize);
           //did.setValueSerializedSize(byteSizeOnDisk);
           try {
             entry.handleValueOverflow(region);
@@ -1551,6 +1556,7 @@ public interface DiskEntry extends RegionEntry {
           }finally {
             entry.afterValueOverflow(region);
           }
+          region.updateSizeOnEvict(entry.getKey(), oldSize);
           movedValueToDisk = true;
           change = ((LRUClockNode)entry).updateEntrySize(ccHelper);
         }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
@@ -89,7 +89,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
       if (faultInValue) {
         v = re.getValue(br);
       } else {
-        v = re.getValueOffHeapOrDiskWithoutFaultIn(br);
+        v = re.getValueInVMOrDiskWithoutFaultIn(br);
       }
       try {
         this.value = OffHeapHelper.getHeapForm(v);  // OFFHEAP: copy into heap cd

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RegionEntry.java
@@ -426,10 +426,8 @@ public interface RegionEntry extends ExclusiveSharedLockObject {
   public Object getSerializedValueOnDisk(LocalRegion localRegion);
 
   /**
-   * Gets the value for this entry. For DiskRegions, unlike
-   * {@link #getValue(RegionEntryContext)} this will not fault in the value rather
-   * return a temporary copy. For GemFireXD this is used during table scans in
-   * queries when faulting in every value will be only an unnecessary overhead.
+   * Get the value in region or disk without faultin in raw form without any
+   * change in storage format (SnappyData off-heap will return off-heap buffer).
    */
   @Retained
   public Object getValueInVMOrDiskWithoutFaultIn(LocalRegion owner);


### PR DESCRIPTION
After update & delta merge Old entry GC thread prints multiple warnings.
Attempted to release XXX bytes of storage memory when we only have YYYY bytes.
Further analysis of this issue revealed other potential problems.
a) Old Entry GC thread faults in data to heap memory, which can cause a LowMemory exception if a user has provisioned for off-heap memory. 
b) Also, buffer retain was not called properly while copying to old entry map. That would cause in correct results in case of the snapshot.

## Changes proposed in this pull request
Fixes suggested by @sumwale 

a) Old entry map will copy overflown data to off heap only if its an instance of SerializedDiskBuffer. This will reduce memory pressure if off-heap is configured.
b) DirectByteBuffer retain() and release is handled properly for coying into old entry map.
c) Old entry map accounting is corrected , when its copying entry from disk. Earlier it was computing value size before copying the entry to memory.

## Patch testing

precheckin

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
