### PR TITLE
[SNAP-2215] pass through only host-data flag separately to LauncherBase.setDefaultVMArgs

### DIFF
--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/LauncherBase.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/LauncherBase.java
@@ -220,7 +220,7 @@ public abstract class LauncherBase {
     vmArgs.add(vmArg);
   }
 
-  protected void setDefaultVMArgs(Map<String, Object> map, Map<?, ?> props,
+  protected void setDefaultVMArgs(Map<String, Object> map, boolean hostData,
       List<String> vmArgs) {
 
     // determine the total physical RAM
@@ -248,8 +248,6 @@ public abstract class LauncherBase {
         vmArgs.add("-Xmx" + this.initialHeapSize);
         this.maxHeapSize = this.initialHeapSize;
       } else {
-        final boolean hostData = !"false".equalsIgnoreCase(
-            (String)props.get(HOST_DATA));
         long defaultMemoryMB = getDefaultHeapSizeMB(hostData);
         if (defaultMemoryMB > 0 && totalMemory > 0L) {
           // Try some sane default for heapSize if none specified.

--- a/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/internal/GfxdServerLauncher.java
+++ b/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/internal/GfxdServerLauncher.java
@@ -618,7 +618,10 @@ public class GfxdServerLauncher extends CacheServerLauncher {
     }
 
     final ArrayList<String> vmArgs = new ArrayList<String>();
-    setDefaultVMArgs(map, (Properties)map.get(PROPERTIES), vmArgs);
+
+    final boolean hostData = !"false".equalsIgnoreCase(
+        (String)((Properties)map.get(PROPERTIES)).get(HOST_DATA));
+    setDefaultVMArgs(map, hostData, vmArgs);
     vmArgs.addAll(incomingVMArgs);
     processedDefaultGCParams = true;
 


### PR DESCRIPTION
## Changes proposed in this pull request

"map" and "props" properties sent have different conventions here: key->full arg, vs key->value
e.g. "host-data"->"-host-data=false" vs "host-data" -> "false" which are not treated differently
by SnappyData's QuickLauncher, so removing "props" argument and just pass host-data boolean required

## Patch testing

manual

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/964