### PR TITLE
[SNAP-2032] move bucket size tracking inside RegionEntry._setValue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ allprojects {
     gitBranch = "${gitCmd} rev-parse --abbrev-ref HEAD".execute().text.trim()
     commitId = "${gitCmd} rev-parse HEAD".execute().text.trim()
     sourceDate = "${gitCmd} log -n 1 --format=%ai".execute().text.trim()
+    buildIdPrefix = System.env.USER + ' '
 
     osArch = System.getProperty('os.arch')
     osName = org.gradle.internal.os.OperatingSystem.current()
@@ -123,6 +124,9 @@ allprojects {
     buildDir = new File(buildRoot, osDir + '/' +  project.path.replace(':', '/'))
   } else {
     buildDir = 'build-artifacts/' + osDir
+  }
+  if (rootProject.hasProperty('enablePublish')) {
+    buildIdPrefix = 'SnappyData, Inc. '
   }
 
   ext {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskRegionEntry.java
@@ -59,7 +59,7 @@ public abstract class AbstractDiskRegionEntry
    */
   @Override
   public void setValueWithContext(RegionEntryContext context, Object value) {
-    _setValue(value);
+    _setValue(context, value);
     initDiskIdForOffHeap(context, value);
     if (value != null && context != null && context instanceof LocalRegion
         && ((LocalRegion)context).isThisRegionBeingClosedOrDestroyed()

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
@@ -66,17 +66,17 @@ public abstract class AbstractOplogDiskRegionEntry
   {
     synchronized (this) {
       Helper.removeFromDisk(this, r, isClear);
-      _removePhase1();
+      _removePhase1(r);
     }
   }
   @Override
-  public void removePhase2() {
+  public void removePhase2(LocalRegion r) {
     Object syncObj = getDiskId();
     if (syncObj == null) {
       syncObj = this;
     }
     synchronized (syncObj) {
-      super.removePhase2();
+      super.removePhase2(r);
     }
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
@@ -181,7 +181,7 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
         // Phase 2 of region entry removal is done here. The first phase is done
         // by the RegionMap. It is unclear why this code is needed. ARM destroy
         // does this also and we are now doing it as phase3 of the ARM destroy.
-        removePhase2();
+        removePhase2(rgn);
         rgn.getRegionMap().removeEntry(event.getKey(), this, true, event, rgn, null);
       }
     }
@@ -220,17 +220,17 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
     throw new InternalStatisticsDisabledException();
   }
     
-  public void _removePhase1() {
-    _setValue(Token.REMOVED_PHASE1);
+  public void _removePhase1(LocalRegion r) {
+    _setValue(r, Token.REMOVED_PHASE1);
     // debugging for 38467 (hot thread in ARM.basicUpdate)
 //    this.removeTrace = new Exception("stack trace for thread " + Thread.currentThread());
   }
   public void removePhase1(LocalRegion r, boolean isClear) throws RegionClearedException {
-    _removePhase1();
+    _removePhase1(r);
   }
   
-  public void removePhase2() {
-    _setValue(Token.REMOVED_PHASE2);
+  public void removePhase2(LocalRegion r) {
+    _setValue(r, Token.REMOVED_PHASE2);
 //    this.removeTrace = new Exception("stack trace for thread " + Thread.currentThread());
   }
 
@@ -474,7 +474,7 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
   
   @Released
   protected void setValue(RegionEntryContext context, @Unretained Object value, boolean recentlyUsed) {
-    _setValue(value);
+    _setValue(context, value);
     if (value != null && context != null && context instanceof LocalRegion
         && ((LocalRegion)context).isThisRegionBeingClosedOrDestroyed()
         && isOffHeap()) {
@@ -854,7 +854,7 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
             if(isValueNull()) {
               @Released Object value = getValueOffHeapOrDiskWithoutFaultIn(region);
               try {
-              _setValue(prepareValueForCache(region, value, false, false));
+              _setValue(region, prepareValueForCache(region, value, false, false));
               if (value != null && region != null && isOffHeap() && region.isThisRegionBeingClosedOrDestroyed()) {
                 ((OffHeapRegionEntry)this).release();
                 region.checkReadiness();
@@ -1394,7 +1394,7 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
     _setLastModified(LOCKED_TOKEN);
   }
 
-  public final void _setValue(@Unretained final Object val) {
+  final void _setValue(RegionEntryContext context, @Unretained final Object val) {
     final StaticSystemCallbacks sysCb =
         GemFireCacheImpl.FactoryStatics.systemCallbacks;
     final Object containerInfo;
@@ -1419,11 +1419,14 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
     }
 
     // release old SerializedDiskBuffer explicitly for eager cleanup
-    if (!isOffHeap()) {
-      Object oldVal = getValueField();
-      if (oldVal != val && oldVal instanceof SerializedDiskBuffer) {
+    final boolean isOffHeap = isOffHeap();
+    Object rawOldVal = null;
+    if (!isOffHeap) {
+      rawOldVal = getValueField();
+      if (rawOldVal != val && rawOldVal instanceof SerializedDiskBuffer) {
         setValueField(val);
-        ((SerializedDiskBuffer)oldVal).release();
+        if (context != null) context.updateMemoryStats(rawOldVal, val);
+        ((SerializedDiskBuffer)rawOldVal).release();
         return;
       }
     }
@@ -1436,6 +1439,9 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
         // and will remain the same
         || (Token.isRemoved(val) && getValueAsToken() != Token.NOT_A_TOKEN)) {
       setValueField(val);
+      if (!isOffHeap && context != null) {
+        context.updateMemoryStats(rawOldVal, val);
+      }
     }
     else {
       final LocalRegion region = sysCb
@@ -1464,6 +1470,9 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
           else {
             setValueField(val);
             _setRawKey(null);
+          }
+          if (!isOffHeap && context != null) {
+            context.updateMemoryStats(rawOldVal, val);
           }
           // also upgrade GemFireXD schema information if required; there is no
           // problem of concurrency since GFXD DDL cannot happen concurrently
@@ -3063,8 +3072,8 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
     return Token.isDestroyed(getValueAsToken());
   }
 
-  public void setValueToNull() {
-    _setValue(null);
+  public void setValueToNull(RegionEntryContext context) {
+    _setValue(context, null);
   }
   
   public boolean isInvalidOrRemoved() {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
@@ -500,13 +500,14 @@ abstract class AbstractRegionMap implements RegionMap {
   }
 
   public final void removeEntry(Object key, RegionEntry re, boolean updateStat) {
+    final LocalRegion owner = _getOwner();
     if (re.isTombstone() && _getMap().get(key) == re && !re.isMarkedForEviction()) {
-      _getOwner().getLogWriterI18n().severe(LocalizedStrings.AbstractRegionMap_ATTEMPT_TO_REMOVE_TOMBSTONE, key, new Exception("stack trace"));
+      owner.getLogWriterI18n().severe(LocalizedStrings.AbstractRegionMap_ATTEMPT_TO_REMOVE_TOMBSTONE, key, new Exception("stack trace"));
       return; // can't remove tombstones except from the tombstone sweeper
     }
 //    _getOwner().getLogWriterI18n().info(LocalizedStrings.DEBUG, "DEBUG: removing entry " + re, new Exception("stack trace"));
     if (_getMap().remove(key, re)) {
-      re.removePhase2();
+      re.removePhase2(owner);
       if (updateStat) {
         incEntryCount(-1);
       }
@@ -562,7 +563,7 @@ abstract class AbstractRegionMap implements RegionMap {
       }
       
       if (_getMap().remove(key, re)) {
-        re.removePhase2();
+        re.removePhase2(owner);
         success = true;
         if (updateStat) {
           incEntryCount(-1);
@@ -690,7 +691,7 @@ abstract class AbstractRegionMap implements RegionMap {
                 } catch (RegionClearedException e) {
                   //do nothing, it's already cleared.
                 }
-                re.removePhase2();
+                re.removePhase2(lr);
                 lruEntryDestroy(re);
                 if (tombstone) {
                   _getOwner().incTombstoneCount(-1);
@@ -826,9 +827,10 @@ abstract class AbstractRegionMap implements RegionMap {
     //so that they will be in the correct order.
     OrderedTombstoneMap<RegionEntry> tombstones = new OrderedTombstoneMap<RegionEntry>();
     if (rm != null) {
+      final LocalRegion owner = _getOwner();
       // Read current time to later pass it to all calls to copyRecoveredEntry.  This is 
       // needed if a dummy version tag has to be created for a region entry
-      final long currentTime = ((LocalRegion)owner).getCache().cacheTimeMillis();
+      final long currentTime = owner.getCache().cacheTimeMillis();
       
       CustomEntryConcurrentHashMap<Object, Object> other = ((AbstractRegionMap)rm)._getMap();
       Iterator<Map.Entry<Object, Object>> it = other
@@ -847,8 +849,12 @@ abstract class AbstractRegionMap implements RegionMap {
             VersionTag tag = oldRe.getVersionStamp().asVersionTag();
             tombstones.put(tag, oldRe);
           }
-          _getOwner().updateSizeOnCreate(key,
-              _getOwner().calculateRegionEntryValueSize(oldRe));
+          // only for incrementing count while size is updated below
+          owner.updateSizeOnCreate(key, 0);
+          if (!oldRe.isOffHeap()) {
+            owner.updateMemoryStats(null, oldRe._getValue());
+          }
+          // owner.calculateRegionEntryValueSize(oldRe));
           incEntryCount(1);
           lruEntryUpdate(oldRe);
           lruUpdateCallback();
@@ -1987,7 +1993,7 @@ RETRY_LOOP:
                   // do this before basicDestroyPart2 to fix bug 31786
                   if (!inTokenMode) {
                     if ( re.getVersionStamp() == null) {
-                      re.removePhase2();
+                      re.removePhase2(owner);
                       // GFXD index maintenance will happen from destroyEntry call
                       removeEntry(event.getKey(), re, true);
                       removed = true;
@@ -2009,7 +2015,7 @@ RETRY_LOOP:
                     EntryLogger.logDestroy(event);
                     owner.recordEvent(event);
                     if (re.getVersionStamp() == null) {
-                      re.removePhase2();
+                      re.removePhase2(owner);
                       // GFXD index maintenance will happen from destroyEntry call
                       removeEntry(event.getKey(), re, true);
                       lruEntryDestroy(re);
@@ -2274,7 +2280,7 @@ RETRY_LOOP:
           }
           else {
             re.removePhase1(owner, false); // fix for bug 43063
-            re.removePhase2();
+            re.removePhase2(owner);
             removeEntry(key, re, true);
           }
           if (EntryLogger.isEnabled()) {
@@ -3268,7 +3274,7 @@ RETRY_LOOP:
     if (re != null) {
       synchronized (re) {
         if (!re.isValueNull()) {
-          re.setValueToNull();
+          re.setValueToNull(owner);
           owner.getDiskRegion().incNumEntriesInVM(-1L);
           owner.getDiskRegion().incNumOverflowOnDisk(1L);
           if(owner instanceof BucketRegion)
@@ -3377,7 +3383,7 @@ RETRY_LOOP:
                 ((ListOfDeltas)oVal).merge(owner, delta);
                 @Retained Object newVal = ((AbstractRegionEntry)re).prepareValueForCache(
                     owner, oVal, true, false);
-                ((AbstractRegionEntry)re)._setValue(newVal); // TODO:KIRK:48068
+                ((AbstractRegionEntry)re)._setValue(owner, newVal); // TODO:KIRK:48068
                                                              // prevent orphan
               }
               else {
@@ -3411,7 +3417,7 @@ RETRY_LOOP:
                 // here?
                 @Retained Object newVal = ((AbstractRegionEntry)re).prepareValueForCache(owner,
                     new ListOfDeltas(delta), true, false);
-                ((AbstractRegionEntry)re)._setValue(newVal); // TODO:KIRK:48068
+                ((AbstractRegionEntry)re)._setValue(owner, newVal); // TODO:KIRK:48068
                                                              // prevent orphan
                 ImageState imageState = owner.getImageState();
                 if (imageState != null) {
@@ -3872,8 +3878,8 @@ RETRY_LOOP:
     boolean indexLocked = false;
     // GemFireXD Changes - END
 
-    boolean retrieveOldValueForDelta = event.getDeltaBytes() != null
-        && event.getRawNewValue() == null;
+    boolean retrieveOldValueForDelta = event.hasDelta() ||
+        (event.getDeltaBytes() != null && event.getRawNewValue() == null);
     lockForCacheModification(owner, event);
     try {
       // take read lock for GFXD index initializations if required; the index
@@ -3958,7 +3964,7 @@ RETRY_LOOP:
                   // notify index of an update
                   notifyIndex(re, owner, true);
                   try {
-                    RegionEntry oldRe = null;
+                    NonLocalRegionEntry oldRe = null;
                     try {
                       final Object memoryValue = oldValueForDelta != null ? oldValueForDelta
                           : re._getValue();
@@ -3973,10 +3979,11 @@ RETRY_LOOP:
                           valueSize = memoryValue != null && oldSize > 0
                               ? oldSize : region.calculateValueSize(oldRe._getValue());
                           oldRe.setUpdateInProgress(true);
+                          oldRe.setValueSize(valueSize);
                           checkConflict(owner, event, re);
                         }
                         // need to put old entry in oldEntryMap for MVCC
-                        owner.getCache().addOldEntry(oldRe, re, owner, valueSize, false);
+                        owner.getCache().addOldEntry(oldRe, re, owner);
                       }
                       if ((cacheWrite && event.getOperation().isUpdate()) // if there is a cacheWriter, type of event has already been set
                           || !re.isRemoved()
@@ -4383,7 +4390,7 @@ RETRY_LOOP:
       throws CacheWriterException, TimeoutException, EntryNotFoundException,
       RegionClearedException {
 
-    RegionEntry oldRe = null;
+    NonLocalRegionEntry oldRe = null;
     boolean retVal = false;
     try {
       final Object memoryValue = re._getValue();
@@ -4397,7 +4404,9 @@ RETRY_LOOP:
         oldRe.setUpdateInProgress(true);
         final int valueSize = memoryValue != null && oldSize > 0
             ? oldSize : _getOwner().calculateValueSize(oldRe._getValue());
-        _getOwner().getCache().addOldEntry(oldRe, re, _getOwner(), valueSize, true);
+        oldRe.setValueSize(valueSize);
+        oldRe.setForDelete();
+        _getOwner().getCache().addOldEntry(oldRe, re, _getOwner());
       }
       processVersionTag(re, event);
 
@@ -5124,7 +5133,7 @@ RETRY_LOOP:
 //              if (makeTombstones) {
 //                re.makeTombstone(owner, re.getVersionStamp().asVersionTag());
 //              } else {
-              re.removePhase2();
+              re.removePhase2(owner);
               removeEntry(key, re, true);
             }
           }
@@ -5160,7 +5169,7 @@ RETRY_LOOP:
       LocalRegion owner = _getOwner();
       if (reHasDelta(owner, re)) {
         synchronized (re) {
-          re.removePhase2();
+          re.removePhase2(owner);
           removeEntry(key, re, true);
         }
       }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -3098,13 +3098,12 @@ public class BucketRegion extends DistributedRegion implements Bucket {
         throw new InternalGemFireError("Bucket " + this + " size (" +
             bSize + ") negative after applying delta of " + memoryDelta);
       }
+
+      final PartitionedRegionDataStore prDS = this.partitionedRegion.getDataStore();
+      prDS.updateMemoryStats(memoryDelta);
+      //cache.getLogger().fine("DEBUG updateBucketMemoryStats delta=" + memoryDelta + " newSize=" + bytesInMemory.get(), new RuntimeException("STACK"));
     }
-    
-    final PartitionedRegionDataStore prDS = this.partitionedRegion.getDataStore();
-    prDS.updateMemoryStats(memoryDelta);
-    //cache.getLogger().fine("DEBUG updateBucketMemoryStats delta=" + memoryDelta + " newSize=" + bytesInMemory.get(), new RuntimeException("STACK"));
   }
-  
 
   public static BucketRegionIndexCleaner getIndexCleaner() {
     BucketRegionIndexCleaner cleaner = bucketRegionIndexCleaner.get();

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -2652,11 +2652,11 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   }
 
   static int calcMemSize(Object value) {
-    if (value != null && (value instanceof GatewaySenderEventImpl)) {
-      return ((GatewaySenderEventImpl)value).getSerializedValueSize();
-    } 
     if (value == null || value instanceof Token) {
       return 0;
+    }
+    if (value instanceof GatewaySenderEventImpl) {
+      return ((GatewaySenderEventImpl)value).getSerializedValueSize();
     }
     if (!(value instanceof byte[])
         && !CachedDeserializableFactory.preferObject()
@@ -2752,7 +2752,6 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   public int calculateRegionEntryValueSize(RegionEntry re) {
     return calcMemSize(re._getValue()); // OFFHEAP _getValue ok
   }
-
 
   @Override
   void updateSizeOnPut(Object key, int oldSize, int newSize) {
@@ -3052,6 +3051,9 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   void updateBucket2Size(int oldSize, int newSize,
                          SizeOp op) {
 
+    // now done from AbstractRegionEntry._setValue by a direct call to
+    // updateBucketMemoryStats
+    /*
     final int memoryDelta = op.computeMemoryDelta(oldSize, newSize);
     
     if (memoryDelta == 0) return;
@@ -3064,8 +3066,18 @@ public class BucketRegion extends DistributedRegion implements Bucket {
 
     // do the bigger one first to keep the sum > 0
     updateBucketMemoryStats(memoryDelta);
+    */
   }
-  
+
+  @Override
+  public void updateMemoryStats(final Object oldValue, final Object newValue) {
+    if (newValue != oldValue) {
+      int oldValueSize = calcMemSize(oldValue);
+      int newValueSize = calcMemSize(newValue);
+      updateBucketMemoryStats(newValueSize - oldValueSize);
+    }
+  }
+
   void updateBucketMemoryStats(final int memoryDelta) {
     if (memoryDelta != 0) {
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
@@ -134,8 +134,8 @@ public interface DiskEntry extends RegionEntry {
    */
   public DiskId getDiskId();
 
-  public void _removePhase1();
-  
+  public void _removePhase1(LocalRegion r);
+
   public int updateAsyncEntrySize(EnableLRU capacityController);
   
   public DiskEntry getPrev();
@@ -1867,7 +1867,7 @@ public interface DiskEntry extends RegionEntry {
 //            + " with value " + entry._getValue() + "checkValue=" + checkValue);
         if (checkValue) {
           valueWasNull = entry.isValueNull();
-          entry._removePhase1();
+          entry._removePhase1(region);
         }
         if (valueWasNull) {
           dr.incNumOverflowOnDisk(-1L);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskRegion.java
@@ -813,7 +813,7 @@ public class DiskRegion extends AbstractDiskRegion {
    * Only called on overflow-only regions.
    * Needs to take every entry currently using disk storage and free up that storage
    */
-  void freeAllEntriesOnDisk(LocalRegion region) {
+  void freeAllEntriesOnDisk(final LocalRegion region) {
     if(region == null) {
       return;
     }
@@ -825,8 +825,8 @@ public class DiskRegion extends AbstractDiskRegion {
             synchronized (id) {
               // GemFireXD: give a chance to copy key from value bytes when key
               // is just a pointer to value row
-              re.setValueToNull(); // TODO why call _setValue twice in a row?
-              re.removePhase2();
+              re.setValueToNull(region); // TODO why call _setValue twice in a row?
+              re.removePhase2(region);
               id.unmarkForWriting();
               if (EntryBits.isNeedsValue(id.getUserBits())) {
                 long oplogId = id.getOplogId();

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -537,7 +537,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
    * Time interval after which oldentries cleaner thread run
    */
   public static long OLD_ENTRIES_CLEANER_TIME_INTERVAL = Long.getLong("gemfire" +
-      ".snapshot-oldentries-cleaner-time-interval", 15000);
+      ".snapshot-oldentries-cleaner-time-interval", 20000);
 
 
   /**

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -528,7 +528,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   private String vmIdRegionPath;
 
   //TODO:Suranjan This has to be replcaed with better approach. guava cache or WeakHashMap.
-  protected final Map<String, Map<Object, BlockingQueue<RegionEntry>
+  private final Map<String, Map<Object, BlockingQueue<RegionEntry>
     /*RegionEntry*/>>  oldEntryMap;
   
   private ScheduledExecutorService oldEntryMapCleanerService;
@@ -537,7 +537,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
    * Time interval after which oldentries cleaner thread run
    */
   public static long OLD_ENTRIES_CLEANER_TIME_INTERVAL = Long.getLong("gemfire" +
-      ".snapshot-oldentries-cleaner-time-interval", 30000);
+      ".snapshot-oldentries-cleaner-time-interval", 15000);
 
 
   /**
@@ -581,8 +581,8 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   }
   // For each entry this should be in sync
 
-  public void addOldEntry(RegionEntry oldRe, RegionEntry newEntry, LocalRegion region,
-      int oldSize, boolean forDelete) {
+  public void addOldEntry(NonLocalRegionEntry oldRe, RegionEntry newEntry,
+      LocalRegion region) {
     if (!snapshotEnabled()) {
       return;
     }
@@ -605,7 +605,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
     if (!region.reservedTable() && region.needAccounting()) {
       region.calculateEntryOverhead(oldRe);
       LocalRegion.regionPath.set(region.getFullPath());
-      region.acquirePoolMemory(0, oldSize, forDelete, null, true);
+      region.acquirePoolMemory(0, oldRe.getValueSize(), oldRe.isForDelete(), null, true);
     }
 
     if(getLoggerI18n().fineEnabled()) {
@@ -746,7 +746,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   }
 
   class OldEntriesCleanerThread implements Runnable {
-    // Keep each entry alive for atleast 5 mins.
+    // Keep each entry alive for at least 15 secs.
     public void run() {
       try {
         if (!oldEntryMap.isEmpty()) {
@@ -771,7 +771,8 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
                         "OldEntriesCleanerThread : Removing the entry " + re + " entry update in progress : " +
                             re.isUpdateInProgress());
                   }
-                  oldEntriesQueue.remove(re);
+                  // continue if some explicit call removed the entry
+                  if (!oldEntriesQueue.remove(re)) continue;
                   if (GemFireCacheImpl.hasNewOffHeap()) {
                     // also remove reference to region buffer, if any
                     Object value = re._getValue();
@@ -781,8 +782,8 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
                   }
                   // free the allocated memory
                   if (!region.reservedTable() && region.needAccounting()) {
-                    int size = region.calculateRegionEntryValueSize(re);
-                    region.freePoolMemory(size, true);
+                    NonLocalRegionEntry nre = (NonLocalRegionEntry)re;
+                    region.freePoolMemory(nre.getValueSize(), nre.isForDelete());
                   }
                 }
               }
@@ -790,6 +791,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
           }
         }
 
+       synchronized (oldEntryMap) {
         for (Map<Object, BlockingQueue<RegionEntry>> regionEntryMap : oldEntryMap.values()) {
           for (Entry<Object, BlockingQueue<RegionEntry>> entry : regionEntryMap.entrySet()) {
             if (entry.getValue().size() == 0) {
@@ -801,6 +803,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
             }
           }
         }
+       }
       }
       catch (Exception e) {
         if (getLoggerI18n().warningEnabled()) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -746,7 +746,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   }
 
   class OldEntriesCleanerThread implements Runnable {
-    // Keep each entry alive for at least 15 secs.
+    // Keep each entry alive for at least 20 secs.
     public void run() {
       try {
         if (!oldEntryMap.isEmpty()) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
@@ -377,7 +377,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     //throw new UnsupportedOperationException(LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY.toLocalizedString());
   }
 
-  public void setOwner(LocalRegion owner) {
+  public void setOwner(LocalRegion owner, Object previousOwner) {
     throw new UnsupportedOperationException(LocalizedStrings
         .PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
@@ -54,6 +54,8 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
   protected Object value;
   private VersionTag<?> versionTag;
   private boolean updateInProgress = false;
+  private transient int valueSize;
+  private transient boolean forDelete;
 
   /**
    * Create one of these in the local case so that we have a snapshot of the
@@ -142,6 +144,22 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     this.isRemoved = Token.isRemoved(value);
     // TODO need to get version information from transaction entries
     this.versionTag = versionTag;
+  }
+
+  public void setValueSize(int size) {
+    this.valueSize = size;
+  }
+
+  public int getValueSize() {
+    return this.valueSize;
+  }
+
+  public void setForDelete() {
+    this.forDelete = true;
+  }
+
+  public boolean isForDelete() {
+    return this.forDelete;
   }
 
   @Override
@@ -343,7 +361,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     throw new UnsupportedOperationException(LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY.toLocalizedString());
   }
 
-  public void removePhase2()
+  public void removePhase2(LocalRegion r)
   {
     throw new UnsupportedOperationException(
         "Not appropriate for PartitionedRegion.NonLocalRegionEntry");
@@ -696,7 +714,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
   }
 
   @Override
-  public void setValueToNull() {
+  public void setValueToNull(RegionEntryContext context) {
     throw new UnsupportedOperationException(LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY.toLocalizedString());
   }
   

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
@@ -8386,7 +8386,7 @@ public final class Oplog implements CompactableOplog {
     public Object prepareValueForCache(RegionEntryContext r, Object val, boolean isEntryUpdate,
         boolean valHasMetadataForGfxdOffHeapUpdate)
     { throw new IllegalStateException("Should never be called");  }
-    public void _removePhase1() {throw new IllegalStateException();}
+    public void _removePhase1(LocalRegion r) {throw new IllegalStateException();}
     public DiskId getDiskId() {throw new IllegalStateException();}
     public long getLastModified() {throw new IllegalStateException();}
     public boolean isRecovered() {throw new IllegalStateException();}
@@ -8510,7 +8510,7 @@ public final class Oplog implements CompactableOplog {
       // TODO Auto-generated method stub
     }
     @Override
-    public void removePhase2() {
+    public void removePhase2(LocalRegion r) {
       // TODO Auto-generated method stub
     }
     @Override
@@ -8666,7 +8666,7 @@ public final class Oplog implements CompactableOplog {
       return false;
     }
     @Override
-    public void setValueToNull() {
+    public void setValueToNull(RegionEntryContext context) {
       // TODO Auto-generated method stub
     }
     @Override

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
@@ -8399,7 +8399,7 @@ public final class Oplog implements CompactableOplog {
     public void setLastModified(long lastModifiedTime) { throw new IllegalStateException(); }
     public boolean isLockedForCreate() {throw new IllegalStateException();}
     public Object getRawKey() { throw new IllegalStateException(); }
-    public void setOwner(LocalRegion owner) { throw new IllegalStateException(); }
+    public void setOwner(LocalRegion owner, Object previousOwner) { throw new IllegalStateException(); }
     public Object getContainerInfo() { throw new IllegalStateException();
     }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyRegionMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyRegionMap.java
@@ -617,7 +617,7 @@ public final class ProxyRegionMap implements RegionMap {
       throw new UnsupportedOperationException(LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0.toLocalizedString(DataPolicy.EMPTY));
     }
 
-    public void setOwner(LocalRegion owner) {
+    public void setOwner(LocalRegion owner, Object previousOwner) {
       throw new UnsupportedOperationException(LocalizedStrings
           .ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyRegionMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyRegionMap.java
@@ -548,7 +548,7 @@ public final class ProxyRegionMap implements RegionMap {
       throw new UnsupportedOperationException(LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0.toLocalizedString(DataPolicy.EMPTY));
     }
 
-    public void removePhase2() {
+    public void removePhase2(LocalRegion r) {
       throw new UnsupportedOperationException(LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0.toLocalizedString(DataPolicy.EMPTY));
     }
 
@@ -837,7 +837,7 @@ public final class ProxyRegionMap implements RegionMap {
     }
 
     @Override
-    public void setValueToNull() {
+    public void setValueToNull(RegionEntryContext context) {
       throw new UnsupportedOperationException(LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0.toLocalizedString(DataPolicy.EMPTY));
     }
     

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RegionEntry.java
@@ -278,7 +278,7 @@ public interface RegionEntry extends ExclusiveSharedLockObject {
   /**
    * Set the owner for this RegionEntry. Used only by GemFireXD.
    */
-  public void setOwner(LocalRegion owner);
+  public void setOwner(LocalRegion owner, Object previousOwner);
 
   /**
    * Obtain and return the value of this entry using {@link #_getValue()}.

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RegionEntry.java
@@ -193,7 +193,8 @@ public interface RegionEntry extends ExclusiveSharedLockObject {
    * Mark this entry as having been removed from the map that contained it
    * by setting its value to Token.REMOVED_PHASE2
    */
-  public void removePhase2();
+  public void removePhase2(LocalRegion r);
+
   /**
    * Returns true if this entry does not exist.  This is true if removal
    * has started (value == Token.REMOVED_PHASE1) or has completed
@@ -546,7 +547,7 @@ public interface RegionEntry extends ExclusiveSharedLockObject {
   /**
    * Sets the entry value to null.
    */
-  public void setValueToNull();
+  public void setValueToNull(RegionEntryContext context);
 
   public void returnToPool();
   

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RegionEntryContext.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RegionEntryContext.java
@@ -44,4 +44,8 @@ public interface RegionEntryContext extends HasCachePerfStats {
    * Returns true if this region is persistent.
    */
   public boolean isBackup();
+
+  default void updateMemoryStats(Object oldValue, Object newValue) {
+    // only used by BucketRegion as of now
+  }
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ValidatingDiskRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ValidatingDiskRegion.java
@@ -195,7 +195,7 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
       throw new IllegalStateException("Should never be called");
     }
 
-    public void _removePhase1() {
+    public void _removePhase1(LocalRegion r) {
       throw new IllegalStateException("should never be called");
     }
 
@@ -311,7 +311,7 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
       // TODO Auto-generated method stub
     }
     @Override
-    public void removePhase2() {
+    public void removePhase2(LocalRegion r) {
       // TODO Auto-generated method stub
     }
     @Override
@@ -466,7 +466,7 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
       return false;
     }
     @Override
-    public void setValueToNull() {
+    public void setValueToNull(RegionEntryContext context) {
       // TODO Auto-generated method stub
     }
     @Override

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ValidatingDiskRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ValidatingDiskRegion.java
@@ -551,7 +551,7 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
      * {@inheritDoc}
      */
     @Override
-    public void setOwner(LocalRegion owner) {
+    public void setOwner(LocalRegion owner, Object previousOwner) {
       // TODO Auto-generated method stub
       
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/GfxdTXEntryState.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/GfxdTXEntryState.java
@@ -1252,7 +1252,7 @@ public final class GfxdTXEntryState extends TXEntryState implements
   }
 
   @Override
-  public void setOwner(LocalRegion owner) {
+  public void setOwner(LocalRegion owner, Object previousOwner) {
     throw new UnsupportedOperationException("unexpected invocation");
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/GfxdTXEntryState.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/entry/GfxdTXEntryState.java
@@ -1372,7 +1372,7 @@ public final class GfxdTXEntryState extends TXEntryState implements
   }
 
   @Override
-  public void removePhase2() {
+  public void removePhase2(LocalRegion r) {
     throw new UnsupportedOperationException("unexpected invocation");
   }
 
@@ -1626,7 +1626,7 @@ public final class GfxdTXEntryState extends TXEntryState implements
    * {@inheritDoc}
    */
   @Override
-  public void setValueToNull() {
+  public void setValueToNull(RegionEntryContext context) {
     throw new UnsupportedOperationException("unexpected invocation for "
         + toString());
   }


### PR DESCRIPTION
## Changes proposed in this pull request

- to make size tracking much more reliable, moved the size tracking to be inside
  RegionEntry._setValue
- extra argument of RegionEntryContext for tracking so signatures of callers changed likewise
- BucketRegion.updateMemoryStats method taking old+new value that is invoked from above;
  the previous entry point of updateBucket2Size is now commented out
- separate call to updateMemoryStats in AbstractRegionMap.copyRecoveredEntries since the
  RegionEntryContext changes here from place holder region to actual region
- always faultin old value for internal Delta like for public Delta; this avoids multiple reads
  of old value without faultin (by NonLocalRegionEntry creation and then by updateEntry)
- fixed accounting error in UMM where overhead was added in delete not in update (as
  required) but freePoolMemory was always reducing entry overhead; now storing the original
  calculated size as well as op=DELETE flag in NonLocalRegionEntry which are used in free
- allow explicit call to old map cleaner task, and make it thread-safe
- reduced old map cleaner time to 20s
- added buildPrefix to build.gradle so that store targets can be run independently

## Patch testing

precheckin and manual TPCH testing with large bulk deletes

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/856