### PR TITLE
[SNAP-2127] use separate disk-stores for deltas per main disk-store

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/FunctionExecutionPooledExecutor.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/FunctionExecutionPooledExecutor.java
@@ -213,19 +213,19 @@ public class FunctionExecutionPooledExecutor extends ThreadPoolExecutor {
   public FunctionExecutionPooledExecutor(BlockingQueue<Runnable> q, int poolSize, PoolStatHelper stats, ThreadFactory tf) {
   /**
    * How long an idle thread will wait, in milliseconds, before it is removed
-   * from its thread pool. Default is (30000 * 60) ms (30 minutes).
+   * from its thread pool. Default is (2000 * 60) ms (2 minutes).
    * It is not static so it can be set at runtime and pick up different values.
    */
-    this(q, poolSize, stats, tf, Integer.getInteger("gemfire.IDLE_THREAD_TIMEOUT", 30000*60), false /* not for fn exec*/);
+    this(q, poolSize, stats, tf, Integer.getInteger("gemfire.IDLE_THREAD_TIMEOUT", 2000*60), false /* not for fn exec*/);
   }
   
   public FunctionExecutionPooledExecutor(BlockingQueue<Runnable> q, int poolSize, PoolStatHelper stats, ThreadFactory tf, boolean forFnExec) {
     /**
      * How long an idle thread will wait, in milliseconds, before it is removed
-     * from its thread pool. Default is (30000 * 60) ms (30 minutes).
+     * from its thread pool. Default is (2000 * 60) ms (2 minutes).
      * It is not static so it can be set at runtime and pick up different values.
      */
-      this(q, poolSize, stats, tf, Integer.getInteger("gemfire.IDLE_THREAD_TIMEOUT", 30000*60), forFnExec);
+      this(q, poolSize, stats, tf, Integer.getInteger("gemfire.IDLE_THREAD_TIMEOUT", 2000*60), forFnExec);
     }
   /**
    * Default timeout with no stats.

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/PooledExecutorWithDMStats.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/PooledExecutorWithDMStats.java
@@ -146,10 +146,10 @@ public class PooledExecutorWithDMStats extends ThreadPoolExecutor {
   public PooledExecutorWithDMStats(BlockingQueue<Runnable> q, int poolSize, PoolStatHelper stats, ThreadFactory tf) {
   /**
    * How long an idle thread will wait, in milliseconds, before it is removed
-   * from its thread pool. Default is (30000 * 60) ms (30 minutes).
+   * from its thread pool. Default is (2000 * 60) ms (2 minutes).
    * It is not static so it can be set at runtime and pick up different values.
    */
-    this(q, poolSize, stats, tf, Integer.getInteger("gemfire.IDLE_THREAD_TIMEOUT", 30000*60).intValue());
+    this(q, poolSize, stats, tf, Integer.getInteger("gemfire.IDLE_THREAD_TIMEOUT", 2000*60).intValue());
   }
 
   /**

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -247,8 +247,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
    * Maximum number of disk compaction and related tasks that can be scheduled.
    */
   public static final int MAX_CONCURRENT_DISK_COMPACTIONS = sysProps.getInteger(
-      "MAX_CONCURRENT_COMPACTIONS",
-      sysProps.getInteger("MAX_CONCURRENT_ROLLS", 4));
+      "MAX_CONCURRENT_COMPACTIONS", sysProps.getInteger("MAX_CONCURRENT_ROLLS", 4));
 
   /**
    * This system property indicates that maximum number of delayed disk write
@@ -554,8 +553,15 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
 
   private String vmIdRegionPath;
 
+  /**
+   * Thread pool used by all disk stores for disk compaction and related tasks.
+   */
   private final ThreadPoolExecutor diskStoreTaskPool;
 
