### PR TITLE
[SNAP-2113] VTI to show DiskStoreIDs

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/DiskStoreIDs.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/DiskStoreIDs.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package com.pivotal.gemfirexd.internal.engine.diag;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Iterator;
+
+import com.gemstone.gemfire.internal.cache.DiskStoreImpl;
+import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
+import com.gemstone.gemfire.internal.cache.persistence.DiskStoreID;
+import com.pivotal.gemfirexd.internal.engine.GfxdVTITemplate;
+import com.pivotal.gemfirexd.internal.iapi.reference.Limits;
+import com.pivotal.gemfirexd.internal.iapi.sql.ResultColumnDescriptor;
+import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedResultSetMetaData;
+
+/**
+ * Display the {@link DiskStoreID}s with names and directories.
+ */
+public class DiskStoreIDs extends GfxdVTITemplate {
+
+  private Iterator<DiskStoreImpl> diskStores;
+
+  private DiskStoreImpl currentDiskStore;
+
+  @Override
+  public boolean next() throws SQLException {
+
+    if (this.diskStores == null) {
+      final GemFireCacheImpl cache = GemFireCacheImpl.getInstance();
+      if (cache != null && !cache.isClosed()) {
+        this.diskStores = cache.listDiskStoresIncludingRegionOwned()
+            .iterator();
+      }
+    }
+    if (this.diskStores != null && this.diskStores.hasNext()) {
+      this.currentDiskStore = this.diskStores.next();
+      this.wasNull = false;
+      return true;
+    } else {
+      this.currentDiskStore = null;
+      return false;
+    }
+  }
+
+  @Override
+  protected Object getObjectForColumn(int columnNumber) throws SQLException {
+    final ResultColumnDescriptor desc = columnInfo[columnNumber - 1];
+    final String columnName = desc.getName();
+    final String res;
+    if (MEMBERID.equals(columnName)) {
+      res = this.currentDiskStore.getCache().getMyId().getId();
+    } else if (NAME.equals(columnName)) {
+      res = this.currentDiskStore.getName();
+    } else if (ID.equals(columnName)) {
+      res = this.currentDiskStore.getDiskStoreUUID().toString();
+    } else if (DIRS.equals(columnName)) {
+      StringBuilder dirs = new StringBuilder();
+      for (File dir : this.currentDiskStore.getDiskDirs()) {
+        if (dirs.length() > 0) {
+          dirs.append(',');
+        }
+        String dirPath;
+        try {
+          dirPath = dir.getCanonicalPath();
+        } catch (IOException ioe) {
+          dirPath = dir.getAbsolutePath();
+        }
+        dirs.append(dirPath);
+      }
+      res = dirs.toString();
+    } else {
+      res = null;
+    }
+    return res;
+  }
+
+  @Override
+  public ResultSetMetaData getMetaData() throws SQLException {
+    return metadata;
+  }
+
+  /** Metadata */
+
+  public static final String MEMBERID = "MEMBERID";
+
+  public static final String NAME = "NAME";
+
+  public static final String ID = "ID";
+
+  public static final String DIRS = "DIRECTORIES";
+
+  private static final ResultColumnDescriptor[] columnInfo = {
+      EmbedResultSetMetaData.getResultColumnDescriptor(MEMBERID,
+          Types.VARCHAR, false, 128),
+      EmbedResultSetMetaData.getResultColumnDescriptor(NAME, Types.VARCHAR,
+          false, 128),
+      EmbedResultSetMetaData.getResultColumnDescriptor(ID, Types.CHAR, false,
+          36),
+      EmbedResultSetMetaData.getResultColumnDescriptor(DIRS, Types.VARCHAR,
+          false, Limits.DB2_VARCHAR_MAXWIDTH) };
+
+  private static final ResultSetMetaData metadata = new EmbedResultSetMetaData(
+      columnInfo);
+}

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/DiskStoreIDs.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/DiskStoreIDs.java
@@ -38,7 +38,6 @@ import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedResultSetMetaData;
 public class DiskStoreIDs extends GfxdVTITemplate {
 
   private Iterator<DiskStoreImpl> diskStores;
-
   private DiskStoreImpl currentDiskStore;
 
   @Override
@@ -47,8 +46,7 @@ public class DiskStoreIDs extends GfxdVTITemplate {
     if (this.diskStores == null) {
       final GemFireCacheImpl cache = GemFireCacheImpl.getInstance();
       if (cache != null && !cache.isClosed()) {
-        this.diskStores = cache.listDiskStoresIncludingRegionOwned()
-            .iterator();
+        this.diskStores = cache.listDiskStoresIncludingRegionOwned().iterator();
       }
     }
     if (this.diskStores != null && this.diskStores.hasNext()) {
@@ -106,14 +104,11 @@ public class DiskStoreIDs extends GfxdVTITemplate {
   public static final String DIRS = "DIRS";
 
   private static final ResultColumnDescriptor[] columnInfo = {
-      EmbedResultSetMetaData.getResultColumnDescriptor(MEMBERID,
-          Types.VARCHAR, false, 128),
-      EmbedResultSetMetaData.getResultColumnDescriptor(NAME, Types.VARCHAR,
-          false, 128),
+      EmbedResultSetMetaData.getResultColumnDescriptor(MEMBERID, Types.VARCHAR, false, 128),
+      EmbedResultSetMetaData.getResultColumnDescriptor(NAME, Types.VARCHAR, false, 128),
       EmbedResultSetMetaData.getResultColumnDescriptor(ID, Types.CHAR, false, 36),
       EmbedResultSetMetaData.getResultColumnDescriptor(DIRS, Types.VARCHAR,
           false, Limits.DB2_VARCHAR_MAXWIDTH) };
 
-  private static final ResultSetMetaData metadata = new EmbedResultSetMetaData(
-      columnInfo);
+  private static final ResultSetMetaData metadata = new EmbedResultSetMetaData(columnInfo);
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/DiskStoreIDs.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/DiskStoreIDs.java
@@ -101,11 +101,8 @@ public class DiskStoreIDs extends GfxdVTITemplate {
   /** Metadata */
 
   public static final String MEMBERID = "MEMBERID";
-
   public static final String NAME = "NAME";
-
   public static final String ID = "ID";
-
   public static final String DIRS = "DIRS";
 
   private static final ResultColumnDescriptor[] columnInfo = {
@@ -113,8 +110,7 @@ public class DiskStoreIDs extends GfxdVTITemplate {
           Types.VARCHAR, false, 128),
       EmbedResultSetMetaData.getResultColumnDescriptor(NAME, Types.VARCHAR,
           false, 128),
-      EmbedResultSetMetaData.getResultColumnDescriptor(ID, Types.CHAR, false,
-          36),
+      EmbedResultSetMetaData.getResultColumnDescriptor(ID, Types.CHAR, false, 36),
       EmbedResultSetMetaData.getResultColumnDescriptor(DIRS, Types.VARCHAR,
           false, Limits.DB2_VARCHAR_MAXWIDTH) };
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/DiskStoreIDs.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/DiskStoreIDs.java
@@ -106,7 +106,7 @@ public class DiskStoreIDs extends GfxdVTITemplate {
 
   public static final String ID = "ID";
 
-  public static final String DIRS = "DIRECTORIES";
+  public static final String DIRS = "DIRS";
 
   private static final ResultColumnDescriptor[] columnInfo = {
       EmbedResultSetMetaData.getResultColumnDescriptor(MEMBERID,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -14,6 +14,24 @@
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
+/*
+ * Changes for SnappyData distributed computational and data platform.
+ *
+ * Portions Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
 
 package com.pivotal.gemfirexd.internal.impl.sql.catalog;
 
@@ -43,6 +61,7 @@ import com.pivotal.gemfirexd.internal.engine.ddl.callbacks.CallbackProcedures;
 import com.pivotal.gemfirexd.internal.engine.ddl.catalog.GfxdSystemProcedures;
 import com.pivotal.gemfirexd.internal.engine.ddl.wan.WanProcedures;
 import com.pivotal.gemfirexd.internal.engine.diag.DiagProcedures;
+import com.pivotal.gemfirexd.internal.engine.diag.DiskStoreIDs;
 import com.pivotal.gemfirexd.internal.engine.diag.HdfsProcedures;
 import com.pivotal.gemfirexd.internal.engine.diag.HiveTablesVTI;
 import com.pivotal.gemfirexd.internal.engine.diag.JSONProcedures;
@@ -2090,6 +2109,8 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
 
   public static final String HIVETABLES_TABLENAME = "HIVETABLES";
 
+  public static final String DISKSTOREIDS_TABLENAME = "DISKSTOREIDS";
+
   private static final String[][] VTI_TABLE_CLASSES = {
       { DIAG_MEMBERS_TABLENAME,
           "com.pivotal.gemfirexd.internal.engine.diag.DistributedMembers" },
@@ -2110,6 +2131,7 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
       { SESSIONS_TABLENAME,
           "com.pivotal.gemfirexd.internal.engine.diag.SessionsVTI" },
       { HIVETABLES_TABLENAME, HiveTablesVTI.class.getName() },
+      { DISKSTOREIDS_TABLENAME, DiskStoreIDs.class.getName() },
   };
 
   private final HashMap<String, TableDescriptor> diagVTIMap =


### PR DESCRIPTION
Sample output:

```
snappy> select * from sys.diskstoreids;
MEMBERID                         |NAME                    |ID                                  |DIRS
----------------------------------------------------------------------------------------------------
192.168.1.137(27095)<v2>:45630   |GFXD-DEFAULT-DISKSTORE  |b042dfd9-3f48-4357-a5c8-04e0f36c3ebf|...
192.168.1.137(27095)<v2>:45630   |GFXD-DD-DISKSTORE       |3fc69a16-0531-4290-ab9b-141ae95c19fc|...
192.168.1.137(27269)<v3>:2472    |GFXD-DEFAULT-DISKSTORE  |0206fd8a-c4db-4d3d-9696-2d1c0826ed62|...
192.168.1.137(27269)<v3>:2472    |GFXD-DD-DISKSTORE       |65af3ef8-54ac-4b8f-b280-2190673855d8|...
192.168.1.137(26921)<v1>:35276   |GFXD-DD-DISKSTORE       |f28c1f95-eac1-443b-9278-1c7d0c396a80|...
192.168.1.137(26921)<v1>:35276   |GFXD-DEFAULT-DISKSTORE  |5bb7f76b-27d3-4431-830e-29f49ae61df4|...
localhost(26614)<v0>:6685        |GFXD-DEFAULT-DISKSTORE  |ce5a4953-d0a7-4713-a3a6-ba68f85d1351|...
localhost(26614)<v0>:6685        |GFXD-DD-DISKSTORE       |e8cff498-f408-4e71-8b52-9de07e77a7a7|...
192.168.1.137(27464)<v4>:65057   |GFXD-DEFAULT-DISKSTORE  |68ff3122-13cd-43cc-b1e4-7a64079cf50c|...

9 rows selected
snappy> create diskstore d4 ('D2');
snappy> select * from sys.diskstoreids;
MEMBERID                        |NAME                    |ID                                  |DIRS
---------------------------------------------------------------------------------------------------
192.168.1.137(27269)<v3>:2472   |GFXD-DEFAULT-DISKSTORE  |0206fd8a-c4db-4d3d-9696-2d1c0826ed62|...
192.168.1.137(27269)<v3>:2472   |D4                      |20fa202e-035a-4ab9-995d-5e6a2e514dba|...
192.168.1.137(27269)<v3>:2472   |GFXD-DD-DISKSTORE       |65af3ef8-54ac-4b8f-b280-2190673855d8|...
192.168.1.137(27095)<v2>:45630  |GFXD-DEFAULT-DISKSTORE  |b042dfd9-3f48-4357-a5c8-04e0f36c3ebf|...
192.168.1.137(27095)<v2>:45630  |D4                      |edb7a028-6730-4974-a465-63b2d5b20eda|...
192.168.1.137(27095)<v2>:45630  |GFXD-DD-DISKSTORE       |3fc69a16-0531-4290-ab9b-141ae95c19fc|...
localhost(26614)<v0>:6685       |GFXD-DEFAULT-DISKSTORE  |ce5a4953-d0a7-4713-a3a6-ba68f85d1351|...
localhost(26614)<v0>:6685       |GFXD-DD-DISKSTORE       |e8cff498-f408-4e71-8b52-9de07e77a7a7|...
192.168.1.137(26921)<v1>:35276  |GFXD-DD-DISKSTORE       |f28c1f95-eac1-443b-9278-1c7d0c396a80|...
192.168.1.137(26921)<v1>:35276  |D4                      |70770c4b-8e77-46fc-a9ea-91115c9e0cfb|...
192.168.1.137(26921)<v1>:35276  |GFXD-DEFAULT-DISKSTORE  |5bb7f76b-27d3-4431-830e-29f49ae61df4|...
192.168.1.137(27464)<v4>:65057  |GFXD-DEFAULT-DISKSTORE  |68ff3122-13cd-43cc-b1e4-7a64079cf50c|...
```

## Changes proposed in this pull request

Added a "DiskStoreIDs" VTI that shows all the diskstoreIds, names and directories on a member.

## Patch testing

Manual. Unit tests will be added later.

## ReleaseNotes changes

Document the new system table.

## Other PRs 

NA