### PR TITLE
Fix threadId in logging with non-GFE logs

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/GFToSlf4jBridge.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/GFToSlf4jBridge.java
@@ -23,7 +23,6 @@ import com.gemstone.gemfire.GemFireIOException;
 import com.gemstone.gemfire.internal.shared.ClientSharedUtils;
 import com.gemstone.org.jgroups.util.StringId;
 import org.apache.log4j.Level;
-import org.apache.log4j.MDC;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +35,7 @@ public class GFToSlf4jBridge extends LogWriterImpl {
   private final String logFile;
   private final String logName;
   private int level;
-  private final AtomicReference<Logger> logRef = new AtomicReference<Logger>();
+  private final AtomicReference<Logger> logRef = new AtomicReference<>();
 
   public GFToSlf4jBridge(String logName, String logFile) {
     this(logName, logFile, INFO_LEVEL);
@@ -60,7 +59,6 @@ public class GFToSlf4jBridge extends LogWriterImpl {
   @Override
   public void put(int level, String msg, Throwable exception) {
     Logger log = getLogger();
-    MDC.put("tid", Long.toHexString(Thread.currentThread().getId()));
     switch (level) {
       case SEVERE_LEVEL:
       case ERROR_LEVEL:

--- a/gemfire-shared/src/main/java/io/snappydata/log4j/PatternLayout.java
+++ b/gemfire-shared/src/main/java/io/snappydata/log4j/PatternLayout.java
@@ -60,7 +60,8 @@ public class PatternLayout extends org.apache.log4j.PatternLayout {
     final sun.misc.Unsafe unsafe = UnsafeHolder.getUnsafe();
     String currentName = (String)unsafe.getObject(event, threadNameOffset);
     if (currentName == null ||
-        currentName.charAt(currentName.length() - 1) != '>') {
+        currentName.charAt(currentName.length() - 1) != '>' ||
+        !currentName.contains("<tid=0x")) {
       Thread currentThread = Thread.currentThread();
       String threadNameAndId = currentThread.getName() + "<tid=0x" +
           Long.toHexString(currentThread.getId()) + '>';

--- a/gemfire-shared/src/main/java/io/snappydata/log4j/PatternLayout.java
+++ b/gemfire-shared/src/main/java/io/snappydata/log4j/PatternLayout.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package io.snappydata.log4j;
+
+import java.lang.reflect.Field;
+
+import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder;
+import org.apache.log4j.spi.LoggingEvent;
+
+/**
+ * Custom layout to add thread ID to the thread name (%t) pattern.
+ * <p>
+ * Normally it is simpler to use this custom class as the layout for any
+ * appender but will not work correctly for async logging with AsyncAppender.
+ * In that case use {@link ThreadIdAppender} on top of AsyncAppender.
+ */
+public class PatternLayout extends org.apache.log4j.PatternLayout {
+
+  private static final long threadNameOffset;
+
+  static {
+    try {
+      Field f = LoggingEvent.class.getDeclaredField("threadName");
+      f.setAccessible(true);
+      threadNameOffset = UnsafeHolder.getUnsafe().objectFieldOffset(f);
+    } catch (NoSuchFieldException nse) {
+      throw new ExceptionInInitializerError(nse);
+    }
+  }
+
+  public PatternLayout() {
+    super();
+  }
+
+  public PatternLayout(String pattern) {
+    super(pattern);
+  }
+
+  @Override
+  public String format(LoggingEvent event) {
+    return super.format(addThreadIdToEvent(event));
+  }
+
+  static LoggingEvent addThreadIdToEvent(LoggingEvent event) {
+    Thread currentThread = Thread.currentThread();
+    String threadNameAndId = currentThread.getName() + "<tid=0x" +
+        Long.toHexString(currentThread.getId()) + '>';
+    UnsafeHolder.getUnsafe().putObject(event, PatternLayout.threadNameOffset,
+        threadNameAndId);
+    return event;
+  }
+}

--- a/gemfire-shared/src/main/java/io/snappydata/log4j/PatternLayout.java
+++ b/gemfire-shared/src/main/java/io/snappydata/log4j/PatternLayout.java
@@ -57,11 +57,15 @@ public class PatternLayout extends org.apache.log4j.PatternLayout {
   }
 
   static LoggingEvent addThreadIdToEvent(LoggingEvent event) {
-    Thread currentThread = Thread.currentThread();
-    String threadNameAndId = currentThread.getName() + "<tid=0x" +
-        Long.toHexString(currentThread.getId()) + '>';
-    UnsafeHolder.getUnsafe().putObject(event, PatternLayout.threadNameOffset,
-        threadNameAndId);
+    final sun.misc.Unsafe unsafe = UnsafeHolder.getUnsafe();
+    String currentName = (String)unsafe.getObject(event, threadNameOffset);
+    if (currentName == null ||
+        currentName.charAt(currentName.length() - 1) != '>') {
+      Thread currentThread = Thread.currentThread();
+      String threadNameAndId = currentThread.getName() + "<tid=0x" +
+          Long.toHexString(currentThread.getId()) + '>';
+      unsafe.putObject(event, threadNameOffset, threadNameAndId);
+    }
     return event;
   }
 }

--- a/gemfire-shared/src/main/java/io/snappydata/log4j/ThreadIdAppender.java
+++ b/gemfire-shared/src/main/java/io/snappydata/log4j/ThreadIdAppender.java
@@ -17,12 +17,7 @@
 
 package io.snappydata.log4j;
 
-import java.util.Enumeration;
-
-import org.apache.log4j.Appender;
 import org.apache.log4j.AppenderSkeleton;
-import org.apache.log4j.helpers.AppenderAttachableImpl;
-import org.apache.log4j.spi.AppenderAttachable;
 import org.apache.log4j.spi.LoggingEvent;
 
 /**
@@ -33,65 +28,11 @@ import org.apache.log4j.spi.LoggingEvent;
  * this appender needs to be attached on top of AsyncAppender to display
  * the thread ID in logs.
  */
-public class ThreadIdAppender extends AppenderSkeleton implements AppenderAttachable {
-
-  private final AppenderAttachableImpl appenders = new AppenderAttachableImpl();
+public class ThreadIdAppender extends AppenderSkeleton {
 
   @Override
   protected void append(LoggingEvent event) {
-    synchronized (appenders) {
-      appenders.appendLoopOnAppenders(PatternLayout.addThreadIdToEvent(event));
-    }
-  }
-
-  @Override
-  public void addAppender(final Appender newAppender) {
-    synchronized (appenders) {
-      appenders.addAppender(newAppender);
-    }
-  }
-
-  @Override
-  public Enumeration getAllAppenders() {
-    synchronized (appenders) {
-      return appenders.getAllAppenders();
-    }
-  }
-
-  @Override
-  public Appender getAppender(final String name) {
-    synchronized (appenders) {
-      return appenders.getAppender(name);
-    }
-  }
-
-
-  @Override
-  public boolean isAttached(final Appender appender) {
-    synchronized (appenders) {
-      return appenders.isAttached(appender);
-    }
-  }
-
-  @Override
-  public void removeAllAppenders() {
-    synchronized (appenders) {
-      appenders.removeAllAppenders();
-    }
-  }
-
-  @Override
-  public void removeAppender(final Appender appender) {
-    synchronized (appenders) {
-      appenders.removeAppender(appender);
-    }
-  }
-
-  @Override
-  public void removeAppender(final String name) {
-    synchronized (appenders) {
-      appenders.removeAppender(name);
-    }
+    PatternLayout.addThreadIdToEvent(event);
   }
 
   @Override
@@ -102,16 +43,5 @@ public class ThreadIdAppender extends AppenderSkeleton implements AppenderAttach
   @Override
   public void close() {
     closed = true;
-    synchronized (appenders) {
-      Enumeration<?> iter = appenders.getAllAppenders();
-      if (iter != null) {
-        while (iter.hasMoreElements()) {
-          Object next = iter.nextElement();
-          if (next instanceof Appender) {
-            ((Appender)next).close();
-          }
-        }
-      }
-    }
   }
 }

--- a/gemfire-shared/src/main/java/io/snappydata/log4j/ThreadIdAppender.java
+++ b/gemfire-shared/src/main/java/io/snappydata/log4j/ThreadIdAppender.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package io.snappydata.log4j;
+
+import java.util.Enumeration;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.helpers.AppenderAttachableImpl;
+import org.apache.log4j.spi.AppenderAttachable;
+import org.apache.log4j.spi.LoggingEvent;
+
+/**
+ * Custom appender to add thread ID to the thread name (%t) pattern.
+ * <p>
+ * Normally it is simpler to use the custom {@link PatternLayout} but that
+ * will not work correctly for async logging with AsyncAppender, in which case
+ * this appender needs to be attached on top of AsyncAppender to display
+ * the thread ID in logs.
+ */
+public class ThreadIdAppender extends AppenderSkeleton implements AppenderAttachable {
+
+  private final AppenderAttachableImpl appenders = new AppenderAttachableImpl();
+
+  @Override
+  protected void append(LoggingEvent event) {
+    synchronized (appenders) {
+      appenders.appendLoopOnAppenders(PatternLayout.addThreadIdToEvent(event));
+    }
+  }
+
+  @Override
+  public void addAppender(final Appender newAppender) {
+    synchronized (appenders) {
+      appenders.addAppender(newAppender);
+    }
+  }
+
+  @Override
+  public Enumeration getAllAppenders() {
+    synchronized (appenders) {
+      return appenders.getAllAppenders();
+    }
+  }
+
+  @Override
+  public Appender getAppender(final String name) {
+    synchronized (appenders) {
+      return appenders.getAppender(name);
+    }
+  }
+
+
+  @Override
+  public boolean isAttached(final Appender appender) {
+    synchronized (appenders) {
+      return appenders.isAttached(appender);
+    }
+  }
+
+  @Override
+  public void removeAllAppenders() {
+    synchronized (appenders) {
+      appenders.removeAllAppenders();
+    }
+  }
+
+  @Override
+  public void removeAppender(final Appender appender) {
+    synchronized (appenders) {
+      appenders.removeAppender(appender);
+    }
+  }
+
+  @Override
+  public void removeAppender(final String name) {
+    synchronized (appenders) {
+      appenders.removeAppender(name);
+    }
+  }
+
+  @Override
+  public boolean requiresLayout() {
+    return false;
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+    synchronized (appenders) {
+      Enumeration<?> iter = appenders.getAllAppenders();
+      if (iter != null) {
+        while (iter.hasMoreElements()) {
+          Object next = iter.nextElement();
+          if (next instanceof Appender) {
+            ((Appender)next).close();
+          }
+        }
+      }
+    }
+  }
+}

--- a/gemfire-shared/src/main/resources/store-log4j.properties
+++ b/gemfire-shared/src/main/resources/store-log4j.properties
@@ -23,14 +23,14 @@ log4j.appender.file.append=true
 log4j.appender.file.file=snappydata.log
 log4j.appender.file.MaxFileSize=1GB
 log4j.appender.file.MaxBackupIndex=10000
-log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS zzz} %t<tid=0x%X{tid}> %p %c{1}: %m%n
+log4j.appender.file.layout=io.snappydata.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS zzz} %t %p %c{1}: %m%n
 
 # Console appender
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.out
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS zzz} %t<tid=0x%X{tid}> %p %c{1}: %m%n
+log4j.appender.console.layout=io.snappydata.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS zzz} %t %p %c{1}: %m%n
 
 # Ignore messages below warning level from Jetty, because it's a bit verbose
 log4j.logger.org.spark-project.jetty=WARN


### PR DESCRIPTION
Currently the MDC mechanism used for adding threadID is thread-local set in
GFToSlf4jBridge so threads using Spark Logging/slf4j/log4j directly don't get
the threadID (appears as "Thread..<tid=>"). It is not feasible to expect all threads
to set MDC in all their log paths (which will be inefficient too since it will do
a threadLocal lookup/set in every such call) so need a cleaner mechanism.

## Changes proposed in this pull request

This changes to use a more general way of updating the PatternLayout
that updates the threadName in the LoggingEvent itself to append the
threadID in the above format. However, this will not work if user
has configured AsyncAppender which will run in a separate dedicated
thread so an alternative using ThreadIdAppender has also been provided
that needs to be applied before AsyncAppender which will update LoggingEvent.

The "%t" pattern will itself be like `threadName<tid=0x{threadId}>` where "{threadId}" the long threadID as hexadecimal. When not using AsyncAppender use layout as below:

```
log4j.rootCategory=INFO, file

log4j.appender.file=org.apache.log4j.RollingFileAppender
...
log4j.appender.file.layout=io.snappydata.log4j.PatternLayout
```

Or else use the additional appender before others:

```
log4j.rootCategory=INFO, threadId, file

log4j.appender.threadId=io.snappydata.log4j.ThreadIdAppender

log4j.appender.file=org.apache.log4j.RollingFileAppender
...
log4j.appender.file.layout=org.apache.log4j.PatternLayout
```

## Patch testing

manual using both the default of custom PatternLayout, ThreadIdAppender and both

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/893