### PR TITLE
[SNAP-2214] set the Region/DiskId in column value in all cases

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskRegionEntry.java
@@ -18,7 +18,6 @@ package com.gemstone.gemfire.internal.cache;
 
 import com.gemstone.gemfire.cache.hdfs.internal.AbstractBucketRegionQueue;
 import com.gemstone.gemfire.cache.query.internal.IndexUpdater;
-import com.gemstone.gemfire.internal.cache.persistence.DiskRegionView;
 import com.gemstone.gemfire.internal.cache.store.SerializedDiskBuffer;
 import com.gemstone.gemfire.internal.cache.wan.GatewaySenderEventImpl;
 import com.gemstone.gemfire.internal.cache.wan.serial.SerialGatewaySenderQueue;
@@ -76,8 +75,7 @@ public abstract class AbstractDiskRegionEntry
   protected final void initDiskIdForOffHeap(RegionEntryContext context,
       Object value) {
     // copy DiskId to value if required
-    if (GemFireCacheImpl.hasNewOffHeap() &&
-        value instanceof SerializedDiskBuffer) {
+    if (value instanceof SerializedDiskBuffer) {
       ((SerializedDiskBuffer)value).setDiskLocation(getDiskId(), context);
     }
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
@@ -1516,8 +1516,7 @@ public interface DiskEntry extends RegionEntry {
         ((AbstractDiskLRURegionEntry)entry).setDelayedDiskId(region);
         did = entry.getDiskId();
         final Object oldValue;
-        if (GemFireCacheImpl.hasNewOffHeap() &&
-            (oldValue = entry._getValue()) instanceof SerializedDiskBuffer) {
+        if ((oldValue = entry._getValue()) instanceof SerializedDiskBuffer) {
           ((SerializedDiskBuffer)oldValue).setDiskLocation(did, region);
         }
         // add DiskId overhead to change

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -14413,10 +14413,8 @@ public class LocalRegion extends AbstractRegion
       synchronized (this) {
         if (!regionOverHeadAccounted) {
           this.regionOverHead = ReflectionSingleObjectSizer.INSTANCE.sizeof(this);
-          if (!callback.acquireStorageMemory(getFullPath(),
-                  regionOverHead, null, true, false)) {
-            throwLowMemoryException(regionOverHead);
-          }
+          callback.acquireStorageMemory(getFullPath(),
+                  regionOverHead, null, true, false);
           regionOverHeadAccounted = true;
         }
       }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/CustomEntryConcurrentHashMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/CustomEntryConcurrentHashMap.java
@@ -920,11 +920,9 @@ RETRYLOOP:
     }
 
     final void postMemAccount(String path) {
-      long numBytes = this.table.length * ReflectionSingleObjectSizer.REFERENCE_SIZE;
-      if (!CallbackFactoryProvider.getStoreCallbacks().acquireStorageMemory(path,
-          numBytes, null, true, false)) {
-        throw LocalRegion.lowMemoryException(null, numBytes);
-      }
+      CallbackFactoryProvider.getStoreCallbacks().acquireStorageMemory(path,
+          this.table.length * ReflectionSingleObjectSizer.REFERENCE_SIZE,
+          null, true, false);
     }
 
     final void accountMapOverhead(int oldCapacity) {
@@ -933,11 +931,9 @@ RETRYLOOP:
       // memory manager as this is the last step of a region operation.
       String regionPath = LocalRegion.regionPath.get();
       if (regionPath != null) {
-        long numBytes = oldCapacity * ReflectionSingleObjectSizer.REFERENCE_SIZE;
-        if (!CallbackFactoryProvider.getStoreCallbacks().acquireStorageMemory(
-            regionPath, numBytes, null, true, false)) {
-          throw LocalRegion.lowMemoryException(null, numBytes);
-        }
+        CallbackFactoryProvider.getStoreCallbacks().acquireStorageMemory(regionPath,
+            oldCapacity * ReflectionSingleObjectSizer.REFERENCE_SIZE,
+            null, true, false);
         LocalRegion.regionPath.remove();
       }
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/CustomEntryConcurrentHashMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/CustomEntryConcurrentHashMap.java
@@ -920,9 +920,11 @@ RETRYLOOP:
     }
 
     final void postMemAccount(String path) {
-      CallbackFactoryProvider.getStoreCallbacks().acquireStorageMemory(path,
-          this.table.length * ReflectionSingleObjectSizer.REFERENCE_SIZE,
-          null, true, false);
+      long numBytes = this.table.length * ReflectionSingleObjectSizer.REFERENCE_SIZE;
+      if (!CallbackFactoryProvider.getStoreCallbacks().acquireStorageMemory(path,
+          numBytes, null, true, false)) {
+        throw LocalRegion.lowMemoryException(null, numBytes);
+      }
     }
 
     final void accountMapOverhead(int oldCapacity) {
@@ -931,9 +933,11 @@ RETRYLOOP:
       // memory manager as this is the last step of a region operation.
       String regionPath = LocalRegion.regionPath.get();
       if (regionPath != null) {
-        CallbackFactoryProvider.getStoreCallbacks().acquireStorageMemory(regionPath,
-            oldCapacity * ReflectionSingleObjectSizer.REFERENCE_SIZE,
-            null, true, false);
+        long numBytes = oldCapacity * ReflectionSingleObjectSizer.REFERENCE_SIZE;
+        if (!CallbackFactoryProvider.getStoreCallbacks().acquireStorageMemory(
+            regionPath, numBytes, null, true, false)) {
+          throw LocalRegion.lowMemoryException(null, numBytes);
+        }
         LocalRegion.regionPath.remove();
       }
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
@@ -1473,7 +1473,7 @@ public final class GfxdSystemProcedureMessage extends
 
       @Override
       String getSQLStatement(Object[] params) throws StandardException {
-        return "CALL SYS.REPAIR_CATALOG(1)";
+        return "CALL SYS.REPAIR_CATALOG()";
       }
     },
     


### PR DESCRIPTION
## Changes proposed in this pull request

- remove the check for off-heap when setting Region and DiskId in SerializedDiskBuffer
- refactored out LowMemoryException as a separate public static method in LocalRegion
  for use by other layers

## Patch testing

store precheckin

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/960