### PR TITLE
[SNAP-2068] cleanup open transactions and TXContexts

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/cache/CacheTransactionManager.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/cache/CacheTransactionManager.java
@@ -152,11 +152,6 @@ public interface CacheTransactionManager {
      * transaction data has departed. This is only relevant for transaction that
      * involve PartitionedRegions.
      * 
-     * @throws TransactionDataNotColocatedException if at commit time, the data
-     * involved in the transaction has moved away from the transaction hosting 
-     * node. This can only happen if rebalancing/recovery happens during a 
-     * transaction that involves a PartitionedRegion. 
-     *   
      * @throws TransactionInDoubtException when GemFire cannot tell which nodes
      * have applied the transaction and which have not. This only occurs if nodes
      * fail mid-commit, and only then in very rare circumstances.

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DMStats.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DMStats.java
@@ -190,6 +190,10 @@ public interface DMStats {
   
   public void incNumProcessingThreads(int threads);
 
+  public void incNumThriftProcessingThreads(int threads);
+
+  public void incThriftProcessingThreadStarts();
+
   public int getNumSerialThreads();
   
   public void incNumSerialThreads(int threads);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionStats.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionStats.java
@@ -59,6 +59,7 @@ public class DistributionStats implements DMStats {
   private final static int nodesId;
   private final static int overflowQueueSizeId;
   private final static int processingThreadsId;
+  private final static int thriftProcessingThreadsId;
   private final static int serialThreadsId;
   private final static int waitingThreadsId;
   private final static int highPriorityThreadsId;
@@ -227,6 +228,7 @@ public class DistributionStats implements DMStats {
   private static final int serialThreadStartsId;
   private static final int viewThreadStartsId;
   private static final int processingThreadStartsId;
+  private static final int thriftProcessingThreadStartsId;
   private static final int highPriorityThreadStartsId;
   private static final int waitingThreadStartsId;
   private static final int partitionedRegionThreadStartsId;
@@ -281,6 +283,7 @@ public class DistributionStats implements DMStats {
     final String serialQueueThrottleCountDesc = "The total number of times a thread was delayed in adding a ordered message to the serial queue.";
     final String serialThreadsDesc = "The number of threads currently processing serial/ordered messages.";
     final String processingThreadsDesc = "The number of threads currently processing normal messages.";
+    final String thriftProcessingThreadsDesc = "The number of threads currently processing thrift messages.";
     final String highPriorityThreadsDesc = "The number of threads currently processing high priority messages.";
     final String partitionedRegionThreadsDesc = "The number of threads currently processing partitioned region messages.";
     final String functionExecutionThreadsDesc = "The number of threads currently processing function execution messages.";
@@ -393,6 +396,7 @@ public class DistributionStats implements DMStats {
         f.createLongCounter("serialQueueThrottleTime", serialQueueThrottleTimeDesc, "nanoseconds", false),
         f.createIntGauge("serialThreads", serialThreadsDesc, "threads"),
         f.createIntGauge("processingThreads", processingThreadsDesc, "threads"),
+        f.createIntGauge("thriftProcessingThreads", thriftProcessingThreadsDesc, "threads"),
         f.createIntGauge("highPriorityThreads", highPriorityThreadsDesc, "threads"),
         f.createIntGauge("partitionedRegionThreads", partitionedRegionThreadsDesc, "threads"),
         f.createIntGauge("functionExecutionThreads", functionExecutionThreadsDesc, "threads"),
@@ -566,6 +570,7 @@ public class DistributionStats implements DMStats {
         f.createLongCounter("serialThreadStarts", "Total number of times a thread has been created for the serial message executor.", "starts", false),
         f.createLongCounter("viewThreadStarts", "Total number of times a thread has been created for the view message executor.", "starts", false),
         f.createLongCounter("processingThreadStarts", "Total number of times a thread has been created for the pool processing normal messages.", "starts", false),
+        f.createLongCounter("thriftProcessingThreadStarts", "Total number of times a thread has been created for the pool processing thrift messages.", "starts", false),
         f.createLongCounter("highPriorityThreadStarts", "Total number of times a thread has been created for the pool handling high priority messages.", "starts", false),
         f.createLongCounter("waitingThreadStarts", "Total number of times a thread has been created for the waiting pool.", "starts", false),
         f.createLongCounter("partitionedRegionThreadStarts", "Total number of times a thread has been created for the pool handling partitioned region messages.", "starts", false),
@@ -631,6 +636,7 @@ public class DistributionStats implements DMStats {
     serialQueueThrottleCountId = type.nameToId("serialQueueThrottleCount");
     serialThreadsId = type.nameToId("serialThreads");
     processingThreadsId = type.nameToId("processingThreads");
+    thriftProcessingThreadsId = type.nameToId("thriftProcessingThreads");
     highPriorityThreadsId = type.nameToId("highPriorityThreads");
     partitionedRegionThreadsId = type.nameToId("partitionedRegionThreads");
     functionExecutionThreadsId = type.nameToId("functionExecutionThreads");
@@ -774,6 +780,7 @@ public class DistributionStats implements DMStats {
     serialThreadStartsId = type.nameToId("serialThreadStarts");
     viewThreadStartsId = type.nameToId("viewThreadStarts");
     processingThreadStartsId = type.nameToId("processingThreadStarts");
+    thriftProcessingThreadStartsId = type.nameToId("thriftProcessingThreadStarts");
     highPriorityThreadStartsId = type.nameToId("highPriorityThreadStarts");
     waitingThreadStartsId = type.nameToId("waitingThreadStarts");
     partitionedRegionThreadStartsId = type.nameToId("partitionedRegionThreadStarts");
@@ -1128,6 +1135,10 @@ public class DistributionStats implements DMStats {
 
   public void incNumProcessingThreads(int threads) {
     this.stats.incInt(processingThreadsId, threads);
+  }
+
+  public void incNumThriftProcessingThreads(int threads) {
+    this.stats.incInt(thriftProcessingThreadsId, threads);
   }
 
   public int getNumSerialThreads() {
@@ -2021,6 +2032,9 @@ public class DistributionStats implements DMStats {
   }
   public void incProcessingThreadStarts() {
     stats.incLong(processingThreadStartsId, 1);
+  }
+  public void incThriftProcessingThreadStarts() {
+    stats.incLong(thriftProcessingThreadStartsId, 1);
   }
   public void incHighPriorityThreadStarts() {
     stats.incLong(highPriorityThreadStartsId, 1);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/LonerDistributionManager.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/LonerDistributionManager.java
@@ -362,6 +362,8 @@ public class LonerDistributionManager implements DM {
     public void incOverflowQueueSize(int messages) {}
     public int getNumProcessingThreads() {return 0;}
     public void incNumProcessingThreads(int threads) {}
+    public void incNumThriftProcessingThreads(int threads) {}
+    public void incThriftProcessingThreadStarts() {}
     public int getNumSerialThreads() {return 0;}
     public void incNumSerialThreads(int threads) {}
     public void incMessageChannelTime(long val) {}

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXManagerImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXManagerImpl.java
@@ -24,6 +24,7 @@ import com.gemstone.gemfire.internal.cache.locks.LockMode;
 import com.gemstone.gemfire.internal.cache.locks.LockingPolicy;
 import com.gemstone.gemfire.internal.cache.locks.NonReentrantReadWriteLock;
 import com.gemstone.gemfire.internal.cache.tier.sockets.Message;
+import com.gemstone.gemfire.internal.concurrent.ConcurrentTHashSet;
 import com.gemstone.gemfire.internal.concurrent.CustomEntryConcurrentHashMap;
 import com.gemstone.gemfire.internal.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 import com.gemstone.gemfire.internal.concurrent.MapCallback;
@@ -92,10 +93,6 @@ public final class TXManagerImpl implements CacheTransactionManager,
   private static final WeakHashMap<TXContext, Boolean> jtaContexts =
     new WeakHashMap<TXContext, Boolean>();
 
-  // This holds snapshot txState started by Gemfire layer.
-  public static ThreadLocal<TXStateInterface> snapshotTxState =
-      new ThreadLocal<TXStateInterface>();
-
   /**
    * Avoid doing the potentially expensive lock owner search in case of
    * conflicts by {@link #searchLockOwner}. Note that this is disabled by
@@ -130,6 +127,9 @@ public final class TXManagerImpl implements CacheTransactionManager,
   private boolean closed = false;
 
   private final CustomEntryConcurrentHashMap<TXId, TXStateProxy> hostedTXStates;
+
+  private static final ConcurrentTHashSet<TXContext> hostedTXContexts =
+      new ConcurrentTHashSet<>(16, 128);
 
   private final ConcurrentHashMap<TXId, TXStateInterface> suspendedTXs;
 
@@ -583,6 +583,8 @@ public final class TXManagerImpl implements CacheTransactionManager,
 
     private TXStateInterface txState;
 
+    private TXStateInterface snapshotTXState;
+
     // below field is volatile since ReplyProcessor for this will remove itself
     // from TXContext when its done
     private final AtomicReference<CommitResponse> pendingCommit =
@@ -618,11 +620,16 @@ public final class TXManagerImpl implements CacheTransactionManager,
     private static TXContext newContext() {
       final TXContext context = new TXContext();
       txContext.set(context);
+      hostedTXContexts.add(context);
       return context;
     }
 
     public final TXStateInterface getTXState() {
       return this.txState;
+    }
+
+    public final TXStateInterface getSnapshotTXState() {
+      return this.snapshotTXState;
     }
 
     public final TXId getTXId() {
@@ -639,11 +646,28 @@ public final class TXManagerImpl implements CacheTransactionManager,
       this.waitForPhase2Commit = false;
     }
 
+    public final void setSnapshotTXState(final TXStateInterface tx) {
+      this.snapshotTXState = tx;
+      this.commitRecipients = null;
+      this.waitForPhase2Commit = false;
+    }
+
     public final void clearTXState() {
       this.txState = null;
       this.commitRecipients = null;
       this.waitForPhase2Commit = false;
       this.msgUsesTXProxy = false;
+    }
+
+    public final void clearTXStateAll() {
+      clearTXState();
+      this.snapshotTXState = null;
+    }
+
+    /** clear the TXContext and remove from global list when thread closes */
+    public final void threadClose() {
+      clearTXStateAll();
+      hostedTXContexts.remove(this);
     }
 
     public final Transaction getJTA() {
@@ -802,7 +826,7 @@ public final class TXManagerImpl implements CacheTransactionManager,
     this.dm = cache.getDistributedSystem().getDistributionManager();
     this.cachePerfStats = cachePerfStats;
     this.logWriter = logWriter;
-    this.hostedTXStates = new CustomEntryConcurrentHashMap<TXId, TXStateProxy>(
+    this.hostedTXStates = new CustomEntryConcurrentHashMap<>(
         128, CustomEntryConcurrentHashMap.DEFAULT_LOAD_FACTOR,
         TXMAP_CONCURRENCY);
     this.suspendedTXs = new ConcurrentHashMap<TXId, TXStateInterface>();
@@ -973,7 +997,7 @@ public final class TXManagerImpl implements CacheTransactionManager,
     // For snapshot isolation, create tx state at the beginning
     if (txState.isSnapshot()) {
       txState.getTXStateForRead();
-      snapshotTxState.set(txState);
+      context.setSnapshotTXState(txState);
     }
 
     return txState;
@@ -1029,9 +1053,9 @@ public final class TXManagerImpl implements CacheTransactionManager,
    *
    */
   public void commit() throws TransactionException {
-    commit(getTXState(), null, FULL_COMMIT, null, false);
-    // set the txState set in the cache also to null
-    snapshotTxState.set(null);
+    final TXContext context = txContext.get();
+    final TXStateInterface tx = context != null ? context.getTXState() : null;
+    commit(tx, null, FULL_COMMIT, context, false);
   }
 
   public final TXManagerImpl.TXContext commit(
@@ -1083,6 +1107,13 @@ public final class TXManagerImpl implements CacheTransactionManager,
     // TODO: TX: how to account for time in phase one
     if (commitPhase != PHASE_ONE_COMMIT) {
       noteCommitSuccess(opStart, lifeTime, tx, isRemoteCommit);
+    }
+    if (ctx == null) {
+      ctx = currentTXContext();
+    }
+    if (ctx != null) {
+      // clear the snapshot TXState
+      ctx.setSnapshotTXState(null);
     }
     return ctx;
   }
@@ -1218,10 +1249,12 @@ public final class TXManagerImpl implements CacheTransactionManager,
 
     final long opStart = CachePerfStats.getStatTime();
     final long lifeTime = opStart - tx.getBeginTime();
-    clearTXState();
+    TXManagerImpl.TXContext context = TXManagerImpl.currentTXContext();
+    if (context != null) {
+      context.clearTXStateAll();
+    }
     tx.rollback(callbackArg);
     noteRollbackSuccess(opStart, lifeTime, tx, isRemoteRollback);
-    snapshotTxState.set(null);
   }
 
   final void noteRollbackSuccess(final long opStart, final long lifeTime,
@@ -1352,7 +1385,7 @@ public final class TXManagerImpl implements CacheTransactionManager,
 
   //See #50072
   public void release() {
-    TXState tx = null;
+    TXState tx;
     for (TXStateProxy proxy : getHostedTransactionsInProgress()) {
       if ((tx = proxy.getLocalTXState()) != null) {
         final TXRegionState[] txrs = tx.getTXRegionStatesSnap();
@@ -1368,7 +1401,18 @@ public final class TXManagerImpl implements CacheTransactionManager,
           }
         }
       }
+      if (!proxy.isClosed()) {
+        try {
+          proxy.rollback(null);
+        } catch (Throwable ignored) {
+        }
+      }
     }
+    // clear the hosted TXContexts too
+    for (TXContext context : hostedTXContexts) {
+      context.clearTXStateAll();
+    }
+    hostedTXContexts.clear();
   }
 
   public void close() {
@@ -1376,13 +1420,10 @@ public final class TXManagerImpl implements CacheTransactionManager,
       return;
     }
     this.closed = true;
-    {
-      TransactionListener[] listeners = getListeners();
-      for (int i = 0; i < listeners.length; i++) {
-        closeListener(listeners[i]);
-      }
+    TransactionListener[] listeners = getListeners();
+    for (TransactionListener listener : listeners) {
+      closeListener(listener);
     }
-
   }
 
   private void closeListener(TransactionListener tl) {
@@ -1487,7 +1528,8 @@ public final class TXManagerImpl implements CacheTransactionManager,
   }
 
   public static TXStateInterface getCurrentSnapshotTXState() {
-    return snapshotTxState.get();
+    final TXContext context = txContext.get();
+    return context != null ? context.getSnapshotTXState() : null;
   }
 
   public static TXId getCurrentTXId() {
@@ -1964,7 +2006,7 @@ public final class TXManagerImpl implements CacheTransactionManager,
     return this.hostedTXStates.containsKey(txId);
   }
 
-  public TXStateProxy getHostedTXState(TransactionId txId) {
+  public TXStateProxy getHostedTXState(TXId txId) {
     return this.hostedTXStates.get(txId);
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXManagerImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXManagerImpl.java
@@ -666,8 +666,23 @@ public final class TXManagerImpl implements CacheTransactionManager,
 
     /** clear the TXContext and remove from global list when thread closes */
     public final void threadClose() {
+      rollback(this.txState);
+      rollback(this.snapshotTXState);
       clearTXStateAll();
       hostedTXContexts.remove(this);
+    }
+
+    private void rollback(TXStateInterface tx) {
+      if (tx != null && !tx.isClosed()) {
+        // skip if cache is closing
+        GemFireCacheImpl cache = GemFireCacheImpl.getInstance();
+        if (cache != null && !cache.isClosing) {
+          try {
+            tx.rollback(null);
+          } catch (Throwable ignored) {
+          }
+        }
+      }
     }
 
     public final Transaction getJTA() {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
@@ -703,8 +703,14 @@ public final class TXState implements TXStateInterface {
     return changes;
   }
 
+  @Override
   public final boolean isInProgress() {
     return !this.state.isClosed();
+  }
+
+  @Override
+  public boolean isClosed() {
+    return this.state.isClosed();
   }
 
   public final boolean isCommitted() {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateInterface.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateInterface.java
@@ -98,6 +98,13 @@ public interface TXStateInterface extends InternalDataView {
    */
   public boolean isInProgress();
 
+  /**
+   * Only check if this TX (proxy or local) is closed.
+   * Differs from "isInProgress" in that this will not check for
+   * the state of inner TXState.
+   */
+  public boolean isClosed();
+
   public void commit(Object callbackArg) throws TransactionException;
 
   public void rollback(Object callbackArg);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/tcp/ConnectionTable.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/tcp/ConnectionTable.java
@@ -17,6 +17,7 @@
 package com.gemstone.gemfire.internal.tcp;
 
 import com.gemstone.gemfire.i18n.LogWriterI18n;
+import com.gemstone.gemfire.internal.cache.TXManagerImpl;
 import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import java.io.*;
 import java.lang.ref.Reference;
@@ -1299,6 +1300,11 @@ public final class ConnectionTable  {
   }
 
   public static void releaseThreadsSockets() {
+    // clear TXContext from global list
+    TXManagerImpl.TXContext context = TXManagerImpl.currentTXContext();
+    if (context != null) {
+      context.threadClose();
+    }
     ConnectionTable ct = (ConnectionTable) lastInstance.get();
     if (ct == null) {
       return;

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/concurrent/ConcurrentTHashSet.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/concurrent/ConcurrentTHashSet.java
@@ -67,6 +67,10 @@ public class ConcurrentTHashSet<T> extends THashParameters implements Set<T> {
         THash.DEFAULT_LOAD_FACTOR, null, null);
   }
 
+  public ConcurrentTHashSet(int concurrency, int initialCapacity) {
+    this(concurrency, initialCapacity, THash.DEFAULT_LOAD_FACTOR, null, null);
+  }
+
   public ConcurrentTHashSet(TObjectHashingStrategy strategy,
       HashingStats stats) {
     this(DEFAULT_CONCURRENCY, THash.DEFAULT_INITIAL_CAPACITY,

--- a/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/DRDAConnThread.java
+++ b/gemfirexd/core/src/drda/java/com/pivotal/gemfirexd/internal/impl/drda/DRDAConnThread.java
@@ -82,6 +82,7 @@ import com.gemstone.gemfire.internal.shared.ClientSharedData;
 import com.gemstone.gemfire.internal.shared.SystemProperties;
 import com.gemstone.gemfire.internal.shared.UnsupportedGFXDVersionException;
 import com.gemstone.gemfire.internal.shared.Version;
+import com.gemstone.gemfire.internal.tcp.ConnectionTable;
 import com.pivotal.gemfirexd.Attribute;
 import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.GemFireXDQueryObserver;
@@ -427,6 +428,7 @@ class DRDAConnThread extends Thread {
 				}
 			}
 		}
+		ConnectionTable.releaseThreadsSockets();
 		if (this.trace)
 			trace("Ending connection thread");
 		server.removeThread(this);
@@ -8990,9 +8992,7 @@ class DRDAConnThread extends Thread {
      * <p>
      * This method should behave like the corresponding method for
      * {@code ResultSet}, and changes made to one of these methods, must be
-     * reflected in the other method. See
-     * {@link #getObjectForWriteFdoca(java.sql.ResultSet, int, int)}
-     * for details.
+     * reflected in the other method.
      * </p>
      *
      * @param cs the callable statement to fetch the object from
@@ -9000,7 +9000,6 @@ class DRDAConnThread extends Thread {
      * @param drdaType the DRDA type of the object to fetch
      * @return an object with the value of the output parameter
      * @throws if a database error occurs while fetching the parameter value
-     * @see #getObjectForWriteFdoca(java.sql.ResultSet, int, int)
      */
     private Object getObjectForWriteFdoca(CallableStatement cs,
                                           int index, int drdaType)

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/heap/MemHeapScanController.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/heap/MemHeapScanController.java
@@ -563,7 +563,8 @@ public class MemHeapScanController implements MemScanController, RowCountable,
 
     if (snashotTxStarted) {
       // clear the txState so that other thread local is cleared.
-      TXManagerImpl.getOrCreateTXContext().clearTXState();
+      TXManagerImpl.TXContext context = TXManagerImpl.getOrCreateTXContext();
+      context.clearTXState();
       // gemfire tx shouldn't be cleared in case of row buffer scan
       if (!(this.getGemFireContainer().isRowBuffer() && (fc == null))) {
         if (GemFireXDUtils.TraceQuery) {
@@ -571,7 +572,7 @@ public class MemHeapScanController implements MemScanController, RowCountable,
               "MemHeapScanController::positionAtInitScan bucketSet: " + " lcc.isSkipConstraintChecks " + lcc.isSkipConstraintChecks() +
           " " + "Setting snapshotTxStae to NULL.");
         }
-        TXManagerImpl.snapshotTxState.set(null);
+        context.setSnapshotTXState(null);
         this.localSnapshotTXState = this.txState;
       }
       this.txState = null;

--- a/gemfirexd/core/src/main/java/io/snappydata/thrift/server/SnappyThriftServer.java
+++ b/gemfirexd/core/src/main/java/io/snappydata/thrift/server/SnappyThriftServer.java
@@ -42,12 +42,19 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
 
+import com.gemstone.gemfire.distributed.internal.DM;
+import com.gemstone.gemfire.internal.LogWriterImpl;
 import com.gemstone.gemfire.internal.SocketCreator;
+import com.gemstone.gemfire.internal.tcp.ConnectionTable;
 import com.gemstone.gnu.trove.TObjectProcedure;
 import com.pivotal.gemfirexd.NetworkInterface.ConnectionListener;
+import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.diag.SessionsVTI;
 import com.pivotal.gemfirexd.internal.engine.jdbc.GemFireXDRuntimeException;
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
@@ -69,17 +76,6 @@ import org.apache.thrift.transport.TTransportException;
  */
 public final class SnappyThriftServer {
 
-  private InetAddress thriftAddress;
-  private int thriftPort;
-
-  public InetAddress getThriftAddress() {
-    return thriftAddress;
-  }
-
-  public int getThriftPort() {
-    return thriftPort;
-  }
-
   private LocatorServiceImpl service;
   private TServer thriftServer;
   private ThreadPoolExecutor thriftExecutor;
@@ -92,9 +88,6 @@ public final class SnappyThriftServer {
       final boolean useSSL, final SocketParameters socketParams,
       final ConnectionListener listener) throws TTransportException {
 
-    this.thriftAddress = thriftAddress;
-    this.thriftPort = thriftPort;
-
     if (isServing()) {
       throw GemFireXDRuntimeException.newRuntimeException(
           "A thrift server is already running", null);
@@ -103,12 +96,12 @@ public final class SnappyThriftServer {
     final TServerTransport serverTransport;
     final InetSocketAddress bindAddress;
     final String hostAddress;
-    if (this.thriftAddress != null) {
-      bindAddress = new InetSocketAddress(this.thriftAddress, this.thriftPort);
+    if (thriftAddress != null) {
+      bindAddress = new InetSocketAddress(thriftAddress, thriftPort);
     } else {
       try {
         bindAddress = new InetSocketAddress(SocketCreator.getLocalHost(),
-            this.thriftPort);
+            thriftPort);
       } catch (UnknownHostException uhe) {
         throw new TTransportException(
             "Could not determine localhost for default bind address.", uhe);
@@ -123,17 +116,42 @@ public final class SnappyThriftServer {
     final TProcessor processor;
     if (isServer) {
       SnappyDataServiceImpl service = new SnappyDataServiceImpl(hostAddress,
-          this.thriftPort);
+          thriftPort);
       processor = new SnappyDataServiceImpl.Processor(service);
       this.service = service;
     } else {
       // only locator service on non-server VMs
       LocatorServiceImpl service = new LocatorServiceImpl(hostAddress,
-          this.thriftPort);
+          thriftPort);
       processor = new LocatorService.Processor<>(service);
       this.service = service;
     }
 
+    final LogWriterImpl.LoggingThreadGroup interruptibleGroup = LogWriterImpl
+        .createThreadGroup("SnappyThriftServer Threads", Misc.getI18NLogWriter());
+    interruptibleGroup.setInterruptible();
+    final ThreadFactory tf = new ThreadFactory() {
+      private final AtomicInteger threadNum = new AtomicInteger(0);
+
+      @Override
+      public Thread newThread(@Nonnull final Runnable command) {
+        final DM dm = Misc.getDistributedSystem().getDistributionManager();
+        dm.getStats().incThriftProcessingThreadStarts();
+        Runnable r = () -> {
+          dm.getStats().incNumThriftProcessingThreads(1);
+          try {
+            command.run();
+          } finally {
+            dm.getStats().incNumThriftProcessingThreads(-1);
+            ConnectionTable.releaseThreadsSockets();
+          }
+        };
+        Thread thread = new Thread(interruptibleGroup, r,
+            "ThriftProcessor-" + threadNum.incrementAndGet());
+        thread.setDaemon(true);
+        return thread;
+      }
+    };
     final int parallelism = Math.max(
         Runtime.getRuntime().availableProcessors(), 4);
     if (!ThriftUtils.isThriftSelectorServer()) {
@@ -148,7 +166,7 @@ public final class SnappyThriftServer {
         serverArgs.transportFactory(new TFramedTransport.Factory());
       }
       this.thriftExecutor = new ThreadPoolExecutor(parallelism * 2,
-          maxThreads, 30L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>());
+          maxThreads, 30L, TimeUnit.SECONDS, new SynchronousQueue<>(), tf);
       serverArgs.setExecutorService(this.thriftExecutor).setConnectionListener(
           listener);
 
@@ -170,10 +188,10 @@ public final class SnappyThriftServer {
       int executorThreads = Math.min(Math.max(64, numThreads * 2), maxThreads);
       int maxQueued = Math.min(Math.max(1024, numThreads * 16), maxThreads);
       this.thriftExecutor = new ThreadPoolExecutor(executorThreads, executorThreads,
-          60L, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(maxQueued));
+          60L, TimeUnit.SECONDS, new ArrayBlockingQueue<>(maxQueued), tf);
       this.thriftExecutor.allowCoreThreadTimeOut(true);
       this.thriftThreadPerConnExecutor = new ThreadPoolExecutor(1, numThreads,
-          30L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>());
+          30L, TimeUnit.SECONDS, new SynchronousQueue<>(), tf);
       serverArgs.setExecutorService(this.thriftExecutor);
       serverArgs.setThreadPerConnExecutor(this.thriftThreadPerConnExecutor);
       this.thriftServer = new SnappyThriftServerSelector(serverArgs);

--- a/gemfirexd/core/src/main/java/io/snappydata/thrift/server/SnappyThriftServer.java
+++ b/gemfirexd/core/src/main/java/io/snappydata/thrift/server/SnappyThriftServer.java
@@ -147,7 +147,7 @@ public final class SnappyThriftServer {
           }
         };
         Thread thread = new Thread(interruptibleGroup, r,
-            "ThriftProcessor-" + threadNum.incrementAndGet());
+            "ThriftProcessor-" + threadNum.getAndIncrement());
         thread.setDaemon(true);
         return thread;
       }

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/MVCCDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/MVCCDUnit.java
@@ -374,15 +374,14 @@ public class MVCCDUnit extends DistributedSQLTestBase {
       @Override
       public Object call() {
         try {
-
-          TXStateProxy txStateProxy = GemFireCacheImpl.getInstance().getCacheTransactionManager()
-              .getHostedTXState(txid1);
+          TXManagerImpl txManager = GemFireCacheImpl.getExisting()
+              .getCacheTransactionManager();
+          TXStateProxy txStateProxy = txManager.getHostedTXState(txid1);
           //To invoke this operation without tx we need to unmasquerade
-          TXManagerImpl.TXContext context=GemFireCacheImpl.getInstance()
-              .getCacheTransactionManager().masqueradeAs(txStateProxy);
+          TXManagerImpl.TXContext context = txManager.masqueradeAs(txStateProxy);
 
-          GemFireCacheImpl.getInstance().getCacheTransactionManager().unmasquerade(context, true);
-          TXManagerImpl.snapshotTxState.set(null);
+          txManager.unmasquerade(context, true);
+          context.setSnapshotTXState(null);
           Connection conn = TestUtil.getConnection();
           Statement stmt = conn.createStatement();
           for (int i = 0; i < 5; i++) {
@@ -504,15 +503,14 @@ public class MVCCDUnit extends DistributedSQLTestBase {
       @Override
       public Object call() {
         try {
-
-          TXStateProxy txStateProxy = GemFireCacheImpl.getInstance().getCacheTransactionManager()
-              .getHostedTXState(txid1);
+          TXManagerImpl txManager = GemFireCacheImpl.getExisting()
+              .getCacheTransactionManager();
+          TXStateProxy txStateProxy = txManager.getHostedTXState(txid1);
           //To invoke this operation without tx we need to unmasquerade
-          TXManagerImpl.TXContext context=GemFireCacheImpl.getInstance()
-              .getCacheTransactionManager().masqueradeAs(txStateProxy);
+          TXManagerImpl.TXContext context = txManager.masqueradeAs(txStateProxy);
 
-          GemFireCacheImpl.getInstance().getCacheTransactionManager().unmasquerade(context, true);
-          TXManagerImpl.snapshotTxState.set(null);
+          txManager.unmasquerade(context, true);
+          context.setSnapshotTXState(null);
           Connection conn = TestUtil.getConnection();
           Statement stmt = conn.createStatement();
           for (int i = 0; i < 5; i++) {
@@ -635,15 +633,14 @@ public class MVCCDUnit extends DistributedSQLTestBase {
       @Override
       public Object call() {
         try {
-
-          TXStateProxy txStateProxy = GemFireCacheImpl.getInstance().getCacheTransactionManager()
-              .getHostedTXState(txid1);
+          TXManagerImpl txManager = GemFireCacheImpl.getExisting()
+              .getCacheTransactionManager();
+          TXStateProxy txStateProxy = txManager.getHostedTXState(txid1);
           //To invoke this operation without tx we need to unmasquerade
-          TXManagerImpl.TXContext context=GemFireCacheImpl.getInstance()
-              .getCacheTransactionManager().masqueradeAs(txStateProxy);
+          TXManagerImpl.TXContext context = txManager.masqueradeAs(txStateProxy);
 
-          GemFireCacheImpl.getInstance().getCacheTransactionManager().unmasquerade(context, true);
-          TXManagerImpl.snapshotTxState.set(null);
+          txManager.unmasquerade(context, true);
+          context.setSnapshotTXState(null);
           Connection conn = TestUtil.getConnection();
           Statement stmt = conn.createStatement();
           for (int i = 0; i < 5; i++) {
@@ -789,15 +786,14 @@ public class MVCCDUnit extends DistributedSQLTestBase {
       @Override
       public Object call() {
         try {
-
-          TXStateProxy txStateProxy = GemFireCacheImpl.getInstance().getCacheTransactionManager()
-              .getHostedTXState(txid1);
+          TXManagerImpl txManager = GemFireCacheImpl.getExisting()
+              .getCacheTransactionManager();
+          TXStateProxy txStateProxy = txManager.getHostedTXState(txid1);
           //To invoke this operation without tx we need to unmasquerade
-          TXManagerImpl.TXContext context=GemFireCacheImpl.getInstance()
-              .getCacheTransactionManager().masqueradeAs(txStateProxy);
+          TXManagerImpl.TXContext context = txManager.masqueradeAs(txStateProxy);
 
-          GemFireCacheImpl.getInstance().getCacheTransactionManager().unmasquerade(context, true);
-          TXManagerImpl.snapshotTxState.set(null);
+          txManager.unmasquerade(context, true);
+          context.setSnapshotTXState(null);
           Connection conn = TestUtil.getConnection();
           Statement stmt = conn.createStatement();
           for (int i = 0; i < 5; i++) {
@@ -973,11 +969,11 @@ public class MVCCDUnit extends DistributedSQLTestBase {
       @Override
       public Object call() {
         try {
-          TXStateProxy txStateProxy = GemFireCacheImpl.getInstance().getCacheTransactionManager()
-              .getHostedTXState(txId);
-          TXManagerImpl.TXContext context = GemFireCacheImpl.getInstance()
-              .getCacheTransactionManager().masqueradeAs(txStateProxy);
-          TXManagerImpl.snapshotTxState.set(txStateProxy);
+          TXManagerImpl txManager = GemFireCacheImpl.getExisting()
+              .getCacheTransactionManager();
+          TXStateProxy txStateProxy = txManager.getHostedTXState(txId);
+          TXManagerImpl.TXContext context = txManager.masqueradeAs(txStateProxy);
+          context.setSnapshotTXState(txStateProxy);
 
           Connection conn = TestUtil.getConnection();
           conn.setTransactionIsolation(Connection.TRANSACTION_NONE);
@@ -990,9 +986,8 @@ public class MVCCDUnit extends DistributedSQLTestBase {
             numRows++;
           }
           assertEquals(expectedResults, numRows);
-          GemFireCacheImpl.getInstance()
-              .getCacheTransactionManager().unmasquerade(context, true);
-          TXManagerImpl.snapshotTxState.set(null);
+          txManager.unmasquerade(context, true);
+          context.setSnapshotTXState(null);
         } catch (Exception ex) {
           ex.printStackTrace();
           throw new RuntimeException(ex);

--- a/tests/core/src/main/java/com/gemstone/gemfire/internal/cache/RemoteTransactionDUnitTest.java
+++ b/tests/core/src/main/java/com/gemstone/gemfire/internal/cache/RemoteTransactionDUnitTest.java
@@ -3338,8 +3338,6 @@ public class RemoteTransactionDUnitTest extends CacheTestCase {
   }
 
   /**
-   * @param ds1
-   * @param pr
    * @return first key found on the given member
    */
   CustId getKeyOnMember(final DistributedMember owner,
@@ -3355,10 +3353,7 @@ public class RemoteTransactionDUnitTest extends CacheTestCase {
     }
     return retVal;
   }
-  /**
-   * @param i
-   * @return
-   */
+
   protected Set<Customer> getCustomerSet(int size) {
     Set<Customer> expectedSet = new HashSet<Customer>();
     for (int i=0; i<size; i++) {
@@ -4708,7 +4703,7 @@ protected static class ClientListener extends CacheListenerAdapter {
         return null;
       }
     });
-    final TransactionId txid = (TransactionId)accessor
+    final TXId txid = (TXId)accessor
         .invoke(new SerializableCallable() {
           @Override
           public Object call() throws Exception {


### PR DESCRIPTION
The issue noted in SNAP-2068 is due to open transactions and TXContexts left during
cache close in case the same threads get used subsequently. This can happen for
cache reconnects for Spark executor threads for example (in the test it happens for
RMI threads used by test for method executions).

## Changes proposed in this pull request

- track hosted TXContexts for cleanup in cache close so that subsequent reconnects,
  if any, do not end up using stale TXContexts
- also rollback any open hosted TXs on TXManagerImpl close (ignoring any failures)
- moved the separate snapshotTXState ThreadLocal inside TXContext to aid in cleanup
- changed code and test calls to use TXManagerImpl.getCurrentSnapshotTXState() and
  setSnapshotTXState() instead of direct ThreadLocal handle for above change
- added removal of TXContext from global list on thread close from
  ConnectionTable.releaseThreadsSockets() that is invoked by all GemFire thread pools
- added a ThreadFactory for SnappyThriftServer for above call which should be done for
  GemFire layer cleanup in any case; also added for legacy DRDAConnThread
- also added thread stats for thrift pool like done by other GemFire pools

## Patch testing

precheckin with store

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/872