### PR TITLE
Added a procedure to set the log level at the runtime

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/GFToSlf4jBridge.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/GFToSlf4jBridge.java
@@ -104,14 +104,16 @@ public class GFToSlf4jBridge extends LogWriterImpl {
         level = ERROR_LEVEL;
         break;
       case Level.FATAL_INT:
-      case Level.OFF_INT:
         level = SEVERE_LEVEL;
+        break;
+      case Level.OFF_INT:
+        level = NONE_LEVEL;
         break;
       case Level.TRACE_INT:
         level = FINER_LEVEL;
         break;
       default:
-        level = FINE_LEVEL;
+        level = CONFIG_LEVEL;
         break;
     }
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/GFToSlf4jBridge.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/GFToSlf4jBridge.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import com.gemstone.gemfire.GemFireIOException;
 import com.gemstone.gemfire.internal.shared.ClientSharedUtils;
 import com.gemstone.org.jgroups.util.StringId;
+import org.apache.log4j.Level;
 import org.apache.log4j.MDC;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,6 +82,36 @@ public class GFToSlf4jBridge extends LogWriterImpl {
         break;
       default:
         log.debug(msg, exception);
+        break;
+    }
+  }
+
+  public void setLog4Level(Level log4jlevel) {
+    switch (log4jlevel.toInt()) {
+      case Level.ALL_INT:
+        level = FINEST_LEVEL;
+        break;
+      case Level.DEBUG_INT:
+        level = FINE_LEVEL;
+        break;
+      case Level.INFO_INT:
+        level = INFO_LEVEL;
+        break;
+      case Level.WARN_INT:
+        level = WARNING_LEVEL;
+        break;
+      case Level.ERROR_INT:
+        level = ERROR_LEVEL;
+        break;
+      case Level.FATAL_INT:
+      case Level.OFF_INT:
+        level = SEVERE_LEVEL;
+        break;
+      case Level.TRACE_INT:
+        level = FINER_LEVEL;
+        break;
+      default:
+        level = FINE_LEVEL;
         break;
     }
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/GFToSlf4jBridge.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/GFToSlf4jBridge.java
@@ -86,7 +86,7 @@ public class GFToSlf4jBridge extends LogWriterImpl {
     }
   }
 
