### PR TITLE
[SNAP-2175] don't fail in middle of write if compression fails

### DIFF
--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/SystemProperties.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/SystemProperties.java
@@ -133,7 +133,8 @@ public final class SystemProperties {
      */
     public synchronized String getSystemProperty(String key,
         SystemProperties properties) throws PrivilegedActionException {
-      this._propertyName = this.propertyNamePrefix + key;
+      this._propertyName = key.startsWith(this.propertyNamePrefix)
+          ? key : this.propertyNamePrefix + key;
       String value = AccessController.doPrivileged(this);
       this._propertyName = null;
       return value;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RegionEntryUtils.java
@@ -812,7 +812,12 @@ public final class RegionEntryUtils {
           break;
         }
       }
-      if (!hasPrefix) {
+      if (hasPrefix) {
+        propValue = PropertyUtil.getSystemProperty(key, null);
+        if (propValue != null) {
+          return propValue;
+        }
+      } else {
         for (String prefix : allPrefixes) {
           propValue = PropertyUtil.getSystemProperty(prefix + key, null);
           if (propValue != null) {

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/BlobChunk.java
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/BlobChunk.java
@@ -787,11 +787,22 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
       struct.validate();
     }
 
-    public void write(org.apache.thrift.protocol.TProtocol oprot, BlobChunk struct) throws org.apache.thrift.TException {
-      struct.validate();
+    @Override
+    public void write(org.apache.thrift.protocol.TProtocol oprot, BlobChunk struct)
+        throws org.apache.thrift.TException {
+      try {
+        struct.validate();
+        final ByteBuffer chunk = struct.getCompressedBuffer(oprot);
+        writeData(oprot, struct, chunk);
+      } finally {
+        // free the blob once written
+        struct.free();
+      }
+    }
 
+    private void writeData(org.apache.thrift.protocol.TProtocol oprot,
+        BlobChunk struct, ByteBuffer chunk) throws org.apache.thrift.TException {
       oprot.writeStructBegin(STRUCT_DESC);
-      final ByteBuffer chunk = struct.getCompressedBuffer(oprot);
       if (chunk != null) {
         oprot.writeFieldBegin(CHUNK_FIELD_DESC);
         oprot.writeBinary(chunk);
@@ -817,8 +828,6 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
       }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
-      // free the blob once written
-      struct.free();
     }
 
   }
@@ -832,9 +841,22 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
   private static class BlobChunkTupleScheme extends TupleScheme<BlobChunk> {
 
     @Override
-    public void write(org.apache.thrift.protocol.TProtocol prot, BlobChunk struct) throws org.apache.thrift.TException {
+    public void write(org.apache.thrift.protocol.TProtocol prot,
+        BlobChunk struct) throws org.apache.thrift.TException {
+      try {
+        final ByteBuffer buffer = struct.getCompressedBuffer(prot);
+        writeData(prot, struct,
+            buffer != null ? buffer : ClientSharedData.NULL_BUFFER);
+      } finally {
+        // free the blob once written
+        struct.free();
+      }
+    }
+
+    private void writeData(org.apache.thrift.protocol.TProtocol prot,
+        BlobChunk struct, ByteBuffer buffer) throws org.apache.thrift.TException {
       TTupleProtocol oprot = (TTupleProtocol) prot;
-      oprot.writeBinary(struct.getCompressedBuffer(prot));
+      oprot.writeBinary(buffer);
       oprot.writeBool(struct.last);
       BitSet optionals = new BitSet();
       if (struct.isSetLobId()) {
@@ -856,8 +878,6 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
       if (struct.isSetTotalLength()) {
         oprot.writeI64(struct.totalLength);
       }
-      // free the blob once written
-      struct.free();
     }
 
     @Override

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/BlobChunk.java.tmpl
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/BlobChunk.java.tmpl
@@ -787,11 +787,22 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
       struct.validate();
     }
 
-    public void write(org.apache.thrift.protocol.TProtocol oprot, BlobChunk struct) throws org.apache.thrift.TException {
-      struct.validate();
+    @Override
+    public void write(org.apache.thrift.protocol.TProtocol oprot, BlobChunk struct)
+        throws org.apache.thrift.TException {
+      try {
+        struct.validate();
+        final ByteBuffer chunk = struct.getCompressedBuffer(oprot);
+        writeData(oprot, struct, chunk);
+      } finally {
+        // free the blob once written
+        struct.free();
+      }
+    }
 
+    private void writeData(org.apache.thrift.protocol.TProtocol oprot,
+        BlobChunk struct, ByteBuffer chunk) throws org.apache.thrift.TException {
       oprot.writeStructBegin(STRUCT_DESC);
-      final ByteBuffer chunk = struct.getCompressedBuffer(oprot);
       if (chunk != null) {
         oprot.writeFieldBegin(CHUNK_FIELD_DESC);
         oprot.writeBinary(chunk);
@@ -817,8 +828,6 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
       }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
-      // free the blob once written
-      struct.free();
     }
 
   }
@@ -832,9 +841,22 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
   private static class BlobChunkTupleScheme extends TupleScheme<BlobChunk> {
 
     @Override
-    public void write(org.apache.thrift.protocol.TProtocol prot, BlobChunk struct) throws org.apache.thrift.TException {
+    public void write(org.apache.thrift.protocol.TProtocol prot,
+        BlobChunk struct) throws org.apache.thrift.TException {
+      try {
+        final ByteBuffer buffer = struct.getCompressedBuffer(prot);
+        writeData(prot, struct,
+            buffer != null ? buffer : ClientSharedData.NULL_BUFFER);
+      } finally {
+        // free the blob once written
+        struct.free();
+      }
+    }
+
+    private void writeData(org.apache.thrift.protocol.TProtocol prot,
+        BlobChunk struct, ByteBuffer buffer) throws org.apache.thrift.TException {
       TTupleProtocol oprot = (TTupleProtocol) prot;
-      oprot.writeBinary(struct.getCompressedBuffer(prot));
+      oprot.writeBinary(buffer);
       oprot.writeBool(struct.last);
       BitSet optionals = new BitSet();
       if (struct.isSetLobId()) {
@@ -856,8 +878,6 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
       if (struct.isSetTotalLength()) {
         oprot.writeI64(struct.totalLength);
       }
-      // free the blob once written
-      struct.free();
     }
 
     @Override

--- a/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/internal/GfxdServerLauncher.java
+++ b/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/internal/GfxdServerLauncher.java
@@ -1107,14 +1107,14 @@ public class GfxdServerLauncher extends CacheServerLauncher {
       PersistentMemberID myId, String message) {
     StringBuilder otherMembers = new StringBuilder();
     String tableWithLocation = Misc.getFullTableNameFromRegionPath(regionPath);
-    String myDir = myId != null ? myId.directory : "unknown";
+    String myDir = myId != null ? myId.directory : "(unknown)";
     if (GemFireStore.DDL_STMTS_REGION.equals(tableWithLocation)) {
       tableWithLocation = "DataDictionary at location " + myDir;
     } else {
       tableWithLocation = "Table " + tableWithLocation + " at location " + myDir;
     }
     for (PersistentMemberID otherId : membersToWaitFor) {
-      otherMembers.append("\n [" + otherId.host + "]");
+      otherMembers.append("\n [").append(otherId.host).append(']');
       otherMembers.append(" [DiskId: ")
           .append(otherId.diskStoreId.toUUID().toString())
           .append(", Location: ").append(otherId.directory).append(']');

--- a/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/internal/GfxdServerLauncher.java
+++ b/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/internal/GfxdServerLauncher.java
@@ -1107,11 +1107,11 @@ public class GfxdServerLauncher extends CacheServerLauncher {
       PersistentMemberID myId, String message) {
     StringBuilder otherMembers = new StringBuilder();
     String tableWithLocation = Misc.getFullTableNameFromRegionPath(regionPath);
+    String myDir = myId != null ? myId.directory : "unknown";
     if (GemFireStore.DDL_STMTS_REGION.equals(tableWithLocation)) {
-      tableWithLocation = "DataDictionary at location " + myId.directory;
-    }
-    else {
-      tableWithLocation = "Table " + tableWithLocation + " at location " + myId.directory;
+      tableWithLocation = "DataDictionary at location " + myDir;
+    } else {
+      tableWithLocation = "Table " + tableWithLocation + " at location " + myDir;
     }
     for (PersistentMemberID otherId : membersToWaitFor) {
       otherMembers.append("\n [" + otherId.host + "]");

--- a/gemfirexd/tools/src/testing/java/org/apache/derbyTesting/junit/NetworkServerTestSetup.java
+++ b/gemfirexd/tools/src/testing/java/org/apache/derbyTesting/junit/NetworkServerTestSetup.java
@@ -44,13 +44,13 @@ import junit.framework.Test;
  */
 final public class NetworkServerTestSetup extends BaseTestSetup {
 
-    /** Setting maximum wait time to 40 seconds.   On some platforms
+    /** Setting maximum wait time to 60 seconds.   On some platforms
      * it may take this long to start the server.  Increasing the wait
      *  time should not adversely affect those
      *  systems with fast port turnaround as the actual code loops for 
      *  SLEEP_TIME intervals, so should never see WAIT_TIME.
      */
-    private static final long WAIT_TIME = 40000;
+    private static final long WAIT_TIME = 60000;
     
     /** Sleep for 500 ms before pinging the network server (again) */
     private static final int SLEEP_TIME = 100;


### PR DESCRIPTION
## Changes proposed in this pull request

even if compression fails due to some reason, don't fail write in the middle
else it will result in an unusable connection with dangling data

## Patch testing

store precheckin

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/956