### PR TITLE
[SNAP-2083] correct the metadata of getColumns

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/HiveTablesVTI.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/HiveTablesVTI.java
@@ -149,7 +149,7 @@ public class HiveTablesVTI extends GfxdVTITemplate
 
   private static final ResultColumnDescriptor[] columnInfo = {
       EmbedResultSetMetaData.getResultColumnDescriptor(SCHEMA,
-          Types.VARCHAR, false, 512),
+          Types.VARCHAR, false, 128),
       EmbedResultSetMetaData.getResultColumnDescriptor(TABLE,
           Types.VARCHAR, false, 512),
       EmbedResultSetMetaData.getResultColumnDescriptor(TYPE,

--- a/gemfirexd/prebuild/src/main/resources/com/pivotal/gemfirexd/internal/impl/jdbc/metadata.properties
+++ b/gemfirexd/prebuild/src/main/resources/com/pivotal/gemfirexd/internal/impl/jdbc/metadata.properties
@@ -191,7 +191,7 @@ UNION \
 \
 	SELECT DISTINCT CAST ('' AS VARCHAR(128)) AS TABLE_CAT, \
 		SCHEMANAME AS TABLE_SCHEM,  \
-		TABLENAME AS TABLE_NAME, \
+		CAST (TABLENAME AS VARCHAR(128)) AS TABLE_NAME, \
 		CAST ((TABLETYPE || ' TABLE') AS VARCHAR(16)) AS TABLE_TYPE, \
 		CAST ('' AS VARCHAR(128)) AS REMARKS, \
 		CAST (NULL AS VARCHAR(128)) AS TYPE_CAT, \
@@ -519,10 +519,10 @@ UNION \
 \
       SELECT CAST ('' AS VARCHAR(128)) AS TABLE_CAT, \
         SCHEMANAME AS TABLE_SCHEM, \
-        TABLENAME AS TABLE_NAME, \
-        COLUMNNAME AS COLUMN_NAME, \
+        CAST (TABLENAME AS VARCHAR(128)) AS TABLE_NAME, \
+        CAST (COLUMNNAME AS VARCHAR(128)) AS COLUMN_NAME, \
         TYPEID AS DATA_TYPE, \
-        TYPENAME AS TYPE_NAME, \
+        CAST (TYPENAME AS VARCHAR(128)) AS TYPE_NAME, \
         CASE WHEN (TYPEID IN (java.sql.Types::INTEGER, \
                          java.sql.Types::SMALLINT, \
                          java.sql.Types::TINYINT, \
@@ -547,7 +547,9 @@ UNION \
                 THEN 10 \
                 ELSE CAST (NULL AS INTEGER) END) END \
             AS NUM_PREC_RADIX, \
-        NULLABLE, \
+        CASE WHEN NULLABLE THEN \
+            java.sql.DatabaseMetaData::columnNullable ELSE \
+            java.sql.DatabaseMetaData::columnNoNulls END AS NULLABLE, \
         CAST ('' AS VARCHAR(128)) AS REMARKS, \
         CAST (NULL AS VARCHAR(254)) AS COLUMN_DEF, \
         CAST (NULL AS INT) AS SQL_DATA_TYPE, \


### PR DESCRIPTION
## Changes proposed in this pull request

- fix the metadata of getColumns by explicitly changing NULLABLE column to integer
  in UNION with HIVETABLES
- also modified the width of few other columns to match VARCHAR(128)
- added test for the same in JdbcApiTest

## Patch testing

store precheckin in progress

## ReleaseNotes changes

NA

## Other PRs 

NA