-  public void setLog4Level(Level log4jlevel) {
+  public void setLevelForLog4jLevel(Level log4jlevel) {
     switch (log4jlevel.toInt()) {
       case Level.ALL_INT:
         level = FINEST_LEVEL;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -2200,7 +2200,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
 
   /**
    * This procedure sets the log level for either the root logger or a class.
-   * If the logClass is empty string, the root logger's level is set .
+   * If the logClass is empty string, the root logger's level is set.
    */
   public static void SET_LOG_LEVEL(String logClass, String level)
           throws SQLException, StandardException {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -2200,7 +2200,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
 
   /**
    * This procedure sets the log level for either the root logger or a class.
-   * If the logClass is null, the root logger's level is set .
+   * If the logClass is empty string, the root logger's level is set .
    */
   public static void SET_LOG_LEVEL(String logClass, String level)
           throws SQLException, StandardException {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -2199,9 +2199,8 @@ public class GfxdSystemProcedures extends SystemProcedures {
   }
 
   /**
-   * This procedure sets the log level for a logger.
+   * This procedure sets the log level for either the root logger or a class.
    * If the logClass is null, the root logger's level is set .
-   * corresponding GFE layer flag.
    */
   public static void SET_LOG_LEVEL(String logClass, String level)
           throws SQLException, StandardException {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.logging.Level;
 import javax.annotation.Nonnull;
 
 import com.gemstone.gemfire.DataSerializer;
@@ -121,6 +122,7 @@ import com.pivotal.gemfirexd.internal.shared.common.sanity.SanityManager;
 import com.pivotal.gemfirexd.internal.snappy.LeadNodeSmartConnectorOpContext;
 import com.pivotal.gemfirexd.load.Import;
 import io.snappydata.thrift.ServerType;
+import org.apache.log4j.LogManager;
 
 /**
  * GemFireXD built-in system procedures that will get executed on every
@@ -2194,6 +2196,23 @@ public class GfxdSystemProcedures extends SystemProcedures {
 
     // import finished successfully, commit it.
     conn.commit();
+  }
+
+  /**
+   * This procedure sets the log level for a logger.
+   * If the logClass is null, the root logger's level is set .
+   * corresponding GFE layer flag.
+   */
+  public static void SET_LOG_LEVEL(String logClass, String level)
+          throws SQLException, StandardException {
+
+    final Object[] params = new Object[] { logClass, level };
+    // first process locally
+    GfxdSystemProcedureMessage.SysProcMethod.setLogLevel.processMessage(
+            params, Misc.getMyId());
+    // then publish to other members including locators
+    publishMessage(params, false,
+            GfxdSystemProcedureMessage.SysProcMethod.setLogLevel, false, true);
   }
 
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import com.gemstone.gemfire.CancelException;
 import com.gemstone.gemfire.DataSerializer;
+import com.gemstone.gemfire.LogWriter;
 import com.gemstone.gemfire.cache.hdfs.internal.hoplog.HDFSRegionDirector;
 import com.gemstone.gemfire.distributed.DistributedMember;
 import com.gemstone.gemfire.distributed.internal.DistributionManager;
@@ -1087,8 +1088,9 @@ public final class GfxdSystemProcedureMessage extends
           if (logClass.equals("")) {
             // sets the log level for the root logger and the GFXD bridge
             LogManager.getRootLogger().setLevel(level);
-            if (InternalDistributedSystem.getLoggerI18n() instanceof GFToSlf4jBridge) {
-              ((GFToSlf4jBridge) InternalDistributedSystem.getLoggerI18n()).setLevelForLog4jLevel(level);
+            LogWriter logger = Misc.getCacheLogWriterNoThrow();
+            if (logger instanceof GFToSlf4jBridge) {
+              ((GFToSlf4jBridge) logger).setLevelForLog4jLevel(level);
             }
           } else {
             LogManager.getLogger(logClass).setLevel(level);
@@ -1120,7 +1122,7 @@ public final class GfxdSystemProcedureMessage extends
       String getSQLStatement(Object[] params) throws StandardException {
         final StringBuilder sb = new StringBuilder();
         return sb.append("CALL SYS.SET_LOG_LEVEL('").append(params[0])
-                .append("',").append(params[1]).append(')')
+                .append("', '").append(params[1]).append("')")
                 .toString();
       }
     },

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
@@ -1088,7 +1088,7 @@ public final class GfxdSystemProcedureMessage extends
             // sets the log level for the root logger and the GFXD bridge
             LogManager.getRootLogger().setLevel(level);
             if (InternalDistributedSystem.getLoggerI18n() instanceof GFToSlf4jBridge) {
-              ((GFToSlf4jBridge) InternalDistributedSystem.getLoggerI18n()).setLog4Level(level);
+              ((GFToSlf4jBridge) InternalDistributedSystem.getLoggerI18n()).setLevelForLog4jLevel(level);
             }
           } else {
             LogManager.getLogger(logClass).setLevel(level);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
@@ -31,7 +31,9 @@ import com.gemstone.gemfire.cache.hdfs.internal.hoplog.HDFSRegionDirector;
 import com.gemstone.gemfire.distributed.DistributedMember;
 import com.gemstone.gemfire.distributed.internal.DistributionManager;
 import com.gemstone.gemfire.distributed.internal.DistributionStats;
+import com.gemstone.gemfire.distributed.internal.InternalDistributedSystem;
 import com.gemstone.gemfire.distributed.internal.ReplyException;
+import com.gemstone.gemfire.internal.GFToSlf4jBridge;
 import com.gemstone.gemfire.internal.InternalDataSerializer;
 import com.gemstone.gemfire.internal.NanoTimer;
 import com.gemstone.gemfire.internal.cache.CachePerfStats;
@@ -81,6 +83,8 @@ import com.pivotal.gemfirexd.internal.impl.sql.execute.TablePrivilegeInfo;
 import com.pivotal.gemfirexd.internal.shared.common.SharedUtils;
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState;
 import com.pivotal.gemfirexd.internal.shared.common.sanity.SanityManager;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 
 /**
  * System Procedure Message that is sent out to members to execute procedures
@@ -1001,7 +1005,7 @@ public final class GfxdSystemProcedureMessage extends
             .toString();
       }
     },
-    
+
     waitForSenderQueueFlush {
 
       @Override
@@ -1062,7 +1066,64 @@ public final class GfxdSystemProcedureMessage extends
             .append(params[2]).append(')').toString();
       }
     },
-    
+
+    setLogLevel {
+
+      @Override
+      boolean allowExecution(Object[] params) {
+        // so allowing log level to be set on all nodes including locator
+        return true;
+      }
+
+      @Override
+      public void processMessage(Object[] params, DistributedMember sender)
+          throws StandardException {
+        try {
+          String logClass = (String) params[0];
+          Level level = org.apache.log4j.Level.toLevel((String) params[1]);
+          SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_SYS_PROCEDURES,
+                  "GfxdSystemProcedureMessage: setting log level for class '" + logClass
+                          + "' to " + level);
+          if (logClass.equals("")) {
+            LogManager.getRootLogger().setLevel(level);
+            if (InternalDistributedSystem.getLoggerI18n() instanceof GFToSlf4jBridge) {
+              ((GFToSlf4jBridge) InternalDistributedSystem.getLoggerI18n()).setLog4Level(level);
+            }
+          } else {
+            LogManager.getLogger(logClass).setLevel(level);
+          }
+        } catch (Exception e) {
+          throw StandardException.newException(
+                  com.pivotal.gemfirexd.internal.iapi.reference.SQLState.GENERIC_PROC_EXCEPTION,
+                  e, e.getMessage());
+        }
+      }
+
+      @Override
+      public Object[] readParams(DataInput in, short flags) throws IOException {
+        Object[] inParams = new Object[2];
+        inParams[0] = InternalDataSerializer.readString(in);
+        inParams[1] = InternalDataSerializer.readString(in);
+
+        return inParams;
+      }
+
+      @Override
+      public void writeParams(Object[] params, DataOutput out)
+              throws IOException {
+        InternalDataSerializer.writeString((String)params[0], out);
+        InternalDataSerializer.writeString((String)params[1], out);
+      }
+
+      @Override
+      String getSQLStatement(Object[] params) throws StandardException {
+        final StringBuilder sb = new StringBuilder();
+        return sb.append("CALL SYS.SET_LOG_LEVEL('").append(params[0])
+                .append("',").append(params[1]).append(')')
+                .toString();
+      }
+    },
+
     setGatewayFKChecks {
       @Override
       boolean allowExecution(Object[] params) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
@@ -1085,6 +1085,7 @@ public final class GfxdSystemProcedureMessage extends
                   "GfxdSystemProcedureMessage: setting log level for class '" + logClass
                           + "' to " + level);
           if (logClass.equals("")) {
+            // sets the log level for the root logger and the GFXD bridge
             LogManager.getRootLogger().setLevel(level);
             if (InternalDistributedSystem.getLoggerI18n() instanceof GFToSlf4jBridge) {
               ((GFToSlf4jBridge) InternalDistributedSystem.getLoggerI18n()).setLog4Level(level);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -1483,6 +1483,17 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
     }
 
     {
+      // void SET_LOG_LEVEL(String logClass, String level)
+      String[] argNames = new String[] { "LOGCLASS", "LEVEL" };
+      TypeDescriptor[] argTypes = new TypeDescriptor[] {
+              DataTypeDescriptor.getCatalogType(Types.VARCHAR, 1024),
+              DataTypeDescriptor.getCatalogType(Types.VARCHAR, 64) };
+      super.createSystemProcedureOrFunction("SET_LOG_LEVEL", sysUUID,
+              argNames, argTypes, 0, 0, RoutineAliasInfo.NO_SQL, null,
+              newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, true);
+    }
+
+    {
       // void WAIT_FOR_SENDER_QUEUE_FLUSH(String id, Boolean isAsyncListener,
       //   Integer maxWaitTime)
       String[] argNames = new String[] { "ID", "IS_ASYNCLISTENER",

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -1486,8 +1486,10 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
       // void SET_LOG_LEVEL(String logClass, String level)
       String[] argNames = new String[] { "LOGCLASS", "LEVEL" };
       TypeDescriptor[] argTypes = new TypeDescriptor[] {
-              DataTypeDescriptor.getCatalogType(Types.VARCHAR, 1024),
-              DataTypeDescriptor.getCatalogType(Types.VARCHAR, 64) };
+              DataTypeDescriptor.getBuiltInDataTypeDescriptor(
+                  Types.VARCHAR, false, 1024).getCatalogType(),
+              DataTypeDescriptor.getBuiltInDataTypeDescriptor(
+                  Types.VARCHAR, false, 64).getCatalogType()};
       super.createSystemProcedureOrFunction("SET_LOG_LEVEL", sysUUID,
               argNames, argTypes, 0, 0, RoutineAliasInfo.NO_SQL, null,
               newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, true);

--- a/gemfirexd/core/src/main/resources/com/pivotal/gemfirexd/internal/loc/messages.xml
+++ b/gemfirexd/core/src/main/resources/com/pivotal/gemfirexd/internal/loc/messages.xml
@@ -3816,7 +3816,7 @@ Guide.
            </msg>
            <msg>
                 <name>X0Z27.S</name>
-                <text>An unexpected exception occured during procedure execution: {0}.</text>
+                <text>An unexpected exception occured during procedure execution: {0}. Refer log file for exception details.</text>
                 <arg>value</arg>
            </msg>
            <msg>


### PR DESCRIPTION
## Changes proposed in this pull request

Added a gfxd procedure to set the log level at the runtime. 
The syntax would be: 
snappy> call sys.set_log_level (loggerName, logLevel);

The level can be a log4j level i.e. ALL, DEBUG, INFO, WARN, ERROR, FATAL, OFF, TRACE.

logger name can be a class name or a package name. if the logger name is blank, root logger's level is set. 

Few examples: 

// sets the root logger's level as warn
snappy> call sys.set_log_level ('', 'WARN' );
// sets the WholeStageCodegenExec level as DEBUG
snappy> call sys.set_log_level ('org.apache.spark.sql.execution.WholeStageCodegenExec', 'DEBUG');
// sets the apache spark package's log level as INFO
snappy> call sys.set_log_level ('org.apache.spark', 'INFO');

One thing to note is snappy-store does not honour the log level of individual classes. This behavior has been this way always but noting it here because store classes level cannot be changed using this procedure. 

However, when the root logger level is set as follows, the level of the store logging is appropriately set. 
 call sys.set_log_level ('', 'WARN' );

## Patch testing

Manual. Precheckin. 
