### PR TITLE
Snap 2140

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
@@ -9605,8 +9605,8 @@ public class PartitionedRegion extends LocalRegion implements
    * region in the data Store.
    * 
    */
-  public List getLocalBucketsListTestOnly() {
-    List localBucketList = null;
+  public List<Integer> getLocalBucketsListTestOnly() {
+    List<Integer> localBucketList = null;
     if (this.dataStore != null) {
       localBucketList = this.dataStore.getLocalBucketsListTestOnly();
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionDataStore.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionDataStore.java
@@ -2973,8 +2973,8 @@ public final class PartitionedRegionDataStore implements HasCachePerfStats
    * store.
    *
    */
-  public final List getLocalBucketsListTestOnly() {
-    final List bucketList = new ArrayList();
+  public final List<Integer> getLocalBucketsListTestOnly() {
+    final List<Integer> bucketList = new ArrayList<Integer>();
     visitBuckets(new BucketVisitor() {
       @Override
       public void visit(Integer bucketId, Region r) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionDataStore.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionDataStore.java
@@ -2989,8 +2989,8 @@ public final class PartitionedRegionDataStore implements HasCachePerfStats
    * data store.
    *
    */
-  public final List getLocalPrimaryBucketsListTestOnly() {
-    final List primaryBucketList = new ArrayList();
+  public final List<Integer> getLocalPrimaryBucketsListTestOnly() {
+    final List<Integer> primaryBucketList = new ArrayList<Integer>();
     visitBuckets(new BucketVisitor() {
       @Override
       public void visit(Integer bucketId, Region r) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TransactionObserver.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TransactionObserver.java
@@ -86,4 +86,6 @@ public interface TransactionObserver {
    *          if this is invoked during rollback
    */
   public void afterSend(TXStateProxy tx, boolean rollback);
+
+  public void beforePerformOp(TXStateProxy tx);
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TransactionObserverAdapter.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TransactionObserverAdapter.java
@@ -60,4 +60,7 @@ public class TransactionObserverAdapter implements TransactionObserver,
 
   public void afterSend(TXStateProxy tx, boolean rollback) {
   }
+
+  public void beforePerformOp(TXStateProxy tx){
+  }
 }


### PR DESCRIPTION
## Changes proposed in this pull request
In case of failure due to not enough datastore available for tx
  operations, make sure that endOperation is called so that
  currentVersionOpCount is decremented.
## Patch testing

new tests and precheckin

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