+  /**
+   * Thread pool used by all disk stores for delayed disk write tasks
+   * that can be expensive like unpreblow oplogs, delete oplogs, etc.
+   */
   private final ThreadPoolExecutor diskDelayedWritePool;
 
   //TODO:Suranjan This has to be replcaed with better approach. guava cache or WeakHashMap.

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -185,15 +185,20 @@ import com.gemstone.gnu.trove.THashSet;
  */
 public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePerfStats, DistributionAdvisee {
 
+  public static final SystemProperties sysProps = SystemProperties
+      .getServerInstance();
+
   // moved *SERIAL_NUMBER stuff to DistributionAdvisor
 
   /** The default number of seconds to wait for a distributed lock */
-  public static final int DEFAULT_LOCK_TIMEOUT = Integer.getInteger("gemfire.Cache.defaultLockTimeout", 60).intValue();
+  public static final int DEFAULT_LOCK_TIMEOUT = sysProps.getInteger(
+      "Cache.defaultLockTimeout", 60);
 
   /**
    * The default duration (in seconds) of a lease on a distributed lock
    */
-  public static final int DEFAULT_LOCK_LEASE = Integer.getInteger("gemfire.Cache.defaultLockLease", 120).intValue();
+  public static final int DEFAULT_LOCK_LEASE = sysProps.getInteger(
+      "Cache.defaultLockLease", 120);
 
   /** The default "copy on read" attribute value */
   public static final boolean DEFAULT_COPY_ON_READ = false;
@@ -208,7 +213,8 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   /**
    * The default amount of time to wait for a <code>netSearch</code> to complete
    */
-  public static final int DEFAULT_SEARCH_TIMEOUT = Integer.getInteger("gemfire.Cache.defaultSearchTimeout", 300).intValue();
+  public static final int DEFAULT_SEARCH_TIMEOUT = sysProps.getInteger(
+      "Cache.defaultSearchTimeout", 300);
 
   /**
    * The <code>CacheLifecycleListener</code> s that have been registered in this VM
@@ -218,33 +224,53 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   /**
    * Define LocalRegion.ASYNC_EVENT_LISTENERS=true to invoke event listeners in the background
    */
-  public static final boolean ASYNC_EVENT_LISTENERS = Boolean.getBoolean("gemfire.Cache.ASYNC_EVENT_LISTENERS");
+  public static final boolean ASYNC_EVENT_LISTENERS = sysProps.getBoolean(
+      "Cache.ASYNC_EVENT_LISTENERS", false);
 
   /**
    * If true then when a delta is applied the size of the entry value will be recalculated. If false (the default) then
    * the size of the entry value is unchanged by a delta application. Not a final so that tests can change this value.
    */
-  public static boolean DELTAS_RECALCULATE_SIZE = Boolean.getBoolean("gemfire.DELTAS_RECALCULATE_SIZE");
+  public static boolean DELTAS_RECALCULATE_SIZE = sysProps.getBoolean(
+      "DELTAS_RECALCULATE_SIZE", false);
 
-  public static final int EVENT_QUEUE_LIMIT = Integer.getInteger("gemfire.Cache.EVENT_QUEUE_LIMIT", 4096).intValue();
+  public static final int EVENT_QUEUE_LIMIT = sysProps.getInteger(
+      "Cache.EVENT_QUEUE_LIMIT", 4096);
 
   /**
    * System property to limit the max query-execution time. By default its turned off (-1), the time is set in MiliSecs.
    */
-  public static final int MAX_QUERY_EXECUTION_TIME = Integer.getInteger("gemfire.Cache.MAX_QUERY_EXECUTION_TIME", -1).intValue();
+  public static final int MAX_QUERY_EXECUTION_TIME = sysProps.getInteger(
+      "Cache.MAX_QUERY_EXECUTION_TIME", -1);
+
+  /**
+   * Maximum number of disk compaction and related tasks that can be scheduled.
+   */
+  public static final int MAX_CONCURRENT_DISK_COMPACTIONS = sysProps.getInteger(
+      "MAX_CONCURRENT_COMPACTIONS",
+      sysProps.getInteger("MAX_CONCURRENT_ROLLS", 4));
+
+  /**
+   * This system property indicates that maximum number of delayed disk write
+   * tasks that can be pending before submitting the tasks start blocking.
+   * These tasks are things like unpreblow oplogs, delete oplogs, etc.
+   */
+  public static final int MAX_PENDING_DISK_TASKS = sysProps.getInteger(
+      "disk.MAX_PENDING_TASKS", 10);
 
   /**
    * System property to disable query monitor even if resource manager is in use
    */
-  public final boolean QUERY_MONITOR_DISABLED_FOR_LOW_MEM = Boolean.getBoolean("gemfire.Cache.DISABLE_QUERY_MONITOR_FOR_LOW_MEMORY");
+  public final boolean QUERY_MONITOR_DISABLED_FOR_LOW_MEM = sysProps.getBoolean(
+      "Cache.DISABLE_QUERY_MONITOR_FOR_LOW_MEMORY", false);
 
   /**
    * System property to disable default snapshot
    */
-  public boolean DEFAULT_SNAPSHOT_ENABLED = SystemProperties.getServerInstance().getBoolean(
+  public boolean DEFAULT_SNAPSHOT_ENABLED = sysProps.getBoolean(
       "cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION", false);
 
-  private final boolean DEFAULT_SNAPSHOT_ENABLED_TEST = SystemProperties.getServerInstance().getBoolean(
+  private final boolean DEFAULT_SNAPSHOT_ENABLED_TEST = sysProps.getBoolean(
       "cache.ENABLE_DEFAULT_SNAPSHOT_ISOLATION_TEST", false);
 
   /**
@@ -255,7 +281,8 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   /**
    * True if the user is allowed lock when memory resources appear to be overcommitted. 
    */
-  public static final boolean ALLOW_MEMORY_LOCK_WHEN_OVERCOMMITTED = Boolean.getBoolean("gemfire.Cache.ALLOW_MEMORY_OVERCOMMIT");
+  public static final boolean ALLOW_MEMORY_LOCK_WHEN_OVERCOMMITTED = sysProps.getBoolean(
+      "Cache.ALLOW_MEMORY_OVERCOMMIT", false);
 
   
   //time in ms
@@ -517,7 +544,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   protected static PropertyResolver resolver;
 
   protected static boolean xmlParameterizationEnabled =
-      !Boolean.getBoolean("gemfire.xml.parameterization.disabled");
+      !sysProps.getBoolean("xml.parameterization.disabled", false);
 
   /**
    * the memcachedServer instance that is started when {@link DistributionConfig#getMemcachedPort()}
@@ -526,6 +553,10 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   private GemFireMemcachedServer memcachedServer;
 
   private String vmIdRegionPath;
+
+  private final ThreadPoolExecutor diskStoreTaskPool;
+
+  private final ThreadPoolExecutor diskDelayedWritePool;
 
   //TODO:Suranjan This has to be replcaed with better approach. guava cache or WeakHashMap.
   private final Map<String, Map<Object, BlockingQueue<RegionEntry>
@@ -819,7 +850,8 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   /**
    * disables automatic eviction configuration for HDFS regions
    */
-  private final static Boolean DISABLE_AUTO_EVICTION = Boolean.getBoolean("gemfire.disableAutoEviction");
+  private final static Boolean DISABLE_AUTO_EVICTION = sysProps.getBoolean(
+      "disableAutoEviction", false);
 
   static {
     // this works around jdk bug 6427854, reported in ticket #44434
@@ -1037,6 +1069,24 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
 
       // clear any old TXState
       this.txMgr.clearTXState();
+
+      // create disk related thread pools
+      final ThreadGroup compactThreadGroup = LogWriterImpl.createThreadGroup(
+          "Oplog Compactor Thread Group", getLoggerI18n());
+      final ThreadFactory compactThreadFactory = GemfireCacheHelper.createThreadFactory(
+          compactThreadGroup, "Idle OplogCompactor");
+      this.diskStoreTaskPool = new ThreadPoolExecutor(
+          1, MAX_CONCURRENT_DISK_COMPACTIONS, 60, TimeUnit.SECONDS,
+          new LinkedBlockingQueue<>(), compactThreadFactory);
+
+      final ThreadGroup deleteThreadGroup = LogWriterImpl.createThreadGroup(
+          "Oplog Delete Thread Group", getLoggerI18n());
+      final ThreadFactory deleteThreadFactory = GemfireCacheHelper.createThreadFactory(
+          deleteThreadGroup, "Oplog Delete Task");
+      this.diskDelayedWritePool = new ThreadPoolExecutor(
+          1, Math.max(MAX_PENDING_DISK_TASKS - 2, 4), 60, TimeUnit.SECONDS,
+          new LinkedBlockingQueue<>(MAX_PENDING_DISK_TASKS),
+          deleteThreadFactory, new ThreadPoolExecutor.CallerRunsPolicy());
 
       //this.oldEntryMap = new CustomEntryConcurrentHashMap<>();
       this.oldEntryMap = new ConcurrentHashMap<String, Map<Object, BlockingQueue<RegionEntry>>>();
@@ -1854,7 +1904,8 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
   /**
    * Number of threads used to close PRs in shutdownAll. By default is the number of PRs in the cache
    */
-  private static final int shutdownAllPoolSize = Integer.getInteger("gemfire.SHUTDOWN_ALL_POOL_SIZE", -1);
+  private static final int shutdownAllPoolSize = sysProps.getInteger(
+      "SHUTDOWN_ALL_POOL_SIZE", -1);
 
   void shutdownSubTreeGracefully(Map<String, PartitionedRegion> prSubMap) {
     for (final PartitionedRegion pr : prSubMap.values()) {
@@ -2143,7 +2194,8 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
     }
   }
 
-  private final boolean DISABLE_DISCONNECT_DS_ON_CACHE_CLOSE = Boolean.getBoolean("gemfire.DISABLE_DISCONNECT_DS_ON_CACHE_CLOSE");
+  private final boolean DISABLE_DISCONNECT_DS_ON_CACHE_CLOSE = sysProps.getBoolean(
+      "DISABLE_DISCONNECT_DS_ON_CACHE_CLOSE", false);
 
   /**
    * close the cache
@@ -2563,6 +2615,14 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
     system.handleResourceEvent(ResourceEvent.DISKSTORE_REMOVE, dsi);
   }
 
+  ThreadPoolExecutor getDiskStoreTaskPool() {
+    return this.diskStoreTaskPool;
+  }
+
+  ThreadPoolExecutor getDiskDelayedWritePool() {
+    return this.diskDelayedWritePool;
+  }
+
   public void addRegionOwnedDiskStore(DiskStoreImpl dsi) {
     this.regionOwnedDiskStores.put(dsi.getName(), dsi);
   }
@@ -2580,6 +2640,35 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
         getLoggerI18n().severe(LocalizedStrings.Disk_Store_Exception_During_Cache_Close, e);
       }
       it.remove();
+    }
+    // close the disk thread pools
+    stopDiskStoreTaskPools();
+  }
+
+  private void stopDiskStoreTaskPools() {
+    LogWriter logger = getLogger();
+    if (logger.infoEnabled()) {
+      logger.info("Stopping DiskStore task pools");
+    }
+    shutdownPool(this.diskStoreTaskPool);
+
+    // Allow the delayed writes to complete
+    this.diskDelayedWritePool.shutdown();
+    try {
+      this.diskDelayedWritePool.awaitTermination(1, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private void shutdownPool(ThreadPoolExecutor pool) {
+    // All the regions have already been closed
+    // so this pool shouldn't be doing anything.
+    List<Runnable> l = pool.shutdownNow();
+    for (Runnable runnable : l) {
+      if (runnable instanceof DiskStoreTask) {
+        ((DiskStoreTask)runnable).taskCancelled();
+      }
     }
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/doc-files/properties.html
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/doc-files/properties.html
@@ -1506,7 +1506,7 @@ TBA
 <dd>
 <em>Public:</em> false
 <p>
-<em>Integer</em> (default is 15000)
+<em>Integer</em> (default is 120000)
 <p>
 See <code>com.gemstone.gemfire.distributed.internal.PooledExecutorWithDMStats#PooledExecutorWithDMStats(BlockingQueue, int, PoolStatHelper, ThreadFactory)</code>.
 <p>

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
@@ -336,16 +336,15 @@ public interface GfxdConstants {
   final String GFXD_GLOBALINDEX_DISKSTORE_NAME ="GFXD-GLOBALINDEX-DISKSTORE";
 
   /**
-   * Suffix of disk store used by snappydata's delta regions
-   * (appended to main diskstore name).
-   */
-  final String SNAPPY_DELTA_DISKSTORE_SUFFIX = "-SNAPPY-DELTA";
-
-  /**
    * Name of default disk store used by snappydata's delta regions.
    */
-  final String SNAPPY_DEFAULT_DELTA_DISKSTORE =
-      GFXD_DEFAULT_DISKSTORE_NAME + SNAPPY_DELTA_DISKSTORE_SUFFIX;
+  final String SNAPPY_DEFAULT_DELTA_DISKSTORE = "SNAPPY-INTERNAL-DELTA";
+
+  /**
+   * Suffix of disk store used by snappydata's delta regions
+   * (appended to main diskstore name except for default diskstore).
+   */
+  final String SNAPPY_DELTA_DISKSTORE_SUFFIX = "-SNAPPY-DELTA";
 
   /**
    * default sub-directory to use for delta store

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
@@ -335,13 +335,27 @@ public interface GfxdConstants {
   /** Name of disk store used by global indexes */ 
   final String GFXD_GLOBALINDEX_DISKSTORE_NAME ="GFXD-GLOBALINDEX-DISKSTORE";
 
-  /** Name of disk store used by snappydata's delta regions */
-  final String SNAPPY_DELTA_DISKSTORE_NAME ="SNAPPY-INTERNAL-DELTA";
+  /**
+   * Suffix of disk store used by snappydata's delta regions
+   * (appended to main diskstore name).
+   */
+  final String SNAPPY_DELTA_DISKSTORE_SUFFIX = "-SNAPPY-DELTA";
+
+  /**
+   * Name of default disk store used by snappydata's delta regions.
+   */
+  final String SNAPPY_DEFAULT_DELTA_DISKSTORE =
+      GFXD_DEFAULT_DISKSTORE_NAME + SNAPPY_DELTA_DISKSTORE_SUFFIX;
 
   /**
    * default sub-directory to use for delta store
    */
   final String SNAPPY_DELTA_SUBDIR = "snappy-internal-delta";
+
+  /**
+   * maximum size of each oplog file used for delta disk stores
+   */
+  final int SNAPPY_DELTA_DISKSTORE_SIZEMB = 50;
 
   /** Name of meta-region used to store the max identity column value */ 
   final String IDENTITY_REGION_NAME ="__IDENTITYREGION2";

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -459,7 +459,7 @@ public final class FabricDatabase implements ModuleControl,
           GfxdConstants.GFXD_DD_DISKSTORE_NAME), factory);
       addInternalDiskStore(this.memStore.getDefaultDiskStore(), factory);
       addInternalDiskStore(cache.findDiskStore(
-          GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME), factory);
+          GfxdConstants.SNAPPY_DEFAULT_DELTA_DISKSTORE), factory);
 
       // Initialize ConnectionWrapperHolder with this embeded connection
       GfxdManagementService.handleEvent(

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/CreateDiskStoreConstantAction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/CreateDiskStoreConstantAction.java
@@ -18,17 +18,19 @@ package com.pivotal.gemfirexd.internal.impl.sql.execute;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Hashtable;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
+import com.gemstone.gemfire.cache.DiskAccessException;
 import com.gemstone.gemfire.cache.DiskStoreFactory;
-import com.pivotal.gemfirexd.internal.engine.Misc;
+import com.gemstone.gemfire.internal.shared.OpenHashSet;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
+import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.access.GemFireTransaction;
 import com.pivotal.gemfirexd.internal.engine.access.operations.DiskStoreCreateOperation;
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
@@ -51,7 +53,7 @@ public class CreateDiskStoreConstantAction extends DDLConstantAction {
 
   final private List<Integer> dirSizes;
 
-  final private Map otherAttribs;
+  final private Map<?, ?> otherAttribs;
 
   public static final String REGION_PREFIX_FOR_CONFLATION =
       "__GFXD_INTERNAL_DISKSTORE_";
@@ -83,30 +85,43 @@ public class CreateDiskStoreConstantAction extends DDLConstantAction {
   public String toString() {
     return constructToString("CREATE DISKSTORE ", diskStoreName);
   }
-  
-  // Is this filename valid?
-  public static boolean isFilenameValid(String file) {
-   // Illegal characters are
-   //  asterisk
-   //  question mark
-   //  greater-than/less-than
-   //  pipe character
-   //  semicolon
-   // Some are legal on Linux, but trying to create DISKSTORE "*" crashes anyway
-   // So make this more restrictive and same as Windows restrictions
-   Pattern illegalCharsPattern = Pattern.compile("[*?<>|;]");
-   Matcher matcher = illegalCharsPattern.matcher(file);
-   if (matcher.find())
-   {
-     return false;
-   }
-   return true;
-  }
-
 
   @Override
   public void executeConstantAction(Activation activation)
       throws StandardException {
+    // first register operation to create the main disk store
+    executeConstantAction(diskStoreName, dirPaths, dirSizes,
+        otherAttribs, activation);
+    // next register operation to create the internal delta store
+    if (Misc.getMemStore().isSnappyStore()) {
+      int numDirs = dirPaths.size();
+      List<String> deltaDirs;
+      if (numDirs > 0) {
+        deltaDirs = new ArrayList<>(numDirs);
+        for (String dirPath : dirPaths) {
+          deltaDirs.add(dirPath + File.pathSeparator +
+              GfxdConstants.SNAPPY_DELTA_SUBDIR);
+        }
+      } else {
+        deltaDirs = Collections.singletonList(GfxdConstants.SNAPPY_DELTA_SUBDIR);
+      }
+      // set/overwrite the max oplog size to fixed one for delta store
+      LinkedHashMap<Object, Object> deltaAttrs = new LinkedHashMap<>(otherAttribs);
+      deltaAttrs.put("maxlogsize", GfxdConstants.SNAPPY_DELTA_DISKSTORE_SIZEMB);
+      executeConstantAction(diskStoreName +
+              GfxdConstants.SNAPPY_DELTA_DISKSTORE_SUFFIX, deltaDirs, dirSizes,
+          deltaAttrs, activation);
+    }
+  }
+
+  private static void executeConstantAction(String diskStoreName,
+      List<String> dirPaths, List<Integer> dirSizes, Map<?, ?> otherAttribs,
+      Activation activation) throws StandardException {
+    // Verify that this disk store name is legal
+    if (!GemFireStore.isFilenameValid(diskStoreName)) {
+      throw StandardException.newException(SQLState.NOT_IMPLEMENTED,
+          "Disk Store name " + diskStoreName + " is not valid");
+    }
     if (!ServerGroupUtils.isDataStore()) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_CONGLOM,
           "Skipping create diskstore for " + diskStoreName + " on JVM of kind "
@@ -122,22 +137,20 @@ public class CreateDiskStoreConstantAction extends DDLConstantAction {
       int sizes[] = new int[numDirs];
       boolean dirCreated[] = new boolean[numDirs];
       Arrays.fill(dirCreated, false);
-      Hashtable<String, String> ht = new Hashtable<String, String>();
-      String canonicalPath = null;
+      OpenHashSet<String> ht = new OpenHashSet<>(numDirs);
+      String canonicalPath;
       boolean foundExplicitSize = false;
       for (int i = 0; i < numDirs; ++i) {
         String fileStr = dirPaths.get(i);
-        fileStr = store.generatePersistentDirName(fileStr);
-        // Verify that this directory name is legal
-        if (!isFilenameValid(fileStr))
-        {
-          throw StandardException.newException(SQLState.NOT_IMPLEMENTED,
-              "Directory name " + dirPaths.get(i) + " was not valid");        
+        try {
+          dirs[i] = GemFireStore.createPersistentDir(
+              store.getBasePersistenceDir(), fileStr).toFile();
+          dirPathsAndSizes.append(dirs[i].toString());
+          dirCreated[i] = true;
+        } catch (DiskAccessException dae) {
+          throw StandardException.newException(
+              SQLState.DATA_UNEXPECTED_EXCEPTION, dae);
         }
-
-        dirs[i] = new File(fileStr).getAbsoluteFile();
-        dirPathsAndSizes.append(dirs[i].getAbsolutePath());
-        dirCreated[i] = dirs[i].mkdir();
 
         /* Detect whether the user has entered duplicate directory names.
         * If yes, error out. For example, for CREATE DISKSTORE X ('DIR1', 
@@ -157,7 +170,7 @@ public class CreateDiskStoreConstantAction extends DDLConstantAction {
               "Unexpected exception while accessing the directory "
                   + dirs[i].toString(), ie);
         }
-        if (ht.put(canonicalPath, canonicalPath) != null) {
+        if (!ht.add(canonicalPath)) {
           // Duplicate directory found. Remove only the
           // directories that we have created and error out
           for (int k = 0; k <= i; ++k) {
@@ -187,24 +200,14 @@ public class CreateDiskStoreConstantAction extends DDLConstantAction {
       else {
         dsf.setDiskDirs(dirs);
       }
-    }
-    else {
-      String defaultDir = store.generatePersistentDirName(null);
-      File dirs[] = new File[] { new File(defaultDir).getAbsoluteFile() };
+    } else {
+      Path defaultDir = GemFireStore.createPersistentDir(
+          store.getBasePersistenceDir(), null);
+      File dirs[] = new File[] { defaultDir.toFile() };
       dirPathsAndSizes.append(dirs[0].getAbsolutePath());
-      String fileNameToCheck = defaultDir + "\\" + diskStoreName;
-      // Verify that this directory name is legal
-      if (!isFilenameValid(fileNameToCheck))
-      {
-        throw StandardException.newException(SQLState.NOT_IMPLEMENTED,
-            "Disk Store name " + diskStoreName + " was not valid");        
-      }
-      dirs[0].mkdir();
       dsf.setDiskDirs(dirs);
     }
-    Iterator<Map.Entry> entryItr = otherAttribs.entrySet().iterator();
-    while (entryItr.hasNext()) {
-      Map.Entry entry = entryItr.next();
+    for (Map.Entry<?, ?> entry : otherAttribs.entrySet()) {
       String key = (String)entry.getKey();
       Object vn = entry.getValue();
       try {

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/DistributedSQLTestBase.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/DistributedSQLTestBase.java
@@ -19,7 +19,6 @@ package com.pivotal.gemfirexd;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.net.InetAddress;
 import java.net.Socket;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -1982,7 +1981,7 @@ public class DistributedSQLTestBase extends DistributedTestBase {
           for (DiskStoreImpl ds : cache.listDiskStores()) {
             if (!GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME.equals(ds.getName())
                 && !GfxdConstants.GFXD_DD_DISKSTORE_NAME.equals(ds.getName())
-                && !GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME.equals(ds.getName())) {
+                && !GfxdConstants.SNAPPY_DEFAULT_DELTA_DISKSTORE.equals(ds.getName())) {
               requiresCleanup[2] = true;
               break;
             }
@@ -2095,7 +2094,7 @@ public class DistributedSQLTestBase extends DistributedTestBase {
           for (DiskStoreImpl ds : cache.listDiskStores()) {
             if (!GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME.equals(ds.getName())
                 && !GfxdConstants.GFXD_DD_DISKSTORE_NAME.equals(ds.getName())
-                && !GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME.equals(ds.getName())) {
+                && !GfxdConstants.SNAPPY_DEFAULT_DELTA_DISKSTORE.equals(ds.getName())) {
               executeCleanup(stmt, "drop diskstore \"" + ds.getName() + '"');
             }
           }

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/CreateDiskStoreDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/CreateDiskStoreDUnit.java
@@ -681,7 +681,7 @@ public class CreateDiskStoreDUnit extends DistributedSQLTestBase {
       assertNull(memberMap.put(member, dirs));
       if (name.equals(GfxdConstants.GFXD_DD_DISKSTORE_NAME)) {
         assertTrue(dirs.endsWith("datadictionary"));
-      } else if (name.equals(GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME)) {
+      } else if (name.equals(GfxdConstants.SNAPPY_DEFAULT_DELTA_DISKSTORE)) {
         assertTrue(dirs.endsWith(GfxdConstants.SNAPPY_DELTA_SUBDIR));
       }
       assertTrue(memberDiskStoreIds.add(new GemFireXDUtils.Pair<>(member, id)));
@@ -690,7 +690,7 @@ public class CreateDiskStoreDUnit extends DistributedSQLTestBase {
     assertTrue(diskStores.containsKey(GfxdConstants.GFXD_DD_DISKSTORE_NAME));
     assertTrue(
         diskStores.containsKey(GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME));
-    assertTrue(diskStores.containsKey(GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME));
+    assertTrue(diskStores.containsKey(GfxdConstants.SNAPPY_DEFAULT_DELTA_DISKSTORE));
     for (GemFireXDUtils.Pair<String, String> p : extraStores) {
       HashMap<String, String> memberMap = diskStores.get(p.getKey());
       assertNotNull(memberMap);

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/CreateDiskStoreTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/CreateDiskStoreTest.java
@@ -265,7 +265,7 @@ public class CreateDiskStoreTest extends JdbcTestBase
     Set<String> names = new HashSet<String>();
     names.add(GfxdConstants.GFXD_DD_DISKSTORE_NAME);
     names.add(GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME);
-    names.add(GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME);
+    names.add(GfxdConstants.SNAPPY_DEFAULT_DELTA_DISKSTORE);
     numRows = 0;
     while (rs.next()) {
       ++numRows;
@@ -280,7 +280,7 @@ public class CreateDiskStoreTest extends JdbcTestBase
           .getInt("COMPACTIONTHRESHOLD"));
       if (diskStoreName.equals(GfxdConstants.GFXD_DD_DISKSTORE_NAME)) {
         assertEquals(rs.getLong("MAXLOGSIZE"), 10);
-      } else if (diskStoreName.equals(GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME)) {
+      } else if (diskStoreName.equals(GfxdConstants.SNAPPY_DEFAULT_DELTA_DISKSTORE)) {
         assertEquals(rs.getLong("MAXLOGSIZE"), 100);
       }
       else {
@@ -296,7 +296,7 @@ public class CreateDiskStoreTest extends JdbcTestBase
       if (diskStoreName.equals(GfxdConstants.GFXD_DD_DISKSTORE_NAME)) {
         assertEquals(rs.getString("DIR_PATH_SIZE"), new File(".",
             "datadictionary").getCanonicalPath());
-      } else if (diskStoreName.equals(GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME)) {
+      } else if (diskStoreName.equals(GfxdConstants.SNAPPY_DEFAULT_DELTA_DISKSTORE)) {
         assertEquals(rs.getString("DIR_PATH_SIZE"), new File(".",
             GfxdConstants.SNAPPY_DELTA_SUBDIR).getCanonicalPath());
       } else {
@@ -471,7 +471,7 @@ public class CreateDiskStoreTest extends JdbcTestBase
       Statement stmt = conn.createStatement();
       // Try to drop the default diskstore. Should fail with 0A000.
       stmt.execute("Drop DiskStore " + "\"" +
-          GfxdConstants.SNAPPY_DELTA_DISKSTORE_NAME + "\"");
+          GfxdConstants.SNAPPY_DEFAULT_DELTA_DISKSTORE + "\"");
       fail("Disk store drop should fail because diskstore is a default one");
     } catch (SQLException e) {
       assertEquals(e.getSQLState(), "0A000");


### PR DESCRIPTION
Follow up PR for SNAP-2121 as per review comments in https://github.com/SnappyDataInc/snappy-store/pull/349

## Changes proposed in this pull request

- moved the diskstore thread pools to be global inside GemFireCacheImpl
- add an "-INTERNAL-DELTA" suffix to given disk store name to create both in
  CreateDiskStoreConstantAction and drop both in DropDiskStoreConstantAction;
  the default delta disk store is also changed accordingly
- use oplog size of 50M for delta disk stores (not configurable)
- reduced the thread idle timeout in thread pools to a more reasonable 2mins by default instead
  of 30mins
- use SystemProperties consistently in GemFireCacheImpl instead of java System property based
  reader (among others this allows for multiple prefixes as per product "gemfire", "gemfirexd"
  etc, can read from properties file with "gemfirexd" for example etc)

## Patch testing

precheckin

## ReleaseNotes changes

Note the new implicit delta disk stores in the docs.

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/918