### PR TITLE
[SNAP-2121] separate diskstore for metastore and delta regions

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
@@ -334,7 +334,15 @@ public interface GfxdConstants {
 
   /** Name of disk store used by global indexes */ 
   final String GFXD_GLOBALINDEX_DISKSTORE_NAME ="GFXD-GLOBALINDEX-DISKSTORE";
-  
+
+  /** Name of disk store used by snappydata's delta regions */
+  final String SNAPPY_DELTA_DISKSTORE_NAME ="SNAPPY-INTERNAL-DELTA";
+
+  /**
+   * default sub-directory to use for delta store
+   */
+  final String SNAPPY_DELTA_SUBDIR = "snappy-internal-delta";
+
   /** Name of meta-region used to store the max identity column value */ 
   final String IDENTITY_REGION_NAME ="__IDENTITYREGION2";
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
@@ -465,7 +465,7 @@ public interface GfxdConstants {
           Attribute.SYS_HDFS_ROOT_DIR,
           Attribute.TABLE_DEFAULT_PARTITIONED,
           com.pivotal.gemfirexd.internal.iapi.reference.Attribute.COLLATE,
-          com.pivotal.gemfirexd.internal.iapi.reference.Attribute.INTERNAL_CONNECTION,
+          Attribute.INTERNAL_CONNECTION,
           Attribute.COLLATION,
           Attribute.CREATE_ATTR,
           Attribute.DISABLE_STREAMING,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/DDLConflatable.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/DDLConflatable.java
@@ -144,6 +144,8 @@ public final class DDLConflatable extends GfxdDataSerializable implements
   private static final int F_IS_DROP_FK_CONSTRAINT = 0x04;
   private static final int F_IS_ADD_FK_CONSTRAINT = 0x08;
   private static final int F_DEFAULT_PERSISTENT = 0x10;
+  /** true if metastore should be stored in datadictionary */
+  private static final int F_METASTORE_IN_DD = 0x20;
 
   private String constraintName; 
   private Set<String> droppedFKConstraints = null;
@@ -157,7 +159,10 @@ public final class DDLConflatable extends GfxdDataSerializable implements
 
   public DDLConflatable(String sqlText, String defaultSchema,
       DDLConstantAction constantAction, Object additionalArgs,
-      DDLConflatable implicitSchema, long ddlId, boolean queueInitialized) {
+      DDLConflatable implicitSchema, long ddlId, boolean queueInitialized,
+      LanguageConnectionContext lcc) {
+    // by default newer versions always store metastore in datadictionary
+    this.additionalFlags = F_METASTORE_IN_DD;
     if (constantAction instanceof CreateTableConstantAction) {
       this.flags = GemFireXDUtils.set(this.flags, IS_CREATE_TABLE);
       this.colocatedWithTable = ((CreateTableConstantAction)constantAction)
@@ -172,7 +177,6 @@ public final class DDLConflatable extends GfxdDataSerializable implements
       this.additionalFlags = GemFireXDUtils.set(this.additionalFlags,
           F_HAS_IMPLICIT_SCHEMA);
     }
-    LanguageConnectionContext lcc = Misc.getLanguageConnectionContext();
     if (lcc != null && lcc.isDefaultPersistent()) {
       this.additionalFlags = GemFireXDUtils.set(this.additionalFlags,
           F_DEFAULT_PERSISTENT);
@@ -350,6 +354,10 @@ public final class DDLConflatable extends GfxdDataSerializable implements
   public final boolean defaultPersistent() {
     return GemFireXDUtils.isSet(this.additionalFlags,
         F_DEFAULT_PERSISTENT);
+  }
+
+  public final boolean persistMetaStoreInDataDictionary() {
+    return GemFireXDUtils.isSet(this.additionalFlags, F_METASTORE_IN_DD);
   }
 
   public final boolean isCreateIndex() {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLMessage.java
@@ -86,8 +86,7 @@ public final class GfxdDDLMessage extends GfxdMessage implements
     MessageWithReply {
 
   /**
-   * The arguments encapsulated in an {@link GfxdFunctionArgs} implementation
-   * for the DDL message including the DDL string and connection ID.
+   * The arguments for the DDL message including DDL string and connection ID.
    */
   DDLArgs args;
 
@@ -299,6 +298,8 @@ public final class GfxdDDLMessage extends GfxdMessage implements
         oldContext = lcc.getContextObject();
         lcc.setContextObject(ddl.getAdditionalArgs());
         lcc.setDefaultPersistent(ddl.defaultPersistent());
+        lcc.setPersistMetaStoreInDataDictionary(
+            ddl.persistMetaStoreInDataDictionary());
         lcc.setQueryRoutingFlag(false);
         // also the DDL ID
         tran.setDDLId(ddlId);
@@ -377,6 +378,7 @@ public final class GfxdDDLMessage extends GfxdMessage implements
     } finally {
       if (lcc != null) {
         lcc.setFlags(oldFlags);
+        lcc.setPersistMetaStoreInDataDictionary(true);
         lcc.setContextObject(oldContext);
       }
       if (!success) {
@@ -475,8 +477,7 @@ public final class GfxdDDLMessage extends GfxdMessage implements
   }
 
   /**
-   * Inner class to hold the arguments for the DDL statement as an
-   * {@link GfxdFunctionArgs} object.
+   * Inner class to hold the arguments for the DDL statement.
    * 
    * @author swale
    */

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLRegion.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLRegion.java
@@ -29,42 +29,20 @@ import java.util.regex.Pattern;
 
 import com.gemstone.gemfire.DataSerializer;
 import com.gemstone.gemfire.LogWriter;
-import com.gemstone.gemfire.cache.CacheListener;
-import com.gemstone.gemfire.cache.CacheWriterException;
-import com.gemstone.gemfire.cache.DataPolicy;
-import com.gemstone.gemfire.cache.DiskAccessException;
-import com.gemstone.gemfire.cache.DiskStoreFactory;
-import com.gemstone.gemfire.cache.EntryNotFoundException;
-import com.gemstone.gemfire.cache.EvictionAction;
-import com.gemstone.gemfire.cache.EvictionAttributes;
-import com.gemstone.gemfire.cache.Operation;
-import com.gemstone.gemfire.cache.Region;
-import com.gemstone.gemfire.cache.RegionAttributes;
-import com.gemstone.gemfire.cache.RegionExistsException;
-import com.gemstone.gemfire.cache.Scope;
-import com.gemstone.gemfire.cache.TimeoutException;
+import com.gemstone.gemfire.cache.*;
 import com.gemstone.gemfire.distributed.internal.DistributionManager;
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
-import com.gemstone.gemfire.internal.cache.CachePerfStats;
-import com.gemstone.gemfire.internal.cache.DiskStoreImpl;
-import com.gemstone.gemfire.internal.cache.DistributedRegion;
-import com.gemstone.gemfire.internal.cache.EntryEventImpl;
-import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
-import com.gemstone.gemfire.internal.cache.InitialImageFlowControl;
-import com.gemstone.gemfire.internal.cache.InternalRegionArguments;
-import com.gemstone.gemfire.internal.cache.LocalRegion;
-import com.gemstone.gemfire.internal.cache.Oplog;
-import com.gemstone.gemfire.internal.cache.RegionEntry;
+import com.gemstone.gemfire.internal.cache.*;
 import com.gemstone.gemfire.internal.cache.lru.Sizeable;
 import com.gemstone.gemfire.internal.cache.versions.RegionVersionVector;
 import com.gemstone.gemfire.internal.shared.Version;
 import com.gemstone.gnu.trove.TLongHashSet;
 import com.gemstone.gnu.trove.TObjectIntHashMap;
 import com.gemstone.gnu.trove.TObjectIntProcedure;
-import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
 import com.pivotal.gemfirexd.internal.engine.GfxdDataSerializable;
 import com.pivotal.gemfirexd.internal.engine.GfxdSerializable;
+import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.access.index.GfxdIndexManager;
 import com.pivotal.gemfirexd.internal.engine.ddl.GfxdDDLRegionQueue.QueueValue;
 import com.pivotal.gemfirexd.internal.engine.ddl.catalog.messages.GfxdSystemProcedureMessage;
@@ -131,23 +109,11 @@ public final class GfxdDDLRegion extends DistributedRegion {
     afact.setConcurrencyChecksEnabled(false);
 
     if (persistDD) {
-      if (persistentDir == null || persistentDir.length() == 0) {
-        persistentDir = "." + File.separatorChar
-            + GfxdConstants.DEFAULT_PERSISTENT_DD_SUBDIR;
-      }
-      else {
-        persistentDir += File.separatorChar
-            + GfxdConstants.DEFAULT_PERSISTENT_DD_SUBDIR;
-      }
       DiskStoreFactory dsf =  cache.createDiskStoreFactory();
       // Set disk directories
       File[] diskDirs = new File[1];
-      diskDirs[0] = new File(persistentDir);
-      if (!diskDirs[0].mkdirs() && !diskDirs[0].isDirectory()) {
-        throw new DiskAccessException("Could not create directory for "
-            + "persistence of system tables: " + diskDirs[0].getAbsolutePath(),
-            (Region<?, ?>)null);
-      }
+      diskDirs[0] = GemFireStore.createPersistentDir(persistentDir,
+          GfxdConstants.DEFAULT_PERSISTENT_DD_SUBDIR).toFile();
       dsf.setDiskDirs(diskDirs);
       if(DiskStoreFactory.DEFAULT_MAX_OPLOG_SIZE < 10) {
         dsf.setMaxOplogSize(DiskStoreFactory.DEFAULT_MAX_OPLOG_SIZE);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLRegion.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLRegion.java
@@ -123,8 +123,8 @@ public final class GfxdDDLRegion extends DistributedRegion {
       }
       // writes use fsync
       dsf.setSyncWrites(true);
-      DiskStoreImpl dsImpl = (DiskStoreImpl)dsf
-          .create(GfxdConstants.GFXD_DD_DISKSTORE_NAME);
+      DiskStoreImpl dsImpl = (DiskStoreImpl)GemFireStore.createDiskStore(dsf,
+          GfxdConstants.GFXD_DD_DISKSTORE_NAME, cache.getCancelCriterion());
       dsImpl.setUsedForInternalUse();
       afact.setDiskSynchronous(true);
       afact.setDiskStoreName(GfxdConstants.GFXD_DD_DISKSTORE_NAME);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLRegionQueue.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLRegionQueue.java
@@ -847,7 +847,7 @@ public final class GfxdDDLRegionQueue implements RegionQueue {
           if (!currentSchema.equals(newSchema)) {
             DDLConflatable schemaDDL = new DDLConflatable("SET SCHEMA "
                 + newSchema, newSchema, new CreateSchemaConstantAction(
-                newSchema, null), null, null, 0, true);
+                newSchema, null), null, null, 0, true, null);
             final QueueValue qValue = new QueueValue(0L, new RegionValue(
                 schemaDDL, 0L));
             iter.add(qValue);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -445,8 +445,7 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
             .getDiskStoreName();
         DiskStoreImpl store;
         if (diskStoreName != null && (store = Misc.getGemFireCache()
-            .findDiskStore(diskStoreName)) != null
-            && !store.isUsedForInternalUse()) {
+            .findDiskStore(diskStoreName)) != null) {
           store.writeIndexCreate(getUUID());
         }
       }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -1611,7 +1611,7 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
       } catch (DiskAccessException e) {
         final LogWriter logger = Misc.getGemFireCache().getLogger();
         logger.warning("unexpected exception in creating default "
-            + "disk store, retrying", e);
+            + "disk store " + name + ", retrying", e);
         if (dae == null) { // bug #48719 - retries may throw unclear exceptions
           dae = e;
         }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -39,6 +39,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1378,8 +1382,22 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
     }
   }
 
+  public static Path createPersistentDir(String baseDir, String dirPath) {
+    Path dir = Paths.get(generatePersistentDirName(baseDir, dirPath));
+    try {
+      return Files.createDirectories(dir).toRealPath(LinkOption.NOFOLLOW_LINKS);
+    } catch (IOException ioe) {
+      throw new DiskAccessException("Could not create directory for "
+          + "system disk store: " + dir.toString(), ioe);
+    }
+  }
+
   public String generatePersistentDirName(String dirPath) {
-    String baseDir = this.persistenceDir;
+    return generatePersistentDirName(this.persistenceDir, dirPath);
+  }
+
+  private static String generatePersistentDirName(String baseDir,
+      String dirPath) {
     if (baseDir == null) {
       baseDir = ".";
     }
@@ -1482,16 +1500,10 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
       if (this.persistingDD || this.persistenceDir != null || isLeadMember) {
         try {
           DiskStoreFactory dsf = this.gemFireCache.createDiskStoreFactory();
-          File file = new File(generatePersistentDirName(null))
-              .getAbsoluteFile();
+          Path dir = createPersistentDir(this.persistenceDir, null);
 
-          if (!file.mkdirs() && !file.isDirectory()) {
-            throw new DiskAccessException("Could not create directory for "
-                + " default disk store : " + file.getAbsolutePath(),
-                (Region<?, ?>)null);
-          }
-
-          if (!this.myKind.isStore()) {
+          final boolean isStore = this.myKind.isStore();
+          if (!isStore) {
             // use small oplog files for other VM types
             if (DiskStoreFactory.DEFAULT_MAX_OPLOG_SIZE < 10) {
               dsf.setMaxOplogSize(DiskStoreFactory.DEFAULT_MAX_OPLOG_SIZE);
@@ -1504,49 +1516,33 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
               }
             }
           }
-          dsf.setDiskDirs(new File[] { file });
-          // try a bit harder to go through in case of transient
-          // disk exceptions
-          DiskAccessException dae = null;
-          for (int tries = 1; tries <= 10; tries++) {
-            try {
-              this.gfxdDefaultDiskStore = (DiskStoreImpl)dsf
-                  .create(GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME);
-              dae = null;
-              break;
-            } catch (DiskAccessException e) {
-              final LogWriter logger = this.gemFireCache.getLogger();
-              logger.warning("unexpected exception in creating default "
-                  + "disk store, retrying", e);
-              if (dae == null) { // bug #48719 - retries may throw unclear exceptions
-                dae = e;
-              }
-              // retry after sleep
-              try {
-                Thread.sleep(100);
-              } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                getAdvisee().getCancelCriterion().checkCancelInProgress(ie);
-              }
-            }
-          }
-          if (dae != null) {
-            throw dae;
-          }
+          dsf.setDiskDirs(new File[] { dir.toFile() });
+          this.gfxdDefaultDiskStore = (DiskStoreImpl)createDiskStore(
+              dsf, GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME);
 
           // set the default disk store at GemFire layer
           GemFireCacheImpl.setDefaultDiskStoreName(
               GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME);
+
+          if (isStore) {
+            // create the SnappyData delta store
+            dir = createPersistentDir(this.persistenceDir,
+                GfxdConstants.SNAPPY_DELTA_SUBDIR);
+            dsf = this.gemFireCache.createDiskStoreFactory();
+            dsf.setMaxOplogSize(100); // 100M size for delta by default
+            dsf.setDiskDirs(new File[] { dir.toFile() });
+            createDiskStore(dsf, GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME);
+          }
+
         } catch (GemFireException e) {
           final LogWriter logger = this.gemFireCache.getLogger();
-          logger.warning("Unable to create default disk store.", e);
+          logger.warning("Unable to create default disk stores.", e);
           throw e;
         }
       }
     }
     this.ddlStmtQueue = new GfxdDDLRegionQueue(DDL_STMTS_REGION,
-        this.gemFireCache, this.persistingDD,
-        getBootProperty(Attribute.SYS_PERSISTENT_DIR), null);
+        this.gemFireCache, this.persistingDD, this.persistenceDir, null);
 
     if (this.isHadoopGfxdLonerMode) {
       hadoopGfxdLonerConfig.loadDDLQueueWithDDLsFromHDFS(this.ddlStmtQueue);
@@ -1601,6 +1597,32 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
             SQLState.LANG_UNEXPECTED_USER_EXCEPTION, e, e.toString());
       }
     }
