### PR TITLE
Misc fixes + adding BUCKETS column to TABLESTATS

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
@@ -85,7 +85,7 @@ public class CacheServerLauncher extends LauncherBase {
   protected PrintStream oldErr = System.err;
   protected LogWriterI18n logger = null;
   protected String offHeapSize;
-  protected String serverStartupMessage;
+  protected volatile String serverStartupMessage;
   protected final OpenHashSet<String> knownOptions;
 
   protected static CacheServerLauncher instance;
@@ -643,7 +643,9 @@ public class CacheServerLauncher extends LauncherBase {
         stat.dsMsg = null;
         stat.state = stateIfWaiting;
       } else if (stat.state == RUNNING) {
-        return;
+        if (stat.dsMsg != null) {
+          return;
+        }
       } else {
         stat.state = RUNNING;
       }

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/cache/Status.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/cache/Status.java
@@ -142,6 +142,7 @@ public class Status {
       writeString(exceptionStr, out);
       out.flush();
       stream.write(bos.toByteArray());
+      stream.flush();
     }
   }
 

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/LauncherBase.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/LauncherBase.java
@@ -131,7 +131,7 @@ public abstract class LauncherBase {
   protected final String pidFileName;
   protected final String statusName;
   protected final String hostName;
-  protected Status status;
+  protected volatile Status status;
 
   /**
    * wait for startup to complete, or exit once region GII wait begins

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/Version.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/Version.java
@@ -72,7 +72,7 @@ public final class Version implements Comparable<Version> {
 
   private static final Method getGFEClientCommands;
 
-  public static final int NUM_OF_VERSIONS = 33;
+  public static final int NUM_OF_VERSIONS = 34;
 
   private static final Version[] VALUES = new Version[NUM_OF_VERSIONS];
 
@@ -235,16 +235,19 @@ public final class Version implements Comparable<Version> {
 
   private static final byte GFXD_155_ORDINAL = 32;
 
-  /** GemFire version is at 7.1 for compatibility with external clusters. */
   public static final Version GFXD_155 = new Version("GFXD", "1.5.5",
       (byte)1, (byte)5, (byte)5, (byte)0, GFXD_155_ORDINAL, GFE_80);
 
+  private static final byte STORE_162_ORDINAL = 33;
+
+  public static final Version STORE_162 = new Version("STORE", "1.6.2",
+      (byte)1, (byte)6, (byte)2, (byte)0, STORE_162_ORDINAL, GFE_80);
 
 
   /**
-   * This constant must be set to the most current version of GFE/GFXD.
+   * This constant must be set to the most current version of GFE/GFXD/STORE.
    */
-  public static final Version CURRENT = GFXD_155;
+  public static final Version CURRENT = STORE_162;
   public static final Version CURRENT_GFE = CURRENT.getGemFireVersion();
 
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/SnappyTableStatsVTI.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/SnappyTableStatsVTI.java
@@ -139,7 +139,7 @@ public class SnappyTableStatsVTI extends GfxdVTITemplate
 
   private static final String TOTAL_SIZE = "TOTAL_SIZE";
 
-  private static final String NUM_BUCKETS = "NUM_BUCKETS";
+  private static final String BUCKETS = "BUCKETS";
 
   private static final ResultColumnDescriptor[] columnInfo = {
       EmbedResultSetMetaData.getResultColumnDescriptor(TABLE,
@@ -154,7 +154,7 @@ public class SnappyTableStatsVTI extends GfxdVTITemplate
           Types.BIGINT, false),
       EmbedResultSetMetaData.getResultColumnDescriptor(TOTAL_SIZE,
           Types.BIGINT, false),
-      EmbedResultSetMetaData.getResultColumnDescriptor(NUM_BUCKETS,
+      EmbedResultSetMetaData.getResultColumnDescriptor(BUCKETS,
           Types.INTEGER, false),
   };
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/SnappyTableStatsVTI.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/SnappyTableStatsVTI.java
@@ -115,6 +115,8 @@ public class SnappyTableStatsVTI extends GfxdVTITemplate
         return this.currentTableStats.getSizeInMemory();
       case 6: // TOTAL_SIZE
         return this.currentTableStats.getTotalSize();
+      case 7: // NUM_BUCKETS
+        return this.currentTableStats.getBucketCount();
       default:
         throw new GemFireXDRuntimeException("unexpected column=" +
             columnNumber + " for SnappyTablesStatsVTI");
@@ -137,6 +139,8 @@ public class SnappyTableStatsVTI extends GfxdVTITemplate
 
   private static final String TOTAL_SIZE = "TOTAL_SIZE";
 
+  private static final String NUM_BUCKETS = "NUM_BUCKETS";
+
   private static final ResultColumnDescriptor[] columnInfo = {
       EmbedResultSetMetaData.getResultColumnDescriptor(TABLE,
           Types.VARCHAR, false, 512),
@@ -149,7 +153,9 @@ public class SnappyTableStatsVTI extends GfxdVTITemplate
       EmbedResultSetMetaData.getResultColumnDescriptor(SIZE_IN_MEMORY,
           Types.BIGINT, false),
       EmbedResultSetMetaData.getResultColumnDescriptor(TOTAL_SIZE,
-          Types.BIGINT, false)
+          Types.BIGINT, false),
+      EmbedResultSetMetaData.getResultColumnDescriptor(NUM_BUCKETS,
+          Types.INTEGER, false),
   };
 
   private static final ResultSetMetaData metadata = new EmbedResultSetMetaData(

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStats.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStats.java
@@ -21,17 +21,19 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-import com.gemstone.gemfire.DataSerializable;
 import com.gemstone.gemfire.DataSerializer;
+import com.gemstone.gemfire.internal.VersionedDataSerializable;
+import com.gemstone.gemfire.internal.shared.Version;
 
-public class SnappyRegionStats implements DataSerializable {
+public class SnappyRegionStats implements VersionedDataSerializable {
 
   private boolean isColumnTable = false;
   private String tableName;
   private long rowCount = 0;
   private long sizeInMemory = 0;
   private long totalSize = 0;
-  private Boolean isReplicatedTable = false;
+  private boolean isReplicatedTable = false;
+  private int bucketCount;
 
   public SnappyRegionStats() {
   }
@@ -41,13 +43,15 @@ public class SnappyRegionStats implements DataSerializable {
   }
 
   public SnappyRegionStats(String tableName, long totalSize, long sizeInMemory,
-      long rowCount, boolean isColumnTable, boolean isReplicatedTable) {
+      long rowCount, boolean isColumnTable, boolean isReplicatedTable,
+      int bucketCount) {
     this.tableName = tableName;
     this.totalSize = totalSize;
     this.sizeInMemory = sizeInMemory;
     this.rowCount = rowCount;
     this.isColumnTable = isColumnTable;
     this.isReplicatedTable = isReplicatedTable;
+    this.bucketCount = bucketCount;
   }
 
   public void setTotalSize(long totalSize) {
@@ -99,6 +103,14 @@ public class SnappyRegionStats implements DataSerializable {
     return this.totalSize;
   }
 
+  public int getBucketCount() {
+    return this.bucketCount;
+  }
+
+  public void setBucketCount(int bucketCount) {
+    this.bucketCount = bucketCount;
+  }
+
   public SnappyRegionStats getCombinedStats(SnappyRegionStats stats) {
     String tableName = this.isColumnTable ? stats.tableName : this.tableName;
     SnappyRegionStats combinedStats = new SnappyRegionStats(tableName);
@@ -113,11 +125,18 @@ public class SnappyRegionStats implements DataSerializable {
     combinedStats.setTotalSize(stats.totalSize + this.totalSize);
     combinedStats.setColumnTable(this.isColumnTable || stats.isColumnTable);
     combinedStats.setReplicatedTable(this.isReplicatedTable());
+    combinedStats.setBucketCount(this.bucketCount);
     return combinedStats;
   }
 
+  private static Version[] serializationVersions = new Version[] { Version.GFXD_155 };
+
   @Override
-  public void toData(final DataOutput out) throws IOException {
+  public Version[] getSerializationVersions() {
+    return serializationVersions;
+  }
+
+  public void toDataPre_GFXD_1_5_5_0(final DataOutput out) throws IOException {
     DataSerializer.writeString(tableName, out);
     out.writeLong(totalSize);
     out.writeLong(sizeInMemory);
@@ -127,7 +146,12 @@ public class SnappyRegionStats implements DataSerializable {
   }
 
   @Override
-  public void fromData(DataInput in) throws IOException, ClassNotFoundException {
+  public void toData(final DataOutput out) throws IOException {
+    toDataPre_GFXD_1_5_5_0(out);
+    out.writeInt(bucketCount);
+  }
+
+  public void fromDataPre_GFXD_1_5_5_0(DataInput in) throws IOException {
     this.tableName = DataSerializer.readString(in);
     this.totalSize = in.readLong();
     this.sizeInMemory = in.readLong();
@@ -137,9 +161,16 @@ public class SnappyRegionStats implements DataSerializable {
   }
 
   @Override
+  public void fromData(DataInput in) throws IOException {
+    fromDataPre_GFXD_1_5_5_0(in);
+    this.bucketCount = in.readInt();
+  }
+
+  @Override
   public String toString() {
     return "RegionStats for " + tableName + ": totalSize=" + totalSize +
         " sizeInMemory=" + sizeInMemory + " rowCount=" + rowCount +
-        " isColumnTable=" + isColumnTable + " isReplicatedTable=" + isReplicatedTable;
+        " isColumnTable=" + isColumnTable + " isReplicatedTable=" +
+        isReplicatedTable + " bucketCount=" + bucketCount;
   }
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStats.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStats.java
@@ -129,14 +129,14 @@ public class SnappyRegionStats implements VersionedDataSerializable {
     return combinedStats;
   }
 
-  private static Version[] serializationVersions = new Version[] { Version.GFXD_155 };
+  private static Version[] serializationVersions = new Version[] { Version.STORE_162 };
 
   @Override
   public Version[] getSerializationVersions() {
     return serializationVersions;
   }
 
-  public void toDataPre_GFXD_1_5_5_0(final DataOutput out) throws IOException {
+  public void toDataPre_STORE_1_6_2_0(final DataOutput out) throws IOException {
     DataSerializer.writeString(tableName, out);
     out.writeLong(totalSize);
     out.writeLong(sizeInMemory);
@@ -147,11 +147,11 @@ public class SnappyRegionStats implements VersionedDataSerializable {
 
   @Override
   public void toData(final DataOutput out) throws IOException {
-    toDataPre_GFXD_1_5_5_0(out);
+    toDataPre_STORE_1_6_2_0(out);
     out.writeInt(bucketCount);
   }
 
-  public void fromDataPre_GFXD_1_5_5_0(DataInput in) throws IOException {
+  public void fromDataPre_STORE_1_6_2_0(DataInput in) throws IOException {
     this.tableName = DataSerializer.readString(in);
     this.totalSize = in.readLong();
     this.sizeInMemory = in.readLong();
@@ -162,7 +162,7 @@ public class SnappyRegionStats implements VersionedDataSerializable {
 
   @Override
   public void fromData(DataInput in) throws IOException {
-    fromDataPre_GFXD_1_5_5_0(in);
+    fromDataPre_STORE_1_6_2_0(in);
     this.bucketCount = in.readInt();
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorFunction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorFunction.java
@@ -158,6 +158,11 @@ public class SnappyRegionStatsCollectorFunction implements Function, Declarable 
     boolean isColumnTable = bean.isColumnTable();
     tableStats.setColumnTable(isColumnTable);
     tableStats.setReplicatedTable(isReplicatedTable(lr.getDataPolicy()));
+    if (tableStats.isReplicatedTable()) {
+      tableStats.setBucketCount(1);
+    } else {
+      tableStats.setBucketCount(lr.getPartitionAttributes().getTotalNumBuckets());
+    }
     if (isReservoir) {
       long numLocalEntries = bean.getRowsInReservoir();
       tableStats.setRowCount(numLocalEntries);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorResult.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorResult.java
@@ -60,18 +60,18 @@ public class SnappyRegionStatsCollectorResult extends GfxdDataSerializable {
   }
 
   private static Version[] serializationVersions =
-      new Version[] { Version.GFXD_155 };
+      new Version[] { Version.STORE_162 };
 
   @Override
   public Version[] getSerializationVersions() {
     return serializationVersions;
   }
 
-  private void toData(final DataOutput out, boolean use155) throws IOException {
+  private void toData(final DataOutput out, boolean pre162) throws IOException {
     out.writeInt(combinedStats.size());
     for (SnappyRegionStats stats : combinedStats) {
-      if (use155) {
-        stats.toDataPre_GFXD_1_5_5_0(out);
+      if (pre162) {
+        stats.toDataPre_STORE_1_6_2_0(out);
       } else {
         stats.toData(out);
       }
@@ -84,7 +84,7 @@ public class SnappyRegionStatsCollectorResult extends GfxdDataSerializable {
     }
   }
 
-  public void toDataPre_GFXD_1_5_5_0(final DataOutput out) throws IOException {
+  public void toDataPre_STORE_1_6_2_0(final DataOutput out) throws IOException {
     toData(out, true);
   }
 
@@ -93,13 +93,13 @@ public class SnappyRegionStatsCollectorResult extends GfxdDataSerializable {
     toData(out, false);
   }
 
-  private void fromData(DataInput in, boolean use155) throws IOException {
+  private void fromData(DataInput in, boolean pre162) throws IOException {
     int size = in.readInt();
     while (size > 0) {
       size--;
       SnappyRegionStats stats = new SnappyRegionStats();
-      if (use155) {
-        stats.fromDataPre_GFXD_1_5_5_0(in);
+      if (pre162) {
+        stats.fromDataPre_STORE_1_6_2_0(in);
       } else {
         stats.fromData(in);
       }
@@ -115,7 +115,7 @@ public class SnappyRegionStatsCollectorResult extends GfxdDataSerializable {
     }
   }
 
-  public void fromDataPre_GFXD_1_5_5_0(DataInput in) throws IOException {
+  public void fromDataPre_STORE_1_6_2_0(DataInput in) throws IOException {
     fromData(in, true);
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorResult.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorResult.java
@@ -34,9 +34,11 @@ public class SnappyRegionStatsCollectorResult extends GfxdDataSerializable {
   public void addRegionStat(SnappyRegionStats stats) {
     combinedStats.add(stats);
   }
+
   public void addIndexStat(SnappyIndexStats stats) {
     indexStats.add(stats);
   }
+
   public void addAllIndexStat(List<SnappyIndexStats> stats) {
     indexStats.addAll(stats);
   }
@@ -47,6 +49,7 @@ public class SnappyRegionStatsCollectorResult extends GfxdDataSerializable {
   public List<SnappyRegionStats> getRegionStats() {
     return combinedStats;
   }
+
   public List<SnappyIndexStats> getIndexStats() {
     return indexStats;
   }
@@ -56,21 +59,22 @@ public class SnappyRegionStatsCollectorResult extends GfxdDataSerializable {
     return SNAPPY_REGION_STATS_RESULT;
   }
 
-  @Override
-  public Version[] getSerializationVersions() {
-    return null;
-  }
+  private static Version[] serializationVersions =
+      new Version[] { Version.GFXD_155 };
 
   @Override
-  public void toData(final DataOutput out) throws IOException {
+  public Version[] getSerializationVersions() {
+    return serializationVersions;
+  }
+
+  private void toData(final DataOutput out, boolean pre155) throws IOException {
     out.writeInt(combinedStats.size());
     for (SnappyRegionStats stats : combinedStats) {
-      InternalDataSerializer.writeString(stats.getTableName(), out);
-      InternalDataSerializer.writeLong(stats.getTotalSize(), out);
-      InternalDataSerializer.writeLong(stats.getSizeInMemory(), out);
-      InternalDataSerializer.writeLong(stats.getRowCount(), out);
-      InternalDataSerializer.writeBoolean(stats.isColumnTable(), out);
-      InternalDataSerializer.writeBoolean(stats.isReplicatedTable(), out);
+      if (pre155) {
+        stats.toDataPre_GFXD_1_5_5_0(out);
+      } else {
+        stats.toData(out);
+      }
     }
     out.writeInt(indexStats.size());
     for (SnappyIndexStats stats : indexStats) {
@@ -80,18 +84,26 @@ public class SnappyRegionStatsCollectorResult extends GfxdDataSerializable {
     }
   }
 
+  public void toDataPre_GFXD_1_5_5_0(final DataOutput out) throws IOException {
+    toData(out, true);
+  }
+
   @Override
-  public void fromData(DataInput in) throws IOException {
+  public void toData(final DataOutput out) throws IOException {
+    toData(out, false);
+  }
+
+  private void fromData(DataInput in, boolean pre155) throws IOException {
     int size = in.readInt();
     while (size > 0) {
       size--;
-      String regionName = InternalDataSerializer.readString(in);
-      long totalSize = InternalDataSerializer.readLong(in);
-      long memorySize = InternalDataSerializer.readLong(in);
-      long count = InternalDataSerializer.readLong(in);
-      boolean isColumnTable = InternalDataSerializer.readBoolean(in);
-      boolean isReplicated = InternalDataSerializer.readBoolean(in);
-      addRegionStat(new SnappyRegionStats(regionName, totalSize, memorySize, count, isColumnTable, isReplicated));
+      SnappyRegionStats stats = new SnappyRegionStats();
+      if (pre155) {
+        stats.fromDataPre_GFXD_1_5_5_0(in);
+      } else {
+        stats.fromData(in);
+      }
+      addRegionStat(stats);
     }
     int numIndex = in.readInt();
     while (numIndex > 0) {
@@ -103,4 +115,12 @@ public class SnappyRegionStatsCollectorResult extends GfxdDataSerializable {
     }
   }
 
+  public void fromDataPre_GFXD_1_5_5_0(DataInput in) throws IOException {
+    fromData(in, true);
+  }
+
+  @Override
+  public void fromData(DataInput in) throws IOException {
+    fromData(in, false);
+  }
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorResult.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorResult.java
@@ -67,10 +67,10 @@ public class SnappyRegionStatsCollectorResult extends GfxdDataSerializable {
     return serializationVersions;
   }
 
-  private void toData(final DataOutput out, boolean pre155) throws IOException {
+  private void toData(final DataOutput out, boolean use155) throws IOException {
     out.writeInt(combinedStats.size());
     for (SnappyRegionStats stats : combinedStats) {
-      if (pre155) {
+      if (use155) {
         stats.toDataPre_GFXD_1_5_5_0(out);
       } else {
         stats.toData(out);
@@ -93,12 +93,12 @@ public class SnappyRegionStatsCollectorResult extends GfxdDataSerializable {
     toData(out, false);
   }
 
-  private void fromData(DataInput in, boolean pre155) throws IOException {
+  private void fromData(DataInput in, boolean use155) throws IOException {
     int size = in.readInt();
     while (size > 0) {
       size--;
       SnappyRegionStats stats = new SnappyRegionStats();
-      if (pre155) {
+      if (use155) {
         stats.fromDataPre_GFXD_1_5_5_0(in);
       } else {
         stats.fromData(in);

--- a/gemfirexd/core/src/main/resources/com/pivotal/gemfirexd/internal/loc/messages.xml
+++ b/gemfirexd/core/src/main/resources/com/pivotal/gemfirexd/internal/loc/messages.xml
@@ -1303,7 +1303,8 @@ Guide.
 
             <msg>
                 <name>42000</name>
-                <text>Syntax error or access rule violation; see additional errors for details.</text>
+                <text>Syntax error or analysis exception: {0}</text>
+                <arg>error</arg>
             </msg>
 
             <msg>

--- a/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/shared/common/reference/SQLState.java
+++ b/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/shared/common/reference/SQLState.java
@@ -778,7 +778,7 @@ public interface SQLState {
 	String EXTERNAL_ROUTINE_NO_READS_SQL							   = "38004";
 
 	String LANG_NULL_TO_PRIMITIVE_PARAMETER                            = "39004";
-	String LANG_SYNTAX_OR_ACCESS_VIOLATION                             = "42000";
+	String LANG_SYNTAX_OR_ANALYSIS_EXCEPTION                           = "42000";
 
 	// Fix for Derby-1828 - access rule violations should use SQL state 42
 	String AUTH_NO_TABLE_PERMISSION                                    = "42500";


### PR DESCRIPTION
## Changes proposed in this pull request

- correct occasional cases of node start output missing member, network/job server info:
  - skip setting RUNNING status again only if previously there was some extra "dsMsg" output
  - make few fields volatile
- updated stats messages to include bucket count and added new Version for backward compatibility;
  added "BUCKETS" column to the SYS.TABLESTATS VTI using the same
- better detection of syntax errors in Spark to convert to SQLException having proper SQLState;
  use SQLState "42000" for AnalysisException instead of the overly generic "38000"
- last two changes also help avoid dumping of full stack traces in server logs in case of
  syntax/analysis exceptions since SQLStates with prefix "42" are ignored for stack trace dumps

## Patch testing

precheckin and manual

## ReleaseNotes changes

Update TABLESTATS doc

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/969