### PR TITLE
Handle ConflictingPersistentDataException and close cache

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/cache/DiskAccessException.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/cache/DiskAccessException.java
@@ -122,6 +122,15 @@ public class DiskAccessException extends CacheRuntimeException {
   }
 
   /**
+   * Constructs a new <code>DiskAccessException</code> with a message string.
+   *
+   * @param msg the message string
+   */
+  public DiskAccessException(String msg) {
+    super(msg);
+  }
+
+  /**
    * Returns true if this exception originated from a remote node.
    */
   public final boolean isRemote() {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/cache/persistence/ConflictingPersistentDataException.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/cache/persistence/ConflictingPersistentDataException.java
@@ -17,7 +17,7 @@
 package com.gemstone.gemfire.cache.persistence;
 
 import com.gemstone.gemfire.GemFireException;
-import com.gemstone.gemfire.admin.AdminDistributedSystem;
+import com.gemstone.gemfire.cache.DiskAccessException;
 
 /**
  * Thrown when a member with persistence is recovering, and it discovers that
@@ -32,7 +32,7 @@ import com.gemstone.gemfire.admin.AdminDistributedSystem;
  * @author dsmith
  * @since 6.5
  */
-public class ConflictingPersistentDataException extends GemFireException {
+public class ConflictingPersistentDataException extends DiskAccessException {
 
   private static final long serialVersionUID = -2629287782021455875L;
 
@@ -51,7 +51,5 @@ public class ConflictingPersistentDataException extends GemFireException {
   public ConflictingPersistentDataException(Throwable cause) {
     super(cause);
   }
-
-  
 
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -109,6 +109,7 @@ import com.gemstone.gemfire.cache.hdfs.internal.HoplogListenerForRegion;
 import com.gemstone.gemfire.cache.hdfs.internal.hoplog.HDFSRegionDirector;
 import com.gemstone.gemfire.cache.hdfs.internal.hoplog.HDFSRegionDirector.HdfsRegionManager;
 import com.gemstone.gemfire.cache.partition.PartitionRegionHelper;
+import com.gemstone.gemfire.cache.persistence.ConflictingPersistentDataException;
 import com.gemstone.gemfire.cache.query.FunctionDomainException;
 import com.gemstone.gemfire.cache.query.IndexMaintenanceException;
 import com.gemstone.gemfire.cache.query.IndexType;
@@ -8255,6 +8256,14 @@ public class LocalRegion extends AbstractRegion
     if (dae != null && dae.isRemote()) {
       return;
     }
+    if (duringInitialization && !(dae instanceof ConflictingPersistentDataException)) {
+      return;
+    }
+
+    if (causedByRDE(dae)) {
+      return;
+    }
+
     LogWriterI18n logger = getCache().getLoggerI18n();
     // Locally Destroy the region
     boolean gotRDE = false;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyBucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyBucketRegion.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import com.gemstone.gemfire.CancelCriterion;
 import com.gemstone.gemfire.InternalGemFireError;
+import com.gemstone.gemfire.cache.DiskAccessException;
 import com.gemstone.gemfire.cache.EvictionAttributes;
 import com.gemstone.gemfire.cache.Region;
 import com.gemstone.gemfire.cache.RegionAttributes;
@@ -503,7 +504,11 @@ public final class ProxyBucketRegion implements Bucket {
       }
       
       persistenceAdvisor.initializeMembershipView();
-    } catch(RuntimeException e) {
+    } catch (DiskAccessException dae) {
+      this.partitionedRegion.handleDiskAccessException(dae, true);
+      throw dae;
+    }
+    catch(RuntimeException e) {
       exception=e;
       throw e;
     } finally {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/PersistenceAdvisorImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/PersistenceAdvisorImpl.java
@@ -80,6 +80,7 @@ public class PersistenceAdvisorImpl implements PersistenceAdvisor {
   private volatile Set<PersistentMemberID> allMembersWaitingFor;
   private volatile Set<PersistentMemberID> offlineMembersWaitingFor;
   protected final Object lock;
+  private static PersistenceAdvisorObserver observer = null;
   
   public static final boolean TRACE = Boolean.getBoolean("gemfire.TRACE_PERSISTENCE_ADVISOR");
   
@@ -715,6 +716,10 @@ public class PersistenceAdvisorImpl implements PersistenceAdvisor {
   public boolean checkMyStateOnMembers(Set<InternalDistributedMember> replicates) throws ReplyException {
     PersistentStateQueryResults remoteStates = getMyStateOnMembers(replicates);
     boolean equal = false;
+    if (observer != null) {
+      observer.observe(regionPath);
+    }
+
     for(Map.Entry<InternalDistributedMember, PersistentMemberState> entry: remoteStates.stateOnPeers.entrySet()) {
       InternalDistributedMember member = entry.getKey();
       PersistentMemberID remoteId = remoteStates.persistentIds.get(member);
@@ -1287,5 +1292,14 @@ public class PersistenceAdvisorImpl implements PersistenceAdvisor {
   
   public boolean isOnline() {
     return online;
+  }
+
+  public static interface PersistenceAdvisorObserver {
+    default public void observe(String regionPath) {
+    }
+  }
+
+  public static void setPersistenceAdvisorObserver(PersistenceAdvisorObserver o) {
+     observer = o;
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request

During disk recovery the ConflictingPersistentDataException is not handled properly; it should have logged an error and closed the cache.
Ported the fix from:
https://issues.apache.org/jira/browse/GEODE-2918
## Patch testing

precheckin 
## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
