### PR TITLE
Fix for put into inside transactions for replicated table.

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXBatchMessage.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXBatchMessage.java
@@ -139,6 +139,8 @@ public final class TXBatchMessage extends TXMessage {
       final EntryEventImpl eventTemplate = EntryEventImpl.create(null,
           Operation.UPDATE, null, null, null, true, null);
       eventTemplate.setTXState(txState);
+      // apply as PUT DML so duplicate entry inserts etc. will go through fine
+      eventTemplate.setPutDML(true);
       Object entry;
       TXRegionState txrs;
       LocalRegion region, baseRegion;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXRegionState.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXRegionState.java
@@ -473,9 +473,7 @@ public final class TXRegionState extends ReentrantLock {
         Operation.UPDATE, null, null, null, true, null);
     eventTemplate.setTXState(tx);
     // apply as PUT DML so duplicate entry inserts etc. will go through fine
-    // [sumedh] this is a strange duplication of functionality to combine
-    // fetchFromHDFS with PUT DML -- should have separate flag
-    //eventTemplate.setFetchFromHDFS(false);
+    eventTemplate.setPutDML(true);
     final LocalRegion region = this.region;
     final LocalRegion baseRegion;
     if (region.isUsedForPartitionedRegionBucket()) {


### PR DESCRIPTION
## Changes proposed in this pull request

Wrong EntryExistsException was being thrown from the index manager code. Fixed it.

## Patch testing

Added a dunit test. Check the related PR. https://github.com/SnappyDataInc/snappydata/pull/890

## ReleaseNotes changes

None.

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/890