### PR TITLE
[SNAP-2202] correct decoding of bucket names with underscores

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -743,6 +743,12 @@ public class LocalRegion extends AbstractRegion
         StoreCallbacks.SHADOW_TABLE_SUFFIX);
     this.parentRegion = parentRegion;
     this.fullPath = calcFullPath(regionName, parentRegion);
+    // cannot support patterns like "..._/_..." due to ambiguity in encoding
+    // of bucket regions
+    if (this.fullPath.contains("_/_")) {
+      throw new IllegalArgumentException("Region path " + this.fullPath +
+          " cannot have '_/_' pattern");
+    }
     final GemFireCacheImpl.StaticSystemCallbacks sysCb =
         GemFireCacheImpl.FactoryStatics.systemCallbacks;
     if (sysCb == null) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -743,11 +743,11 @@ public class LocalRegion extends AbstractRegion
         StoreCallbacks.SHADOW_TABLE_SUFFIX);
     this.parentRegion = parentRegion;
     this.fullPath = calcFullPath(regionName, parentRegion);
-    // cannot support patterns like "..._/_..." due to ambiguity in encoding
+    // cannot support patterns like "..._/..." due to ambiguity in encoding
     // of bucket regions
-    if (this.fullPath.contains("_/_")) {
+    if (this.fullPath.contains("_/")) {
       throw new IllegalArgumentException("Region path " + this.fullPath +
-          " cannot have '_/_' pattern");
+          " cannot have trailing slash in a parent region");
     }
     final GemFireCacheImpl.StaticSystemCallbacks sysCb =
         GemFireCacheImpl.FactoryStatics.systemCallbacks;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionHelper.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionHelper.java
@@ -1072,8 +1072,9 @@ public final class PartitionedRegionHelper {
   }
 
   public static String unescapePRPath(String escapedPath) {
-    // below logic is broken if separators are mixed with double underscores
-    // at the start of region name (e.g. "/__TEST" becomes five underscores)
+    // below logic is broken if separators are mixed with underscores
+    // at the start of region name (e.g. "/__TEST" becomes five underscores
+    // and decodes to "__/TEST")
     /*
     String path = escapedPath.replace('_', LocalRegion.SEPARATOR_CHAR);
     path = path.replace(TWO_SEPARATORS, "_");

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionHelper.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegionHelper.java
@@ -1064,13 +1064,21 @@ public final class PartitionedRegionHelper {
     return null;
     
   }
-  
+
+  /**
+   * Encode the partitioned region name to embed within the name that will
+   * be used by its bucket regions ({@link #getBucketName(String, int)}).
+   */
   public static String escapePRPath(String prFullPath) {
     String escaped = prFullPath.replace("_", "__");
     escaped = escaped.replace(LocalRegion.SEPARATOR_CHAR, '_');
     return escaped;
   }
 
+  /**
+   * Decode the result of {@link #escapePRPath(String)} from the bucket region
+   * name to obtain the partitioned region name ({@link #getPRPath(String)}).
+   */
   public static String unescapePRPath(String escapedPath) {
     // below logic is broken if separators are mixed with underscores
     // at the start of region name (e.g. "/__TEST" becomes five underscores

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/BugsTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/BugsTest.java
@@ -31,6 +31,7 @@ import com.gemstone.gemfire.cache.Cache;
 import com.gemstone.gemfire.cache.CacheWriterException;
 import com.gemstone.gemfire.cache.DataPolicy;
 import com.gemstone.gemfire.cache.EntryEvent;
+import com.gemstone.gemfire.cache.Region;
 import com.gemstone.gemfire.cache.asyncqueue.internal.AsyncEventQueueImpl;
 import com.gemstone.gemfire.cache.persistence.PartitionOfflineException;
 import com.gemstone.gemfire.cache.util.CacheWriterAdapter;
@@ -8906,6 +8907,37 @@ public class BugsTest extends JdbcTestBase {
       helper2Bug52352(props, "test", "test");
     } finally {
       TestUtil.shutDown();
+    }
+  }
+
+  public void testSNAP_2202() {
+    String[] regions = new String[] {
+        "/" + GfxdConstants.IDENTITY_REGION_NAME,
+        "/SCHEMA",
+        "/_SCHEMA",
+        "/__SCHEMA",
+        "/__SCHEMA_",
+        "/__SCH_EMA_",
+        "/_SCH__EMA_",
+        "/__SCH__EMA__",
+        "/SCHEMA/TEST",
+        "/_SCHEMA/TEST",
+        "/__SCHEMA/_TEST",
+        "/__SCHE_MA/TEST",
+        "/__SCHEMA/_TE__ST",
+        // the pattern "_/_" is unsupported
+        // "/__SC__HEMA_/_TE_ST__"
+    };
+    int[] bucketIds = new int[] { 0, 1, 23, 101, 1001 };
+    for (String region : regions) {
+      for (int bucketId : bucketIds) {
+        String fullPath = Region.SEPARATOR +
+            PartitionedRegionHelper.PR_ROOT_REGION_NAME + Region.SEPARATOR +
+            PartitionedRegionHelper.getBucketName(region, bucketId);
+        String bucketName = PartitionedRegionHelper.getBucketName(fullPath);
+        assertEquals(region, PartitionedRegionHelper.getPRPath(bucketName));
+        assertEquals(bucketId, PartitionedRegionHelper.getBucketId(bucketName));
+      }
     }
   }
 }

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/BugsTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/BugsTest.java
@@ -8927,6 +8927,7 @@ public class BugsTest extends JdbcTestBase {
         "/__SCHEMA/_TE__ST",
         // the pattern "_/_" is unsupported
         // "/__SC__HEMA_/_TE_ST__"
+        "/__SCHEMA/__TE__ST__"
     };
     int[] bucketIds = new int[] { 0, 1, 23, 101, 1001 };
     for (String region : regions) {

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/BugsTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/BugsTest.java
@@ -8931,6 +8931,7 @@ public class BugsTest extends JdbcTestBase {
     int[] bucketIds = new int[] { 0, 1, 23, 101, 1001 };
     for (String region : regions) {
       for (int bucketId : bucketIds) {
+        // below is same as ProxyBucketRegion.fullPath initialization
         String fullPath = Region.SEPARATOR +
             PartitionedRegionHelper.PR_ROOT_REGION_NAME + Region.SEPARATOR +
             PartitionedRegionHelper.getBucketName(region, bucketId);


### PR DESCRIPTION
## Changes proposed in this pull request

- decode odd-numbered underscores with first as slash and replace remaining pairs by ones
- added unit test for different combinations

Full paths having "\_/" are still not supported due to inherent ambiguity in encoding
and are now disallowed (and need to be documented)

## Patch testing

precheckin in progress

## ReleaseNotes changes

Document that schema names with trailing underscores are not supported (to keep it simple).

## Other PRs 

NA