### PR TITLE
SNAP-2037 spark functions don't work with dml statements

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
@@ -703,8 +703,12 @@ public class GenericStatement
 					    if (observer != null) {
 					      observer.testExecutionEngineDecision(qinfo, ExecutionEngine.SPARK, this.statementText);
 					    }
-					    return getPreparedStatementForSnappy(true, statementContext, lcc, false,
-					      checkCancellation, false);
+					    boolean isUpdateOrDelete = false;
+					    if (DML_TABLE_PATTERN.matcher(source).matches()) {
+					    	isUpdateOrDelete = true;
+							}
+							return getPreparedStatementForSnappy(true, statementContext, lcc, false,
+							  checkCancellation, isUpdateOrDelete);
 					  }
 					  throw ex;
 					}

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
@@ -706,7 +706,7 @@ public class GenericStatement
 					    boolean isUpdateOrDelete = false;
 					    if (DML_TABLE_PATTERN.matcher(source).matches()) {
 					    	isUpdateOrDelete = true;
-							}
+					    }
 							return getPreparedStatementForSnappy(true, statementContext, lcc, false,
 							  checkCancellation, isUpdateOrDelete);
 					  }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
@@ -699,14 +699,14 @@ public class GenericStatement
 						qt.bindStatement();
 					}
 					catch(StandardException | AssertFailure ex) {
-						if (routeQuery && !DML_TABLE_PATTERN.matcher(source).matches()) {
-                                                       if (observer != null) {
-                                                         observer.testExecutionEngineDecision(qinfo, ExecutionEngine.SPARK, this.statementText);
-                                                       }
-							return getPreparedStatementForSnappy(true, statementContext, lcc, false,
-                  checkCancellation, false);
-						}
-						throw ex;
+					  if (routeQuery) {
+					    if (observer != null) {
+					      observer.testExecutionEngineDecision(qinfo, ExecutionEngine.SPARK, this.statementText);
+					    }
+					    return getPreparedStatementForSnappy(true, statementContext, lcc, false,
+					      checkCancellation, false);
+					  }
+					  throw ex;
 					}
 
 					bindTime += getCurrentTimeMillis(lcc);


### PR DESCRIPTION
## Changes proposed in this pull request

After bind exception routing to lead node as it can come due to constructs being used which are known to gemfirexd. Like using spark_partition_id()

## Patch testing

Manual adding a unit test.

## ReleaseNotes changes

None.

## Other PRs 

No.