### PR TITLE
[SNAP-2026] Derby classloader fix

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/services/reflect/UpdateLoader.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/services/reflect/UpdateLoader.java
@@ -322,7 +322,9 @@ final class UpdateLoader implements LockOwner {
 		if (is != null)
 			return is;
 
-		// match behaviour of standard class loaders. 
+		// match behaviour of standard class loaders.
+		// Fix for issue # SNAP-2026 . Closure cleaner reads classes as stream. This piece of code below
+		// was returning null in such case. Hence commented to return proper stream.
 /*		if (name.endsWith(".class"))
 			return null;*/
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/services/reflect/UpdateLoader.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/services/reflect/UpdateLoader.java
@@ -323,8 +323,8 @@ final class UpdateLoader implements LockOwner {
 			return is;
 
 		// match behaviour of standard class loaders. 
-		if (name.endsWith(".class"))
-			return null;
+/*		if (name.endsWith(".class"))
+			return null;*/
 
 		boolean unlockLoader = false;
 		try {


### PR DESCRIPTION
## Changes proposed in this pull request
Removed the condition in UpdateLoader which was returning null for getting a class file as resource stream.

## Patch testing

pre-checkin , installJar.bt

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