+  }
+
+  private DiskStore createDiskStore(DiskStoreFactory dsf, String name)
+      throws DiskAccessException {
+    // try a bit harder to go through in case of transient disk exceptions
+    DiskAccessException dae = null;
+    for (int tries = 1; tries <= 10; tries++) {
+      try {
+        return dsf.create(name);
+      } catch (DiskAccessException e) {
+        final LogWriter logger = this.gemFireCache.getLogger();
+        logger.warning("unexpected exception in creating default "
+            + "disk store, retrying", e);
+        if (dae == null) { // bug #48719 - retries may throw unclear exceptions
+          dae = e;
+        }
+        // retry after sleep
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          getAdvisee().getCancelCriterion().checkCancelInProgress(ie);
+        }
+      }
+    }
+    throw dae;
   }
 
   private void renameDiskStoresIfAny() {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
@@ -737,8 +737,7 @@ public final class RegionEntryUtils {
 
     @Override
     public void waitForAsyncIndexRecovery(DiskStoreImpl dsi) {
-      // don't wait for DataDictionary
-      if (dsi.isUsedForInternalUse() || dsi.isOffline()) {
+      if (dsi.isOffline()) {
         return;
       }
       final GemFireStore memStore = Misc.getMemStoreBooting();
@@ -1670,19 +1669,12 @@ public final class RegionEntryUtils {
               pkrf.getNumColumns());
           final TIntArrayList varCols = new TIntArrayList(pkrf.getNumColumns());
           getFixedAndVarColumns(pkrf, fixedCols, varCols);
-          int[] fixedColumnPositions = null;
-          int[] varColumnPositions = null;
-          if (fixedCols.size() > 0) {
-            fixedColumnPositions = fixedCols.toNativeArray();
-          }
-          if (varCols.size() > 0) {
-            varColumnPositions = varCols.toNativeArray();
-          }
           int keyIndex, offset, width, offsetFromMap;
           int varOffset = 0;
-          if (fixedColumnPositions != null) {
-            for (int index = 0; index < fixedColumnPositions.length; ++index) {
-              keyIndex = fixedColumnPositions[index] - 1;
+          final int numFixedCols = fixedCols.size();
+          if (numFixedCols > 0) {
+            for (int index = 0; index < numFixedCols; ++index) {
+              keyIndex = fixedCols.getQuick(index) - 1;
               offsetFromMap = pkrf.positionMap[keyIndex];
               width = pkrf.getColumnDescriptor(keyIndex).fixedWidth;
               hash = ResolverUtils.addBytesToHash(key, offsetFromMap, width,
@@ -1690,12 +1682,12 @@ public final class RegionEntryUtils {
               varOffset += width;
             }
           }
-          if (varColumnPositions != null) {
+          final int numVarWidths = varCols.size();
+          if (numVarWidths > 0) {
             // next add the variable width columns to hash
-            final int numVarWidths = varColumnPositions.length;
             final int[] varOffsets = new int[numVarWidths];
             for (int index = 0; index < numVarWidths; ++index) {
-              keyIndex = varColumnPositions[index] - 1;
+              keyIndex = varCols.getQuick(index) - 1;
               offsetFromMap = pkrf.positionMap[keyIndex];
               assert offsetFromMap <= 0 : "unexpected offsetFromMap="
                   + offsetFromMap;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
@@ -1614,9 +1614,16 @@ public final class RegionEntryUtils {
         PartitionedRegion region) {
       GemFireContainer container = (GemFireContainer)region.getUserAttribute();
       if (container != null) {
-        return container.fetchHiveMetaData(false);
+        ExternalTableMetaData metaData = container.fetchHiveMetaData(false);
+        if (metaData == null) {
+          throw new IllegalStateException("Table for container " +
+              container.getQualifiedTableName() + " not found in hive metadata");
+        }
+        return metaData;
+      } else {
+        throw new IllegalStateException("Table for " + region.getFullPath() +
+            " not found in containers");
       }
-      return null;
     }
   };
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/sql/conn/LanguageConnectionContext.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/sql/conn/LanguageConnectionContext.java
@@ -1512,12 +1512,20 @@ public interface LanguageConnectionContext extends Context {
    boolean isSnappyInternalConnection();
 
 	/**
-	 * Query routing will be attempted only when this flag is true
-	 * @param routeQuery
+	 * If set then all tables created on this connection will be PERSISTENT
+	 * by default even if not specified in the DDL.
 	 */
 	void setDefaultPersistent(boolean b);
 
 	boolean isDefaultPersistent();
+
+	/**
+	 * If set then metastore tables created on this connection will be stored
+	 * in DataDictionary (default is true).
+	 */
+	void setPersistMetaStoreInDataDictionary(boolean b);
+
+	boolean isPersistMetaStoreInDataDictionary();
 // GemStone changes END
 
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/sql/dictionary/StatementTablePermission.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/sql/dictionary/StatementTablePermission.java
@@ -149,7 +149,7 @@ public class StatementTablePermission extends StatementPermission
 	} // end of check
 
 	protected boolean isSelectOnHiveMetastore(TableDescriptor td) throws StandardException {
-		return td.getSchemaName().equalsIgnoreCase(Misc.SNAPPY_HIVE_METASTORE) &&
+		return Misc.isSnappyHiveMetaTable(td.getSchemaName()) &&
 				this.privType == Authorizer.SELECT_PRIV;
 	}
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedStatement.java
@@ -2383,10 +2383,10 @@ public class EmbedStatement extends ConnectionChild
             if ((csca = ddlAction.getImplicitSchemaCreated()) != null) {
               long schemaDDLId = ddlQ.newUUID();
               schemaDDL = new DDLConflatable(csca.toString(), defaultSchema,
-                  csca, null, null, schemaDDLId, queueInitialized);
+                  csca, null, null, schemaDDLId, queueInitialized, lcc);
             }
             ddl = new DDLConflatable(this.SQLText, defaultSchema, ddlAction,
-                additionalArgs, schemaDDL, ddlId.longValue(), queueInitialized);
+                additionalArgs, schemaDDL, ddlId.longValue(), queueInitialized, lcc);
             if (distribute) {
               if (schemaDDL != null) {
                 SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_DDLREPLAY,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -4153,7 +4153,7 @@ public final class GenericLanguageConnectionContext
 
 	private static final int METASTORE_IN_DD = 0x20000;
 
-  private static final int FLAGS_DEFAULT = METASTORE_IN_DD;
+	private static final int FLAGS_DEFAULT = METASTORE_IN_DD;
 
   /** flags that cannot be changed via {@link #setFlags(int)} */
   private static final int FLAGS_IMMUTABLE = CONNECTION_REMOTE

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -4151,12 +4151,14 @@ public final class GenericLanguageConnectionContext
 
 	private static final int SNAPPY_INTERNAL_CONNECTION = 0x10000;
 
-  private static final int FLAGS_DEFAULT = 0x0;
+	private static final int METASTORE_IN_DD = 0x20000;
+
+  private static final int FLAGS_DEFAULT = METASTORE_IN_DD;
 
   /** flags that cannot be changed via {@link #setFlags(int)} */
   private static final int FLAGS_IMMUTABLE = CONNECTION_REMOTE
       | CONNECTION_REMOTE_DDL | SKIP_LOCKS | POS_DUP_FN
-      | ENABLE_STREAMING | SKIP_LISTENERS;
+      | ENABLE_STREAMING | SKIP_LISTENERS | METASTORE_IN_DD;
 
   private int gfxdFlags = FLAGS_DEFAULT;
 
@@ -5017,6 +5019,16 @@ public final class GenericLanguageConnectionContext
 	@Override
 	public boolean isDefaultPersistent() {
 		return GemFireXDUtils.isSet(this.gfxdFlags, DEFAULT_PERSISTENT);
+	}
+
+	@Override
+	public void setPersistMetaStoreInDataDictionary(boolean b) {
+		this.gfxdFlags = GemFireXDUtils.set(this.gfxdFlags, METASTORE_IN_DD, b);
+	}
+
+	@Override
+	public boolean isPersistMetaStoreInDataDictionary() {
+		return GemFireXDUtils.isSet(this.gfxdFlags, METASTORE_IN_DD);
 	}
 
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/DropDiskStoreConstantAction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/DropDiskStoreConstantAction.java
@@ -79,7 +79,8 @@ public class DropDiskStoreConstantAction extends DDLConstantAction {
     // Diskstore in region has NULL for name, but users may try to
     // drop diskstore names from catalog
     if (diskStoreName.equals(GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME)
-        || diskStoreName.equals(GfxdConstants.GFXD_DD_DISKSTORE_NAME)) {
+        || diskStoreName.equals(GfxdConstants.GFXD_DD_DISKSTORE_NAME)
+        || diskStoreName.equals(GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME)) {
       // 0A000 until more appropriate sqlstate
       throw StandardException.newException(SQLState.NOT_IMPLEMENTED,
           "Cannot DROP default diskstores");

--- a/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
+++ b/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
@@ -425,8 +425,8 @@ public class SQLParser
 	        lcc.isPersistMetaStoreInDataDictionary()) {
 	      afact.setDiskStoreName(GfxdConstants.GFXD_DD_DISKSTORE_NAME);
 	    } else {
-		    afact.setDiskStoreName(GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME);
-		  }
+	      afact.setDiskStoreName(GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME);
+	    }
 	  }
 
 	  if (repPartPersFlags[1] && repPartPersFlags[2]) {

--- a/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
+++ b/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
@@ -418,9 +418,15 @@ public class SQLParser
       }
 
 	  //////////////////////////////////////////////
-	  if (getLanguageConnectionContext().isDefaultPersistent() && !repPartPersFlags[2]) {
+	  final LanguageConnectionContext lcc = getLanguageConnectionContext();
+	  if (lcc.isDefaultPersistent() && !repPartPersFlags[2]) {
 	    repPartPersFlags[2] = true;
-		  afact.setDiskStoreName(GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME);
+	    if (Misc.isSnappyHiveMetaTable(lcc.getDefaultSchema().getSchemaName()) &&
+	        lcc.isPersistMetaStoreInDataDictionary()) {
+	      afact.setDiskStoreName(GfxdConstants.GFXD_DD_DISKSTORE_NAME);
+	    } else {
+		    afact.setDiskStoreName(GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME);
+		  }
 	  }
 
 	  if (repPartPersFlags[1] && repPartPersFlags[2]) {

--- a/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/iapi/reference/Attribute.java
+++ b/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/iapi/reference/Attribute.java
@@ -342,7 +342,6 @@ public interface Attribute {
   String COLLATE = "collate";
 
 // GemStone changes BEGIN
-  String INTERNAL_CONNECTION = "internal-connection";
   // all public client connection only properties are in
   // com.pivotal.gemfirexd.jdbc.ClientAttribute
   /*

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/DistributedSQLTestBase.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/DistributedSQLTestBase.java
@@ -1981,7 +1981,8 @@ public class DistributedSQLTestBase extends DistributedTestBase {
         else {
           for (DiskStoreImpl ds : cache.listDiskStores()) {
             if (!GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME.equals(ds.getName())
-                && !GfxdConstants.GFXD_DD_DISKSTORE_NAME.equals(ds.getName())) {
+                && !GfxdConstants.GFXD_DD_DISKSTORE_NAME.equals(ds.getName())
+                && !GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME.equals(ds.getName())) {
               requiresCleanup[2] = true;
               break;
             }
@@ -2092,9 +2093,9 @@ public class DistributedSQLTestBase extends DistributedTestBase {
                 hdfsStore.getName() + '"');
           }
           for (DiskStoreImpl ds : cache.listDiskStores()) {
-            if (!GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME.equals(ds
-                .getName()) && !GfxdConstants.GFXD_DD_DISKSTORE_NAME
-                .equals(ds.getName())) {
+            if (!GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME.equals(ds.getName())
+                && !GfxdConstants.GFXD_DD_DISKSTORE_NAME.equals(ds.getName())
+                && !GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME.equals(ds.getName())) {
               executeCleanup(stmt, "drop diskstore \"" + ds.getName() + '"');
             }
           }

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/BugsDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/BugsDUnit.java
@@ -4975,7 +4975,8 @@ public class BugsDUnit extends DistributedSQLTestBase {
       invokeInEveryVM(new SerializableRunnable() {
         @Override
         public void run() {
-          if (ServerGroupUtils.isDataStore()) {
+          if (GemFireCacheImpl.getInstance() != null &&
+              ServerGroupUtils.isDataStore()) {
             String regionPath = "/ODS/POSTAL_ADDRESS";
             Region r = Misc.getRegionByPath(regionPath);
             PartitionedRegion pr = (PartitionedRegion)r;

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/CreateDiskStoreDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/CreateDiskStoreDUnit.java
@@ -681,13 +681,16 @@ public class CreateDiskStoreDUnit extends DistributedSQLTestBase {
       assertNull(memberMap.put(member, dirs));
       if (name.equals(GfxdConstants.GFXD_DD_DISKSTORE_NAME)) {
         assertTrue(dirs.endsWith("datadictionary"));
+      } else if (name.equals(GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME)) {
+        assertTrue(dirs.endsWith(GfxdConstants.SNAPPY_DELTA_SUBDIR));
       }
       assertTrue(memberDiskStoreIds.add(new GemFireXDUtils.Pair<>(member, id)));
     }
-    assertEquals(2 + extraStores.length, diskStores.size());
+    assertEquals(3 + extraStores.length, diskStores.size());
     assertTrue(diskStores.containsKey(GfxdConstants.GFXD_DD_DISKSTORE_NAME));
     assertTrue(
         diskStores.containsKey(GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME));
+    assertTrue(diskStores.containsKey(GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME));
     for (GemFireXDUtils.Pair<String, String> p : extraStores) {
       HashMap<String, String> memberMap = diskStores.get(p.getKey());
       assertNotNull(memberMap);

--- a/gemfirexd/tools/src/test/resources/lib/checkDiskStore.xml
+++ b/gemfirexd/tools/src/test/resources/lib/checkDiskStore.xml
@@ -19,6 +19,9 @@
 		<row>
 			<field name="NAME">GFXD-DD-DISKSTORE</field>
 		</row>
+		<row>
+			<field name="NAME">SNAPPY-INTERNAL-DELTA</field>
+		</row>
 	</resultSet>
 	<resultSet id="ddl-dist3">
 		<row>
@@ -37,6 +40,9 @@
 		</row>
 		<row>
 			<field name="NAME">GFXD-DD-DISKSTORE</field>
+		</row>
+		<row>
+			<field name="NAME">SNAPPY-INTERNAL-DELTA</field>
 		</row>
 	</resultSet>
 	<resultSet id="ddl-dist5">


### PR DESCRIPTION
Use separate diskstores for metastore and delta regions. Datadictionary one for former and
new one for latter. However, backward compatibility has to be also maintained so the diskstore
assignment is done by modifying the DDLs that get executed (latter from Snappy layer) so
when starting from existing cluster where these tables have already been created, it will
behave as before.

## Changes proposed in this pull request

- set the "datadictionary" to be the diskstore when the connection specifies default schema as the
  SNAPPY_HIVE_METASTORE which should only be done by the internal hive metastore client
- make all the regions using "datadictionary" as diskstore as persistent in DistributionDefinitionNode
  (in particular metastore regions will be persistent on locator now so backing up datadictionary
   will backup full metadata)
- added separate diskstore in "snappy-internal-delta" for delta regions
- make entry for it in SYSDISKSTORES (in FabricDatabase bootup)
- updated tests for the same

## Patch testing

precheckin

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/916