### PR TITLE
[SNAP-1960] correct setting of RUNNING status

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
@@ -747,7 +747,8 @@ public class CacheServerLauncher  {
   /**
    * Sets the status of the cache server to be {@link #RUNNING}.
    */
-  public void running(final InternalDistributedSystem system, boolean endWaiting) {
+  public void running(final InternalDistributedSystem system,
+      int stateIfWaiting) {
     Status stat = this.status;
     if (stat == null) {
       stat = this.status = createStatus(this.baseName, RUNNING, getProcessId());
@@ -755,9 +756,7 @@ public class CacheServerLauncher  {
     else {
       if (stat.state == WAITING) {
         stat.dsMsg = null;
-        if (endWaiting) {
-          stat.state = RUNNING;
-        }
+        stat.state = stateIfWaiting;
       } else {
         stat.state = RUNNING;
       }
@@ -912,7 +911,7 @@ public class CacheServerLauncher  {
 
     startAdditionalServices(cache, options, props);
 
-    this.running(system, false);
+    this.running(system, RUNNING);
 
     clearLogListener();
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -422,6 +422,15 @@ public final class FabricDatabase implements ModuleControl,
         this.memStore);
   }
 
+  private void notifyRunning() {
+    // notify FabricService
+    final FabricService service = FabricServiceManager
+        .currentFabricServiceInstance();
+    if (service instanceof FabricServiceImpl) {
+      ((FabricServiceImpl)service).notifyRunning();
+    }
+  }
+
   /**
    * Performs the initialization steps after creation of initial database,
    * including initialization of default disk stores in system tables, replay of
@@ -432,6 +441,7 @@ public final class FabricDatabase implements ModuleControl,
       com.pivotal.gemfirexd.internal.iapi.jdbc.EngineConnection conn,
       Properties bootProps) throws StandardException {
     if (this.memStore.initialDDLReplayDone()) {
+      notifyRunning();
       return;
     }
 
@@ -497,12 +507,7 @@ public final class FabricDatabase implements ModuleControl,
         }
       }
 
-      // notify FabricService
-      final FabricService service = FabricServiceManager
-          .currentFabricServiceInstance();
-      if (service != null) {
-        ((FabricServiceImpl)service).notifyRunning();
-      }
+      notifyRunning();
 
       // Execute any provided post SQL scripts last.
       final String postScriptsPath = bootProps

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -1286,20 +1286,6 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
       this.storeStats.init(this.gemFireCache.getDistributedSystem());
       this.indexPersistenceStats.init(this.gemFireCache.getDistributedSystem());
 
-      final FabricService service;
-      // get server or locator instance as appropriate
-      if (this.myKind.isLocator()) {
-        service = FabricServiceManager.getFabricLocatorInstance();
-      }
-      else if (this.myKind.isAgent()) {
-        service = FabricServiceManager.getFabricAgentInstance();
-      }
-      else {
-        service = FabricServiceManager.getFabricServerInstance();
-      }
-      assert service instanceof FabricServiceImpl;
-      ((FabricServiceImpl)service).notifyRunning();
-
       this.isShutdownAll = false;
 
       startExecutor();

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -1290,9 +1290,11 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
       // get server or locator instance as appropriate
       if (this.myKind.isLocator()) {
         service = FabricServiceManager.getFabricLocatorInstance();
-      } else if (this.myKind.isAgent()) {
+      }
+      else if (this.myKind.isAgent()) {
         service = FabricServiceManager.getFabricAgentInstance();
-      } else {
+      }
+      else {
         service = FabricServiceManager.getFabricServerInstance();
       }
       assert service instanceof FabricServiceImpl;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -1286,6 +1286,17 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
       this.storeStats.init(this.gemFireCache.getDistributedSystem());
       this.indexPersistenceStats.init(this.gemFireCache.getDistributedSystem());
 
+      final FabricService service;
+      // get server or locator instance as appropriate
+      if (this.myKind.isLocator()) {
+        service = FabricServiceManager.getFabricLocatorInstance();
+      } else if (this.myKind.isAgent()) {
+        service = FabricServiceManager.getFabricAgentInstance();
+      } else {
+        service = FabricServiceManager.getFabricServerInstance();
+      }
+      assert service instanceof FabricServiceImpl;
+
       this.isShutdownAll = false;
 
       startExecutor();

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
@@ -1385,7 +1385,7 @@ public final class RegionEntryUtils {
       // set the service status
       final FabricService service = FabricServiceManager
           .currentFabricServiceInstance();
-      if (service != null) {
+      if (service instanceof FabricServiceImpl) {
         ((FabricServiceImpl) service).notifyWaiting(regionPath,
             membersToWaitFor, missingBuckets, myId, message);
       }

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/BackwardCompatabilityDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/BackwardCompatabilityDUnit.java
@@ -487,6 +487,7 @@ public class BackwardCompatabilityDUnit extends BackwardCompatabilityTestBase {
                   + locatorDir);
           ProcessStart versionedLocator = startVersionedLocator(version,
               versionDir, locatorDir, false);
+          waitForProcesses(versionedLocator);
           int baseVersionLocatorPort = versionedLocator.port;
 
           getLogWriter().info("Starting earlier version servers");
@@ -496,7 +497,7 @@ public class BackwardCompatabilityDUnit extends BackwardCompatabilityTestBase {
           int clientPort1 = versionedServer1.port;
           ProcessStart versionedServer2 = startVersionedServer(version,
               versionDir, serverTwoDir, -1, baseVersionLocatorPort, false);
-          waitForProcesses(versionedLocator, versionedServer1, versionedServer2);
+          waitForProcesses(versionedServer1, versionedServer2);
 
           // Add data with the client for that version
           doWithVersionedClient(prevProduct, version, versionDir, clientPort1, "addDataForClient");
@@ -527,6 +528,8 @@ public class BackwardCompatabilityDUnit extends BackwardCompatabilityTestBase {
           // Current product is always GemFireXD
           product = PRODUCT_GEMFIREXD;
           ProcessStart currentLocator = startCurrentVersionLocator(locatorDir);
+          // wait for current locator to start
+          waitForProcesses(currentLocator);
           int currentVersionLocatorPort = currentLocator.port;
 
           ProcessStart currentServer1 = startCurrentVersionServer(serverOneDir,
@@ -534,7 +537,7 @@ public class BackwardCompatabilityDUnit extends BackwardCompatabilityTestBase {
           int clientPort = currentServer1.port;
           ProcessStart currentServer2 = startCurrentVersionServer(serverTwoDir,
               currentVersionLocatorPort);
-          waitForProcesses(currentLocator, currentServer1, currentServer2);
+          waitForProcesses(currentServer1, currentServer2);
 
           getLogWriter().info("Verifying data using current GEMFIREXD DRIVER and JDBC URL jdbc:gemfirexd://");
           Connection connection = this.getNetConnection("localhost", clientPort, new Properties());

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/BackwardCompatabilityTestBase.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/BackwardCompatabilityTestBase.java
@@ -170,17 +170,19 @@ public abstract class BackwardCompatabilityTestBase extends
       throws InterruptedException {
     for (ProcessStart procStart : procStarts) {
       final int exitValue = procStart.proc.waitFor();
+      String procType = procStart.isLocator ? "locator" : "server";
+      if (procStart.version != null) {
+        procType += (" version " + procStart.version);
+      }
+      else {
+        procType = "current version " + procType;
+      }
       if (exitValue != 0) {
-        String procType = procStart.isLocator ? "locator" : "server";
-        if (procStart.version != null) {
-          procType += (" version " + procStart.version);
-        }
-        else {
-          procType = "current version " + procType;
-        }
         throw new TestException("Unexpected exit value " + exitValue
             + " while starting " + procType + ". See logs in "
             + procStart.logFile + " and start file output.");
+      } else {
+        getLogWriter().info("Started " + procType);
       }
     }
   }


### PR DESCRIPTION
PR #182 for SNAP-1517 added an "endWaiting" flag which was false in normal launch sequence
and reset by "endNotifyWaiting" callback. This, however, caused SNAP-1893 because
"endNotify" would update only for the case when previous state was RUNNING. So PR #276
added another call to set launch status to RUNNING when internal server status is set so.

The above changes cause premature setting of RUNNING which happens at the end of
GemFireStore boot before even DDL replay is complete (which itself is another issue). Secondly
the launch sequence also starts up additional services like thrift server, so RUNNING should be
set only after that is complete and not just at the end of boot sequence. The original issue
SNAP-1517 could have been solved simply by setting RUNNING status for the normal launch
sequence when it is WAITING and without introducing any new calls, but this PR also
corrects the internal status and switches status correctly as required.

## Changes proposed in this pull request

- pass the status to set from WAITING to CacheServerLauncher.running instead of a boolean
- the full launch sequence will call this with RUNNING at the end while the callback
  of "endNotifyWaiting" will set it to the previous status (STARTING)

  So the launch status will change as: STARTING -> WAITING -> STARTING -> RUNNING,
  which is the correct way because once WAITING is done then GII etc can take a long time

- remove "notifyRunning" call from GemFireStore boot rather only at the end of
  DDL replay in FabricDatabase.postCreate to correct the internal state too

  The failure in BackwardCompatabilityDUnit was due to above two where client would try to
  connect to servers (during DDL replay) much before the thrift servers have started

- also corrected the BackwardCompatabilityDUnit test to wait for locator start before
  starting the servers rather than starting locator+servers in parallel (that cause
      occasional failure in servers due to locator unavailability)

## Patch testing

store precheckin; also manually checked the cases mentioned in SNAP-1517 and SNAP-1893

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/871