### PR TITLE
[SNAP-2192] flags in snapshot transaction to skip rollover

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXId.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXId.java
@@ -140,7 +140,8 @@ public final class TXId extends ExternalizableDSFID implements TransactionId,
   }
 
   public final String stringFormat() {
-    return "" + this.memberId + ':' + this.uniqId;
+    return new StringBuilder(40)
+        .append(this.memberId).append(':').append(this.uniqId).toString();
   }
 
   @Override

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXManagerImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXManagerImpl.java
@@ -1081,11 +1081,10 @@ public final class TXManagerImpl implements CacheTransactionManager,
 
   public final TXManagerImpl.TXContext commit(
       final TXStateInterface tx, final Object callbackArg,
-      final int commitPhase, final TXContext context, boolean isRemoteCommit)
+      final int commitPhase, TXContext ctx, boolean isRemoteCommit)
       throws TransactionException {
     checkClosed();
 
-    TXManagerImpl.TXContext ctx = context;
     if (tx == null) {
       throw new IllegalTransactionStateException(LocalizedStrings
           .TXManagerImpl_THREAD_DOES_NOT_HAVE_AN_ACTIVE_TRANSACTION
@@ -1897,6 +1896,8 @@ public final class TXManagerImpl implements CacheTransactionManager,
     for (TXStateProxy txProxy : txMgr.getHostedTransactionsInProgress()) {
       msg.append(' ');
       txProxy.getTransactionId().appendToString(msg, sys);
+      msg.append(",state=").append(txProxy.state)
+          .append('{').append(txProxy.getIsolationLevel()).append('}');
       msg.append('{').append(txProxy.creatorThread.toString()).append('}');
     }
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/partitioned/PutAllPRMessage.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/partitioned/PutAllPRMessage.java
@@ -685,8 +685,8 @@ public final class PutAllPRMessage extends PartitionMessageWithDirectReply {
         // TODO: For tx it may change.
         // TODO: For concurrent putALLs, this will club other putall as well
         // the putAlls in worst case so columnBatchSize may be large?
-        if (success && bucketRegion.checkForColumnBatchCreation()) {
-          bucketRegion.createAndInsertColumnBatch(false);
+        if (success && bucketRegion.checkForColumnBatchCreation(txi)) {
+          bucketRegion.createAndInsertColumnBatch(txi, false);
         }
         if (success && allEvents != null) {
            CallbackFactoryProvider.getStoreCallbacks()

--- a/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientStatement.java
+++ b/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientStatement.java
@@ -142,7 +142,7 @@ public class ClientStatement extends ClientFetchColumnValue implements
   }
 
   public final void setSnapshotTransactionId(String txId) {
-    if (txId != null && !txId.equals("null")) {
+    if (txId != null && !txId.isEmpty()) {
       this.attrs.setSnapshotTransactionId(txId);
     } else {
       this.attrs.unsetSnapshotTransactionId();

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -1663,43 +1663,55 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
 
     {
       {
-        String[] argNames = new String[]{"txId"};
-        TypeDescriptor[] argTypes = new TypeDescriptor[]{
-            DataTypeDescriptor.getCatalogType(Types.VARCHAR)};
-        super.createSystemProcedureOrFunction("START_SNAPSHOT_TXID", sysUUID,
-            argNames,argTypes, 1, 0, RoutineAliasInfo.NO_SQL, null, newlyCreatedRoutines,
-            tc, GFXD_SYS_PROC_CLASSNAME, false);
-      }
-
-      {
-        String[] argNames = new String[]{"txId"};
-        TypeDescriptor[] argTypes = new TypeDescriptor[]{
-            DataTypeDescriptor.getCatalogType(Types.VARCHAR)};
-        super.createSystemProcedureOrFunction("COMMIT_SNAPSHOT_TXID", sysUUID,
-            argNames,argTypes, 0, 0, RoutineAliasInfo.NO_SQL, null, newlyCreatedRoutines,
-            tc, GFXD_SYS_PROC_CLASSNAME, false);
-      }
-      {
-        String[] argNames = new String[]{"txId"};
-        TypeDescriptor[] argTypes = new TypeDescriptor[]{
-            DataTypeDescriptor.getCatalogType(Types.VARCHAR)};
-        super.createSystemProcedureOrFunction("ROLLBACK_SNAPSHOT_TXID", sysUUID,
-            argNames,argTypes, 0, 0, RoutineAliasInfo.NO_SQL, null, newlyCreatedRoutines,
-            tc, GFXD_SYS_PROC_CLASSNAME, false);
-      }
-      {
-        String[] argNames = new String[] { "txId"};
+        String[] argNames = new String[] { "delayRollover", "txId" };
         TypeDescriptor[] argTypes = new TypeDescriptor[] {
-            DataTypeDescriptor.getCatalogType(Types.VARCHAR)};
+            DataTypeDescriptor.getBuiltInDataTypeDescriptor(
+                Types.BOOLEAN, false).getCatalogType(),
+            DataTypeDescriptor.getBuiltInDataTypeDescriptor(
+                Types.VARCHAR, false).getCatalogType() };
+        super.createSystemProcedureOrFunction("START_SNAPSHOT_TXID", sysUUID,
+            argNames, argTypes, 1, 0, RoutineAliasInfo.NO_SQL, null,
+            newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
+      }
+      {
+        String[] argNames = new String[] { "txId", "rolloverTable" };
+        TypeDescriptor[] argTypes = new TypeDescriptor[] {
+            DataTypeDescriptor.getBuiltInDataTypeDescriptor(
+                Types.VARCHAR, false).getCatalogType(),
+            DataTypeDescriptor.getBuiltInDataTypeDescriptor(
+                Types.VARCHAR, false).getCatalogType() };
+        super.createSystemProcedureOrFunction("COMMIT_SNAPSHOT_TXID", sysUUID,
+            argNames, argTypes, 0, 0, RoutineAliasInfo.NO_SQL,
+            null, newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
+      }
+      {
+        String[] argNames = new String[] { "txId" };
+        TypeDescriptor[] argTypes = new TypeDescriptor[] {
+            DataTypeDescriptor.getBuiltInDataTypeDescriptor(
+                Types.VARCHAR, false).getCatalogType() };
+        super.createSystemProcedureOrFunction("ROLLBACK_SNAPSHOT_TXID", sysUUID,
+            argNames, argTypes, 0, 0, RoutineAliasInfo.NO_SQL, null,
+            newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
+      }
+      {
+        String[] argNames = new String[] { "txId" };
+        TypeDescriptor[] argTypes = new TypeDescriptor[] {
+            DataTypeDescriptor.getBuiltInDataTypeDescriptor(
+                Types.VARCHAR, false).getCatalogType() };
         super.createSystemProcedureOrFunction("USE_SNAPSHOT_TXID", sysUUID,
             argNames, argTypes, 0, 0, RoutineAliasInfo.NO_SQL, null,
             newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
       }
-
-      super.createSystemProcedureOrFunction("GET_SNAPSHOT_TXID", sysUUID,
-          null, null, 0, 0, RoutineAliasInfo.READS_SQL_DATA,
-          DataTypeDescriptor.getCatalogType(Types.VARCHAR), newlyCreatedRoutines,
-          tc, GFXD_SYS_PROC_CLASSNAME, false);
+      {
+        String[] argNames = new String[] { "delayRollover" };
+        TypeDescriptor[] argTypes = new TypeDescriptor[] {
+            DataTypeDescriptor.getBuiltInDataTypeDescriptor(
+                Types.BOOLEAN, false).getCatalogType() };
+        super.createSystemProcedureOrFunction("GET_SNAPSHOT_TXID", sysUUID,
+            argNames, argTypes, 0, 0, RoutineAliasInfo.READS_SQL_DATA,
+            DataTypeDescriptor.getCatalogType(Types.VARCHAR), newlyCreatedRoutines,
+            tc, GFXD_SYS_PROC_CLASSNAME, false);
+      }
     }
 
     {


### PR DESCRIPTION
## Changes proposed in this pull request

- added a flag in TXStateProxy to skip rollover during operations in BucketRegion
- moved explicit rollover of buckets of a region to GfxdSystemProcedures.flushLocalBuckets
  (moved from similar code in snappdata layer)
- added "delayRollover" flag in SNAPSHOT procedures for the same;
  COMMIT_SNAPSHOT_TXID has a String parameter for the table name to trigger rollover
  before commit if required
- improved logging of transactions a bit

## Patch testing

precheckin

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/950