### PR TITLE
SNAP-2041 Use unsafe api to skip locked entry for lru eviction

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RegionEvictorTask.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/RegionEvictorTask.java
@@ -99,7 +99,7 @@ public class RegionEvictorTask implements Callable<Object> {
             LocalRegion region = iter.next();
             try {
               bytesEvicted = ((AbstractLRURegionMap)region.entries)
-                  .centralizedLruUpdateCallback(false, false);
+                  .centralizedLruUpdateCallback(false, true);
               if (bytesEvicted == 0) {
                 iter.remove();
               }


### PR DESCRIPTION
## Changes proposed in this pull request

Skip the locked entry while trying to evict inline

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
