### PR TITLE
[SNAP-2034] separate callback for update/delete post-actions

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -732,6 +732,10 @@ public class BucketRegion extends DistributedRegion implements Bucket {
         if (success && checkForColumnBatchCreation()) {
           createAndInsertColumnBatch(false);
         }
+        if (success && partitionedRegion.isInternalColumnTable()) {
+          CallbackFactoryProvider.getStoreCallbacks()
+              .invokeColumnStorePutCallbacks(this, new EntryEventImpl[]{event});
+        }
       }
     }
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/partitioned/PutAllPRMessage.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/partitioned/PutAllPRMessage.java
@@ -62,7 +62,6 @@ import com.gemstone.gemfire.internal.cache.versions.VersionTag;
 import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import com.gemstone.gemfire.internal.shared.Version;
 import com.gemstone.gemfire.internal.snappy.CallbackFactoryProvider;
-import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
 import com.gemstone.gemfire.internal.snappy.UMMMemoryTracker;
 import com.gemstone.gnu.trove.THashMap;
 
@@ -411,6 +410,8 @@ public final class PutAllPRMessage extends PartitionMessageWithDirectReply {
     final InternalDataView view = (tx != null && tx.isSnapshot()) ? r.getSharedDataView() : r.getDataView(tx);
     boolean lockedForPrimary = false;
     UMMMemoryTracker memoryTracker = null;
+    // needed for column store callback
+    EntryEventImpl[] allEvents = null;
     try {
     
     if (!notificationOnly) {
@@ -506,11 +507,14 @@ public final class PutAllPRMessage extends PartitionMessageWithDirectReply {
           }
 
           if (CallbackFactoryProvider.getStoreCallbacks().isSnappyStore()
-                  && !r.isInternalRegion()){
+                  && !r.isInternalRegion()) {
             // Setting thread local buffer to 0 here.
             // UMM will provide an initial estimation based on the first row
             memoryTracker = new UMMMemoryTracker(
                 Thread.currentThread().getId(), putAllPRDataSize);
+            if (r.isInternalColumnTable()) {
+              allEvents = new EntryEventImpl[putAllPRDataSize];
+            }
           }
 
         /* The real work to be synchronized, it will take long time. We don't
@@ -556,6 +560,9 @@ public final class PutAllPRMessage extends PartitionMessageWithDirectReply {
                   didPut = view.putEntryOnRemote(ev, false, false, null,
                       false, cacheWrite, lastModified, true);
                   putAllPRData[i].setTailKey(ev.getTailKey());
+                }
+                if (didPut && allEvents != null) {
+                  allEvents[i] = ev;
                 }
                 if (didPut && logger.fineEnabled()) {
                   logger.fine("PutAllPRMessage.doLocalPutAll:putLocally success for " + ev);
@@ -681,9 +688,13 @@ public final class PutAllPRMessage extends PartitionMessageWithDirectReply {
         if (success && bucketRegion.checkForColumnBatchCreation()) {
           bucketRegion.createAndInsertColumnBatch(false);
         }
-          if (lockedForPrimary) {
-            bucketRegion.doUnlockForPrimary();
-          }
+        if (success && allEvents != null) {
+           CallbackFactoryProvider.getStoreCallbacks()
+               .invokeColumnStorePutCallbacks(bucketRegion, allEvents);
+        }
+        if (lockedForPrimary) {
+          bucketRegion.doUnlockForPrimary();
+        }
       }
     } else {
       for (int i=0; i<putAllPRDataSize; i++) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/partitioned/PutAllPRMessage.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/partitioned/PutAllPRMessage.java
@@ -410,7 +410,7 @@ public final class PutAllPRMessage extends PartitionMessageWithDirectReply {
     final InternalDataView view = (tx != null && tx.isSnapshot()) ? r.getSharedDataView() : r.getDataView(tx);
     boolean lockedForPrimary = false;
     UMMMemoryTracker memoryTracker = null;
-    // needed for column store callback
+    // needed for column store callbacks
     EntryEventImpl[] allEvents = null;
     try {
     

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.gemstone.gemfire.internal.cache.BucketRegion;
+import com.gemstone.gemfire.internal.cache.EntryEventImpl;
 import com.gemstone.gemfire.internal.snappy.memory.MemoryManagerStats;
 
 public abstract class CallbackFactoryProvider {
@@ -37,6 +38,11 @@ public abstract class CallbackFactoryProvider {
     public Set<Object> createColumnBatch(BucketRegion region, long batchID,
         int bucketID) {
       return null;
+    }
+
+    @Override
+    public void invokeColumnStorePutCallbacks(BucketRegion bucket,
+        EntryEventImpl[] events) {
     }
 
     @Override

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.gemstone.gemfire.internal.cache.BucketRegion;
+import com.gemstone.gemfire.internal.cache.EntryEventImpl;
 import com.gemstone.gemfire.internal.snappy.memory.MemoryManagerStats;
 
 public interface StoreCallbacks {
@@ -37,6 +38,8 @@ public interface StoreCallbacks {
 
   Set<Object> createColumnBatch(BucketRegion region, long batchID,
       int bucketID);
+
+  void invokeColumnStorePutCallbacks(BucketRegion bucket, EntryEventImpl[] events);
 
   List<String> getInternalTableSchemas();
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -771,11 +771,6 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
           uuidAdvisor.handshake();
         }
       }
-      // attach CacheListener for object table if required
-      CacheListener<?, ?> listener = getObjectStoreListener();
-      if (listener != null) {
-        this.region.addCacheListener(listener);
-      }
       this.iargs = null; // free the internal region arguments
     } catch (TimeoutException e) {
       throw StandardException.newException(
@@ -2030,10 +2025,6 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
       // before dropping the table, ensure that WAN queues, if any, are
       // drained completely         
       waitForGatewayQueuesToFlush();
-      CacheListener<?, ?> listener = getObjectStoreListener();
-      if (listener != null && !region.isDestroyed()) {
-        region.removeCacheListener(listener);
-      }
       // Do not distribute region destruction to other caches since the
       // distribution is already handled by GfxdDDLMessages.
       // [sumedh] Special treatment for partitioned region to skip the parent
@@ -5084,13 +5075,6 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
 
   public final RowEncoder getRowEncoder() {
     return this.encoder;
-  }
-
-  private CacheListener<?, ?> getObjectStoreListener() {
-    // doubling the encoder as CacheListener to avoid bloating grammar
-    // since this is internal to SnappyData in any case
-    return (this.encoder instanceof CacheListener<?, ?>)
-        ? (CacheListener<?, ?>)this.encoder : null;
   }
 
   private final boolean isCandidateForByteArrayStore() {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RowEncoder.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RowEncoder.java
@@ -18,6 +18,8 @@ package com.pivotal.gemfirexd.internal.engine.store;
 
 import java.util.Map;
 
+import com.gemstone.gemfire.internal.cache.BucketRegion;
+import com.gemstone.gemfire.internal.cache.EntryEventImpl;
 import com.gemstone.gemfire.internal.cache.RegionEntry;
 import com.pivotal.gemfirexd.internal.iapi.sql.execute.ExecRow;
 import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor;
@@ -48,6 +50,12 @@ public interface RowEncoder {
    * for a set of rows in a bulk/batch insert.
    */
   PreProcessRow getPreProcessorForRows(GemFireContainer container);
+
+  /**
+   * Any actions required after column store put operations which happen
+   * outside of entry/region locks (unlike a CacheListener)
+   */
+  void afterColumnStorePuts(BucketRegion bucket, EntryEventImpl[] events);
 
   /**
    * An interface to do some common pre-processing for bulk/batch inserts.

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RowEncoder.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RowEncoder.java
@@ -53,7 +53,7 @@ public interface RowEncoder {
 
   /**
    * Any actions required after column store put operations which happen
-   * outside of entry/region locks (unlike a CacheListener)
+   * outside of entry locks (unlike a CacheListener)
    */
   void afterColumnStorePuts(BucketRegion bucket, EntryEventImpl[] events);
 


### PR DESCRIPTION
## Changes proposed in this pull request

- CacheListener is occasionally causing trouble due to entry locks in BucketRegions
  when trying to put into the same region so removed its addition in GemFireContainer
- instead using a separate callback in StoreCallbacks that in turn invokes RowEncoder
  for post-put operations outside (like done for rollover createAndInsertColumnBatch)

## Patch testing

precheckin with store

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/858