### PR TITLE
[SNAP-2217] use a proper VTI for snappydata table stats

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -1680,6 +1680,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
     }
   }
 
+  /** Deprecated. To be removed in next release. */
   public static void GET_SNAPPY_TABLE_STATS(Blob[] statsMap) throws SQLException {
     try {
       if (GemFireXDUtils.TraceSysProcedures) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/SnappyTableStatsVTI.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/SnappyTableStatsVTI.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package com.pivotal.gemfirexd.internal.engine.diag;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Iterator;
+import java.util.List;
+
+import com.gemstone.gemfire.cache.execute.FunctionException;
+import com.pivotal.gemfirexd.internal.engine.GfxdVTITemplate;
+import com.pivotal.gemfirexd.internal.engine.GfxdVTITemplateNoAllNodesRoute;
+import com.pivotal.gemfirexd.internal.engine.Misc;
+import com.pivotal.gemfirexd.internal.engine.distributed.FunctionExecutionException;
+import com.pivotal.gemfirexd.internal.engine.distributed.GfxdSingleResultCollector;
+import com.pivotal.gemfirexd.internal.engine.distributed.message.LeadNodeGetStatsMessage;
+import com.pivotal.gemfirexd.internal.engine.jdbc.GemFireXDRuntimeException;
+import com.pivotal.gemfirexd.internal.engine.ui.SnappyRegionStats;
+import com.pivotal.gemfirexd.internal.iapi.error.PublicAPI;
+import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
+import com.pivotal.gemfirexd.internal.iapi.reference.SQLState;
+import com.pivotal.gemfirexd.internal.iapi.sql.ResultColumnDescriptor;
+import com.pivotal.gemfirexd.internal.impl.jdbc.EmbedResultSetMetaData;
+import com.pivotal.gemfirexd.internal.impl.jdbc.TransactionResourceImpl;
+import com.pivotal.gemfirexd.internal.impl.jdbc.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Virtual table for snappydata table statistics.
+ */
+public class SnappyTableStatsVTI extends GfxdVTITemplate
+    implements GfxdVTITemplateNoAllNodesRoute {
+
+  private final Logger logger = LoggerFactory.getLogger(getClass().getName());
+
+  private Iterator<?> tableStats;
+  private SnappyRegionStats currentTableStats;
+
+  @Override
+  public ResultSetMetaData getMetaData() throws SQLException {
+    return metadata;
+  }
+
+  @Override
+  public boolean next() throws SQLException {
+    if (this.tableStats == null) {
+      try {
+        if (logger.isDebugEnabled()) {
+          logger.debug("SnappyTableStatsVTI: getting table stats from lead " +
+              Misc.getLeadNode());
+        }
+        GfxdSingleResultCollector collector = new GfxdSingleResultCollector();
+        LeadNodeGetStatsMessage msg = new LeadNodeGetStatsMessage(collector);
+        this.tableStats = ((List<?>)msg.executeFunction()).iterator();
+      } catch (SQLException se) {
+        throw se;
+      } catch (StandardException se) {
+        throw PublicAPI.wrapStandardException(se);
+      } catch (RuntimeException re) {
+        String message;
+        if ((re instanceof FunctionException) ||
+            (re instanceof FunctionExecutionException) &&
+                re.getCause() != null) {
+          message = re.getCause().getMessage();
+        } else {
+          message = re.getMessage();
+        }
+        throw Util.newEmbedSQLException(SQLState.LANG_UNEXPECTED_USER_EXCEPTION,
+            new Object[] { message }, re);
+      } catch (Throwable t) {
+        throw TransactionResourceImpl.wrapInSQLException(t);
+      }
+    }
+    if (this.tableStats.hasNext()) {
+      this.currentTableStats = (SnappyRegionStats)this.tableStats.next();
+      this.wasNull = false;
+      if (logger.isDebugEnabled()) {
+        logger.debug("SnappyTableStatsVTI: read: " + this.currentTableStats);
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  protected Object getObjectForColumn(int columnNumber) throws SQLException {
+    switch (columnNumber) {
+      case 1: // TABLE
+        return this.currentTableStats.getTableName();
+      case 2: // IS_COLUMN_TABLE
+        return this.currentTableStats.isColumnTable();
+      case 3: // IS_REPLICATED_TABLE
+        return this.currentTableStats.isReplicatedTable();
+      case 4: // ROW_COUNT
+        return this.currentTableStats.getRowCount();
+      case 5: // SIZE_IN_MEMORY
+        return this.currentTableStats.getSizeInMemory();
+      case 6: // TOTAL_SIZE
+        return this.currentTableStats.getTotalSize();
+      default:
+        throw new GemFireXDRuntimeException("unexpected column=" +
+            columnNumber + " for SnappyTablesStatsVTI");
+    }
+  }
+
+  /**
+   * Metadata
+   */
+
+  private static final String TABLE = "TABLE";
+
+  private static final String IS_COLUMN_TABLE = "IS_COLUMN_TABLE";
+
+  private static final String IS_REPLICATED_TABLE = "IS_REPLICATED_TABLE";
+
+  private static final String ROW_COUNT = "ROW_COUNT";
+
+  private static final String SIZE_IN_MEMORY = "SIZE_IN_MEMORY";
+
+  private static final String TOTAL_SIZE = "TOTAL_SIZE";
+
+  private static final ResultColumnDescriptor[] columnInfo = {
+      EmbedResultSetMetaData.getResultColumnDescriptor(TABLE,
+          Types.VARCHAR, false, 512),
+      EmbedResultSetMetaData.getResultColumnDescriptor(IS_COLUMN_TABLE,
+          Types.BOOLEAN, false),
+      EmbedResultSetMetaData.getResultColumnDescriptor(IS_REPLICATED_TABLE,
+          Types.BOOLEAN, false),
+      EmbedResultSetMetaData.getResultColumnDescriptor(ROW_COUNT,
+          Types.BIGINT, false),
+      EmbedResultSetMetaData.getResultColumnDescriptor(SIZE_IN_MEMORY,
+          Types.BIGINT, false),
+      EmbedResultSetMetaData.getResultColumnDescriptor(TOTAL_SIZE,
+          Types.BIGINT, false)
+  };
+
+  private static final ResultSetMetaData metadata = new EmbedResultSetMetaData(
+      columnInfo);
+}

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStats.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStats.java
@@ -27,21 +27,22 @@ import com.gemstone.gemfire.DataSerializer;
 public class SnappyRegionStats implements DataSerializable {
 
   private boolean isColumnTable = false;
-  private String regionName;
+  private String tableName;
   private long rowCount = 0;
   private long sizeInMemory = 0;
   private long totalSize = 0;
   private Boolean isReplicatedTable = false;
 
-  public SnappyRegionStats() {}
-
-  public SnappyRegionStats(String regionName) {
-    this.regionName = regionName;
+  public SnappyRegionStats() {
   }
 
-  public SnappyRegionStats(String regionName, long totalSize, long sizeInMemory,
+  public SnappyRegionStats(String tableName) {
+    this.tableName = tableName;
+  }
+
+  public SnappyRegionStats(String tableName, long totalSize, long sizeInMemory,
       long rowCount, boolean isColumnTable, boolean isReplicatedTable) {
-    this.regionName = regionName;
+    this.tableName = tableName;
     this.totalSize = totalSize;
     this.sizeInMemory = sizeInMemory;
     this.rowCount = rowCount;
@@ -53,12 +54,12 @@ public class SnappyRegionStats implements DataSerializable {
     this.totalSize = totalSize;
   }
 
-  public String getRegionName() {
-    return regionName;
+  public String getTableName() {
+    return tableName;
   }
 
-  public void setRegionName(String regionName) {
-    this.regionName = regionName;
+  public void setTableName(String tableName) {
+    this.tableName = tableName;
   }
 
   public boolean isColumnTable() {
@@ -99,8 +100,8 @@ public class SnappyRegionStats implements DataSerializable {
   }
 
   public SnappyRegionStats getCombinedStats(SnappyRegionStats stats) {
-    String regionName = this.isColumnTable ? stats.regionName : this.regionName;
-    SnappyRegionStats combinedStats = new SnappyRegionStats(regionName);
+    String tableName = this.isColumnTable ? stats.tableName : this.tableName;
+    SnappyRegionStats combinedStats = new SnappyRegionStats(tableName);
 
     if (this.isReplicatedTable()) {
       combinedStats.setRowCount(stats.rowCount);
@@ -117,7 +118,7 @@ public class SnappyRegionStats implements DataSerializable {
 
   @Override
   public void toData(final DataOutput out) throws IOException {
-    DataSerializer.writeString(regionName, out);
+    DataSerializer.writeString(tableName, out);
     out.writeLong(totalSize);
     out.writeLong(sizeInMemory);
     out.writeLong(rowCount);
@@ -127,7 +128,7 @@ public class SnappyRegionStats implements DataSerializable {
 
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    this.regionName = DataSerializer.readString(in);
+    this.tableName = DataSerializer.readString(in);
     this.totalSize = in.readLong();
     this.sizeInMemory = in.readLong();
     this.rowCount = in.readLong();
@@ -137,7 +138,7 @@ public class SnappyRegionStats implements DataSerializable {
 
   @Override
   public String toString() {
-    return "RegionStats for " + regionName + ": totalSize=" + totalSize +
+    return "RegionStats for " + tableName + ": totalSize=" + totalSize +
         " sizeInMemory=" + sizeInMemory + " rowCount=" + rowCount +
         " isColumnTable=" + isColumnTable + " isReplicatedTable=" + isReplicatedTable;
   }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorFunction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorFunction.java
@@ -85,7 +85,7 @@ public class SnappyRegionStatsCollectorFunction implements Function, Declarable 
                 "/" + Misc.SNAPPY_HIVE_METASTORE + '/'))) {
               SnappyRegionStats dataCollector = collectDataFromBean(r, bean);
               if (dataCollector.isColumnTable()) {
-                cachBatchStats.put(dataCollector.getRegionName(), dataCollector);
+                cachBatchStats.put(dataCollector.getTableName(), dataCollector);
               } else {
                 otherStats.add(dataCollector);
               }
@@ -103,9 +103,9 @@ public class SnappyRegionStatsCollectorFunction implements Function, Declarable 
 
       if (Misc.reservoirRegionCreated) {
         for (SnappyRegionStats tableStats : otherStats) {
-          String rgnName = tableStats.getRegionName();
+          String rgnName = tableStats.getTableName();
           StoreCallbacks callback = CallbackFactoryProvider.getStoreCallbacks();
-          String columnBatchTableName = callback.columnBatchTableName(tableStats.getRegionName());
+          String columnBatchTableName = callback.columnBatchTableName(tableStats.getTableName());
           if (cachBatchStats.containsKey(columnBatchTableName)) {
             String reservoirRegionName = Misc.getReservoirRegionNameForSampleTable("APP", rgnName);
             PartitionedRegion pr = Misc.getReservoirRegionForSampleTable(reservoirRegionName);
@@ -124,7 +124,7 @@ public class SnappyRegionStatsCollectorFunction implements Function, Declarable 
       // Create one entry per Column Table by combining the results of row buffer and column table
       for (SnappyRegionStats tableStats : otherStats) {
         StoreCallbacks callback = CallbackFactoryProvider.getStoreCallbacks();
-        String columnBatchTableName = callback.columnBatchTableName(tableStats.getRegionName());
+        String columnBatchTableName = callback.columnBatchTableName(tableStats.getTableName());
         if (cachBatchStats.containsKey(columnBatchTableName)) {
           result.addRegionStat(tableStats.getCombinedStats(cachBatchStats.get(columnBatchTableName)));
         } else {
@@ -152,9 +152,9 @@ public class SnappyRegionStatsCollectorFunction implements Function, Declarable 
   }
 
   private SnappyRegionStats collectDataFromBeanImpl(LocalRegion lr, RegionMXBean bean, boolean isReservoir) {
-    String regionName = (Misc.getFullTableNameFromRegionPath(bean.getFullPath()));
+    String tableName = (Misc.getFullTableNameFromRegionPath(bean.getFullPath()));
     SnappyRegionStats tableStats =
-        new SnappyRegionStats(regionName);
+        new SnappyRegionStats(tableName);
     boolean isColumnTable = bean.isColumnTable();
     tableStats.setColumnTable(isColumnTable);
     tableStats.setReplicatedTable(isReplicatedTable(lr.getDataPolicy()));

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorResult.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorResult.java
@@ -19,16 +19,12 @@ package com.pivotal.gemfirexd.internal.engine.ui;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.gemstone.gemfire.DataSerializable;
-import com.gemstone.gemfire.internal.DataSerializableFixedID;
 import com.gemstone.gemfire.internal.InternalDataSerializer;
 import com.gemstone.gemfire.internal.shared.Version;
 import com.pivotal.gemfirexd.internal.engine.GfxdDataSerializable;
-import com.pivotal.gemfirexd.internal.engine.GfxdSerializable;
 
 public class SnappyRegionStatsCollectorResult extends GfxdDataSerializable {
   private transient List<SnappyRegionStats> combinedStats = new ArrayList<>();
@@ -69,7 +65,7 @@ public class SnappyRegionStatsCollectorResult extends GfxdDataSerializable {
   public void toData(final DataOutput out) throws IOException {
     out.writeInt(combinedStats.size());
     for (SnappyRegionStats stats : combinedStats) {
-      InternalDataSerializer.writeString(stats.getRegionName(), out);
+      InternalDataSerializer.writeString(stats.getTableName(), out);
       InternalDataSerializer.writeLong(stats.getTotalSize(), out);
       InternalDataSerializer.writeLong(stats.getSizeInMemory(), out);
       InternalDataSerializer.writeLong(stats.getRowCount(), out);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -2124,7 +2124,7 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
 
   public static final String DISKSTOREIDS_TABLENAME = "DISKSTOREIDS";
 
-  public static final String SNAPPY_TABLE_STATS = "SNAPPY_TABLE_STATS";
+  public static final String SNAPPY_TABLE_STATS = "TABLESTATS";
 
   private static final String[][] VTI_TABLE_CLASSES = {
       { DIAG_MEMBERS_TABLENAME,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -65,6 +65,7 @@ import com.pivotal.gemfirexd.internal.engine.diag.DiskStoreIDs;
 import com.pivotal.gemfirexd.internal.engine.diag.HdfsProcedures;
 import com.pivotal.gemfirexd.internal.engine.diag.HiveTablesVTI;
 import com.pivotal.gemfirexd.internal.engine.diag.JSONProcedures;
+import com.pivotal.gemfirexd.internal.engine.diag.SnappyTableStatsVTI;
 import com.pivotal.gemfirexd.internal.engine.diag.SortedCSVProcedures;
 import com.pivotal.gemfirexd.internal.engine.distributed.message.GfxdShutdownAllRequest;
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
@@ -2123,6 +2124,8 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
 
   public static final String DISKSTOREIDS_TABLENAME = "DISKSTOREIDS";
 
+  public static final String SNAPPY_TABLE_STATS = "SNAPPY_TABLE_STATS";
+
   private static final String[][] VTI_TABLE_CLASSES = {
       { DIAG_MEMBERS_TABLENAME,
           "com.pivotal.gemfirexd.internal.engine.diag.DistributedMembers" },
@@ -2144,6 +2147,7 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
           "com.pivotal.gemfirexd.internal.engine.diag.SessionsVTI" },
       { HIVETABLES_TABLENAME, HiveTablesVTI.class.getName() },
       { DISKSTOREIDS_TABLENAME, DiskStoreIDs.class.getName() },
+      { SNAPPY_TABLE_STATS, SnappyTableStatsVTI.class.getName() },
   };
 
   private final HashMap<String, TableDescriptor> diagVTIMap =


### PR DESCRIPTION
## Changes proposed in this pull request

- the VTI is both required when not using GUI and avoids unnecessary fragile blob data
  serialization in snappy thin stats service (old procedure is retained but deprecated)
- renamed SnappyRegionStats.regionName to tableName to reflect what it is

## Patch testing

precheckin and manual

## ReleaseNotes changes

Add information on the new VTI in docs @shyjaprabhu 

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/965