### PR TITLE
[SNAP-2243][SNAP-2188] procedure for smart connector iteration and fixes

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskRegion.java
@@ -42,6 +42,7 @@ import com.gemstone.gemfire.internal.cache.versions.VersionSource;
 import com.gemstone.gemfire.internal.cache.versions.VersionTag;
 import com.gemstone.gemfire.internal.concurrent.CustomEntryConcurrentHashMap;
 import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
+import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
 import joptsimple.internal.Strings;
 
 /**
@@ -279,6 +280,14 @@ public abstract class AbstractDiskRegion implements DiskRegionView {
 
   public final DiskStoreImpl getDiskStore() {
     return this.ds;
+  }
+
+  public boolean isInternalColumnTable() {
+    if (isBucket) {
+      return getName().contains(StoreCallbacks.SHADOW_TABLE_BUCKET_TAG);
+    } else {
+      return getName().endsWith(StoreCallbacks.SHADOW_TABLE_SUFFIX);
+    }
   }
 
   abstract void beginDestroyRegion(LocalRegion region);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskRegionEntry.java
@@ -18,7 +18,6 @@ package com.gemstone.gemfire.internal.cache;
 
 import com.gemstone.gemfire.cache.hdfs.internal.AbstractBucketRegionQueue;
 import com.gemstone.gemfire.cache.query.internal.IndexUpdater;
-import com.gemstone.gemfire.internal.cache.store.SerializedDiskBuffer;
 import com.gemstone.gemfire.internal.cache.wan.GatewaySenderEventImpl;
 import com.gemstone.gemfire.internal.cache.wan.serial.SerialGatewaySenderQueue;
 
@@ -72,13 +71,8 @@ public abstract class AbstractDiskRegionEntry
    * Set the RegionEntry DiskId into SerializedDiskBuffer value, if present,
    * so that the value can access data from disk when required independently.
    */
-  protected final void initDiskIdForOffHeap(RegionEntryContext context,
-      Object value) {
-    // copy DiskId to value if required
-    if (value instanceof SerializedDiskBuffer) {
-      ((SerializedDiskBuffer)value).setDiskLocation(getDiskId(), context);
-    }
-  }
+  protected abstract void initDiskIdForOffHeap(RegionEntryContext context,
+      Object value);
 
   @Override
   public void handleValueOverflow(RegionEntryContext context) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
@@ -21,6 +21,7 @@ package com.gemstone.gemfire.internal.cache;
 import com.gemstone.gemfire.cache.EntryEvent;
 import com.gemstone.gemfire.cache.EntryNotFoundException;
 import com.gemstone.gemfire.distributed.internal.DM;
+import com.gemstone.gemfire.internal.cache.store.SerializedDiskBuffer;
 import com.gemstone.gemfire.internal.cache.versions.VersionTag;
 import com.gemstone.gemfire.internal.offheap.annotations.Retained;
 import com.gemstone.gemfire.internal.shared.Version;
@@ -53,6 +54,15 @@ public abstract class AbstractOplogDiskRegionEntry
   /////////////////////////////////////////////////////////////////////
 
   protected abstract void setDiskId(RegionEntry oldRe);
+
+  @Override
+  protected final void initDiskIdForOffHeap(RegionEntryContext context,
+      Object value) {
+    // copy DiskId to value if required
+    if (value instanceof SerializedDiskBuffer) {
+      ((SerializedDiskBuffer)value).setDiskEntry(this, context);
+    }
+  }
 
   public final void setDiskIdForRegion(RegionEntry oldRe) {
     setDiskId(oldRe);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
@@ -58,7 +58,7 @@ public abstract class AbstractOplogDiskRegionEntry
   @Override
   protected final void initDiskIdForOffHeap(RegionEntryContext context,
       Object value) {
-    // copy DiskId to value if required
+    // copy self to value if required
     if (value instanceof SerializedDiskBuffer) {
       ((SerializedDiskBuffer)value).setDiskEntry(this, context);
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -3374,9 +3374,14 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   }
 
   @Override
+  public boolean isInternalColumnTable() {
+    return getPartitionedRegion().isInternalColumnTable();
+  }
+
+  @Override
   public boolean isSnapshotEnabledRegion() {
     // concurrency checks is by default true in column table
-    return getPartitionedRegion().columnTable() ||
+    return getPartitionedRegion().isInternalColumnTable() ||
         getPartitionedRegion().needsBatching() || super.isSnapshotEnabledRegion();
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CachePerfStats.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CachePerfStats.java
@@ -171,6 +171,7 @@ public class CachePerfStats implements HashingStats {
   protected static final int compressionSkippedId;
   protected static final int compressionSkippedTimeId;
   protected static final int compressionSkippedBytesId;
+  protected static final int compressionDecompressedReplacedId;
   protected static final int compressionDecompressedReplaceSkippedId;
   protected static final int compressionCompressedReplaceSkippedId;
 
@@ -297,6 +298,8 @@ public class CachePerfStats implements HashingStats {
     final String compressionSkippedDesc = "The total number of compressions skipped (due to < 25% reduction).";
     final String compressionSkippedTimeDesc = "The total time spent in compressions that were skipped.";
     final String compressionSkippedBytesDesc = "The total number bytes skipped in compression.";
+    final String compressionDecompressedReplacedDesc = "The total number times storage " +
+        "replaced buffer after decompression.";
     final String compressionDecompressedReplaceSkippedDesc = "The total number times storage " +
         "skipped replacing buffer after decompression due to active usage.";
     final String compressionCompressedReplaceSkippedDesc = "The total number times storage " +
@@ -444,6 +447,8 @@ public class CachePerfStats implements HashingStats {
             compressionSkippedTimeDesc, "nanoseconds"),
         f.createLongCounter("compressSkippedBytes",
             compressionSkippedBytesDesc, "bytes"),
+        f.createLongCounter("decompressedReplaced",
+            compressionDecompressedReplacedDesc, "operations"),
         f.createLongCounter("decompressedReplaceSkipped",
             compressionDecompressedReplaceSkippedDesc, "operations"),
         f.createLongCounter("compressedReplaceSkipped",
@@ -590,6 +595,7 @@ public class CachePerfStats implements HashingStats {
     compressionSkippedId = type.nameToId("compressionsSkipped");
     compressionSkippedTimeId = type.nameToId("compressSkippedTime");
     compressionSkippedBytesId = type.nameToId("compressSkippedBytes");
+    compressionDecompressedReplacedId = type.nameToId("decompressedReplaced");
     compressionDecompressedReplaceSkippedId = type.nameToId("decompressedReplaceSkipped");
     compressionCompressedReplaceSkippedId = type.nameToId("compressedReplaceSkipped");
 
@@ -857,6 +863,10 @@ public class CachePerfStats implements HashingStats {
      }
      stats.incLong(compressionSkippedId, 1);
      stats.incLong(compressionSkippedBytesId, startSize);
+   }
+
+   public void incDecompressedReplaced() {
+     stats.incLong(compressionDecompressedReplacedId, 1);
    }
 
    public void incDecompressedReplaceSkipped() {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskEntry.java
@@ -71,6 +71,7 @@ import com.gemstone.gemfire.internal.offheap.annotations.Released;
 import com.gemstone.gemfire.internal.offheap.annotations.Retained;
 import com.gemstone.gemfire.internal.offheap.annotations.Unretained;
 import com.gemstone.gemfire.internal.shared.ClientSharedData;
+import com.gemstone.gemfire.internal.shared.FetchRequest;
 import com.gemstone.gemfire.internal.shared.OutputStreamChannel;
 import com.gemstone.gemfire.internal.shared.Version;
 import com.gemstone.gemfire.internal.snappy.CallbackFactoryProvider;
@@ -1058,7 +1059,7 @@ public interface DiskEntry extends RegionEntry {
       @Retained Object v = entry._getValueRetain(context, true);
       if (rawValue && GemFireCacheImpl.hasNewOffHeap() &&
           (v instanceof SerializedDiskBuffer)) {
-        ((SerializedDiskBuffer)v).retain();
+        return ((SerializedDiskBuffer)v).getValueRetain(FetchRequest.ORIGINAL);
       }
       return v;
     }
@@ -1515,10 +1516,6 @@ public interface DiskEntry extends RegionEntry {
       if (did == null) {
         ((AbstractDiskLRURegionEntry)entry).setDelayedDiskId(region);
         did = entry.getDiskId();
-        final Object oldValue;
-        if ((oldValue = entry._getValue()) instanceof SerializedDiskBuffer) {
-          ((SerializedDiskBuffer)oldValue).setDiskLocation(did, region);
-        }
         // add DiskId overhead to change
         diskIDOverhead += region.calculateDiskIdOverhead(did);
       }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DummyCachePerfStats.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DummyCachePerfStats.java
@@ -336,6 +336,10 @@ public class DummyCachePerfStats extends CachePerfStats {
   }
 
   @Override
+  public void incDecompressedReplaced() {
+  }
+
+  @Override
   public void incDecompressedReplaceSkipped() {
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -13552,6 +13552,12 @@ public class LocalRegion extends AbstractRegion
     }
 
     @Override
+    public void incDecompressedReplaced() {
+      stats.incLong(compressionDecompressedReplacedId, 1);
+      cachePerfStats.stats.incLong(compressionDecompressedReplacedId, 1);
+    }
+
+    @Override
     public void incDecompressedReplaceSkipped() {
       stats.incLong(compressionDecompressedReplaceSkippedId, 1);
       cachePerfStats.stats.incLong(compressionDecompressedReplaceSkippedId, 1);
@@ -14528,9 +14534,10 @@ public class LocalRegion extends AbstractRegion
   public static LowMemoryException lowMemoryException(GemFireCacheImpl cache,
       long size) {
     if (cache == null) {
-      cache = GemFireCacheImpl.getExisting();
+      cache = GemFireCacheImpl.getInstance();
     }
-    Set<DistributedMember> sm = Collections.singleton(cache.getMyId());
+    Set<DistributedMember> sm = cache != null
+        ? Collections.singleton(cache.getMyId()) : Collections.emptySet();
     return new LowMemoryException("Could not obtain memory of size " + size, sm);
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -2309,7 +2309,7 @@ public class LocalRegion extends AbstractRegion
 
       // Rahul: this has to be an update.
       // so executing it as an update.
-      boolean forceUpdateForDelta = event.hasDelta();
+      boolean forceUpdateForDelta = event.hasDelta() && !isInternalColumnTable();
       // Gfxd Changes end.
       if (basicPut(event, false, // ifNew
           forceUpdateForDelta, // ifOld
@@ -14613,6 +14613,7 @@ public class LocalRegion extends AbstractRegion
     }
   }
 
+  @Override
   public boolean isInternalColumnTable() {
     return isInternalColumnTable;
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
@@ -7345,6 +7345,7 @@ public class PartitionedRegion extends LocalRegion implements
                 }
               }
               // no more buckets need to be visited
+              close();
               this.bucketEntriesIter = null;
               this.moveNext = false;
               return false;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
@@ -2523,7 +2523,6 @@ public class PartitionedRegion extends LocalRegion implements
 
 
   private volatile Boolean columnBatching;
-  private volatile Boolean columnStoreTable;
   public boolean needsBatching() {
     final Boolean columnBatching = this.columnBatching;
     if (columnBatching != null) {
@@ -2543,22 +2542,6 @@ public class PartitionedRegion extends LocalRegion implements
       this.columnBatching = needsBatching;
       return needsBatching;
     }
-  }
-
-  public boolean columnTable() {
-    final Boolean columnTable = this.columnStoreTable;
-    if (columnTable != null) {
-      return columnTable;
-    }
-    // Find all the child region and see if they anyone of them has name ending
-    // with _SHADOW_
-    if (this.getName().toUpperCase().endsWith(StoreCallbacks.SHADOW_TABLE_SUFFIX)) {
-      this.columnStoreTable = true;
-      return true;
-    } else {
-      this.columnStoreTable = false;
-    }
-    return false;
   }
 
   private void handleSendOrWaitException(Exception ex,

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateProxy.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateProxy.java
@@ -3345,6 +3345,11 @@ public class TXStateProxy extends NonReentrantReadWriteLock implements
     if (state == State.OPEN || state == State.COMMIT_PHASE2_STARTED) {
       return;
     }
+    if (state == State.ROLLBACK_STARTED) {
+      throw new IllegalTransactionStateException(LocalizedStrings
+          .TransactionManagerImpl_TRANSACTIONMANAGERIMPL_COMMIT_TRANSACTION_ROLLED_BACK_BECAUSE_A_USER_MARKED_IT_FOR_ROLLBACK
+          .toLocalizedString());
+    }
     if (state == State.CLOSED) {
       throw new IllegalTransactionStateException(LocalizedStrings
           .TXManagerImpl_THREAD_DOES_NOT_HAVE_AN_ACTIVE_TRANSACTION

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/DiskRecoveryStore.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/DiskRecoveryStore.java
@@ -60,4 +60,5 @@ public interface DiskRecoveryStore {
   public long getVersionForMember(VersionSource member);
   public void setRVVTrusted(boolean rvvTrusted);
   public DiskStoreImpl getDiskStore();
+  public boolean isInternalColumnTable();
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/store/SerializedDiskBuffer.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/store/SerializedDiskBuffer.java
@@ -20,11 +20,12 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import javax.annotation.concurrent.GuardedBy;
 
-import com.gemstone.gemfire.internal.cache.DiskId;
+import com.gemstone.gemfire.internal.cache.AbstractOplogDiskRegionEntry;
 import com.gemstone.gemfire.internal.cache.RegionEntryContext;
 import com.gemstone.gemfire.internal.shared.BufferAllocator;
 import com.gemstone.gemfire.internal.shared.ByteBufferReference;
 import com.gemstone.gemfire.internal.shared.ClientSharedUtils;
+import com.gemstone.gemfire.internal.shared.FetchRequest;
 import com.gemstone.gemfire.internal.shared.OutputStreamChannel;
 
 /**
@@ -135,11 +136,7 @@ public abstract class SerializedDiskBuffer extends ByteBufferReference {
   }
 
   @Override
-  public SerializedDiskBuffer getValueRetain(boolean decompress,
-      boolean compress) throws IllegalArgumentException {
-    if (decompress && compress) {
-      throw new IllegalArgumentException("both decompress and compress true");
-    }
+  public SerializedDiskBuffer getValueRetain(FetchRequest fetchRequest) {
     return retain() ? this : null;
   }
 
@@ -148,7 +145,8 @@ public abstract class SerializedDiskBuffer extends ByteBufferReference {
   /**
    * For buffers which are stored in region, set its DiskId.
    */
-  public void setDiskLocation(DiskId id, RegionEntryContext context) {
+  public void setDiskEntry(AbstractOplogDiskRegionEntry entry,
+      RegionEntryContext context) {
   }
 
   /**

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
@@ -83,7 +83,7 @@ public abstract class CallbackFactoryProvider {
 
     @Override
     public CloseableIterator<ColumnTableEntry> columnTableScan(
-        String columnTable, int[] projection, byte[] serializedBatchFilters,
+        String columnTable, int[] projection, byte[] serializedFilters,
         Set<Integer> bucketIds) throws SQLException {
       throw new UnsupportedOperationException("unexpected invocation for "
           + toString());

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
@@ -17,6 +17,7 @@
 
 package com.gemstone.gemfire.internal.snappy;
 
+import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -24,6 +25,7 @@ import java.util.Set;
 import com.gemstone.gemfire.internal.cache.BucketRegion;
 import com.gemstone.gemfire.internal.cache.EntryEventImpl;
 import com.gemstone.gemfire.internal.cache.lru.LRUEntry;
+import com.gemstone.gemfire.internal.cache.persistence.query.CloseableIterator;
 import com.gemstone.gemfire.internal.snappy.memory.MemoryManagerStats;
 
 public abstract class CallbackFactoryProvider {
@@ -75,6 +77,14 @@ public abstract class CallbackFactoryProvider {
 
     @Override
     public String columnBatchTableName(String tableName) {
+      throw new UnsupportedOperationException("unexpected invocation for "
+          + toString());
+    }
+
+    @Override
+    public CloseableIterator<ColumnTableEntry> columnTableScan(
+        String columnTable, int[] projection, byte[] serializedBatchFilters,
+        Set<Integer> bucketIds) throws SQLException {
       throw new UnsupportedOperationException("unexpected invocation for "
           + toString());
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
@@ -182,6 +182,10 @@ public abstract class CallbackFactoryProvider {
     @Override
     public void initMemoryStats(MemoryManagerStats stats) {
     }
+
+    @Override
+    public void clearConnectionPools() {
+    }
   };
 
   public static void setStoreCallbacks(StoreCallbacks cb) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/ColumnTableEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/ColumnTableEntry.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.gemstone.gemfire.internal.snappy;
+
+import com.gemstone.gemfire.internal.shared.ByteBufferReference;
+
+/**
+ * Encapsulates a row read from column store.
+ */
+public final class ColumnTableEntry {
+  public final long uuid;
+  public final int bucketId;
+  public final int columnPosition;
+  public final ByteBufferReference columnValue;
+
+  public ColumnTableEntry(long uuid, int bucketId, int columnPosition,
+      ByteBufferReference columnValue) {
+    this.uuid = uuid;
+    this.bucketId = bucketId;
+    this.columnPosition = columnPosition;
+    this.columnValue = columnValue;
+  }
+}

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
@@ -56,7 +56,7 @@ public interface StoreCallbacks {
    * will have reference count incremented, so caller should decrement once done.
    */
   CloseableIterator<ColumnTableEntry> columnTableScan(String qualifiedTable,
-      int[] projection, byte[] serializedBatchFilters,
+      int[] projection, byte[] serializedFilters,
       Set<Integer> bucketIds) throws SQLException;
 
   void registerRelationDestroyForHiveStore();

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
@@ -32,6 +32,8 @@ public interface StoreCallbacks {
 
   String SHADOW_TABLE_SUFFIX = SystemProperties.SHADOW_TABLE_SUFFIX;
 
+  String SHADOW_TABLE_BUCKET_TAG = SHADOW_TABLE_SUFFIX.replace("_", "__");
+
   void registerTypes();
 
   Set<Object> createColumnBatch(BucketRegion region, long batchID,
@@ -121,4 +123,10 @@ public interface StoreCallbacks {
    * Initializes different memory manager related stats
    */
   void initMemoryStats(MemoryManagerStats stats);
+
+  /**
+   * Clear any existing connection pools (forced in case of major
+   * authentication service changes, for example).
+   */
+  void clearConnectionPools();
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
@@ -17,12 +17,14 @@
 
 package com.gemstone.gemfire.internal.snappy;
 
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Set;
 
 import com.gemstone.gemfire.internal.cache.BucketRegion;
 import com.gemstone.gemfire.internal.cache.EntryEventImpl;
 import com.gemstone.gemfire.internal.cache.lru.LRUEntry;
+import com.gemstone.gemfire.internal.cache.persistence.query.CloseableIterator;
 import com.gemstone.gemfire.internal.shared.SystemProperties;
 import com.gemstone.gemfire.internal.snappy.memory.MemoryManagerStats;
 
@@ -48,6 +50,14 @@ public interface StoreCallbacks {
   int getHashCodeSnappy(Object dvds[], int numPartitions);
 
   String columnBatchTableName(String tableName);
+
+  /**
+   * Scan the entries of a column table. The returned value in ColumnTableEntry
+   * will have reference count incremented, so caller should decrement once done.
+   */
+  CloseableIterator<ColumnTableEntry> columnTableScan(String qualifiedTable,
+      int[] projection, byte[] serializedBatchFilters,
+      Set<Integer> bucketIds) throws SQLException;
 
   void registerRelationDestroyForHiveStore();
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/util/BlobHelper.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/util/BlobHelper.java
@@ -42,13 +42,14 @@ import com.gemstone.gemfire.DataSerializer;
 import com.gemstone.gemfire.distributed.internal.DMStats;
 import com.gemstone.gemfire.distributed.internal.InternalDistributedSystem;
 import com.gemstone.gemfire.internal.ByteArrayDataInput;
-import com.gemstone.gemfire.internal.DSCODE;
 import com.gemstone.gemfire.internal.ByteBufferDataInput;
 import com.gemstone.gemfire.internal.ByteBufferDataOutput;
+import com.gemstone.gemfire.internal.DSCODE;
 import com.gemstone.gemfire.internal.HeapDataOutputStream;
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl.StaticSystemCallbacks;
 import com.gemstone.gemfire.internal.cache.store.SerializedDiskBuffer;
+import com.gemstone.gemfire.internal.shared.FetchRequest;
 import com.gemstone.gemfire.internal.shared.Version;
 import com.gemstone.gemfire.pdx.internal.PdxInputStream;
 
@@ -110,7 +111,8 @@ public class BlobHelper {
     SerializedDiskBuffer result;
     if (!(obj instanceof SerializedDiskBuffer) ||
         // compress buffer if possible to reduce disk size
-        (result = ((SerializedDiskBuffer)obj).getValueRetain(false, true)) == null) {
+        (result = ((SerializedDiskBuffer)obj).getValueRetain(
+            FetchRequest.COMPRESS)) == null) {
       // serialize into an expanding direct ByteBuffer
       result = new ByteBufferDataOutput(version).serialize(obj);
     }

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/ByteBufferReference.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/ByteBufferReference.java
@@ -47,7 +47,7 @@ public abstract class ByteBufferReference {
 
   /**
    * Return the data as a ByteBuffer. Should be invoked only after a
-   * {@link #retain()} or {@link #getValueRetain(boolean, boolean)} call.
+   * {@link #retain()} or {@link #getValueRetain} call.
    */
   public abstract ByteBuffer getBuffer();
 
@@ -55,17 +55,11 @@ public abstract class ByteBufferReference {
    * Get a compressed/decompressed/original version of the underlying value
    * after a {@link #retain()}
    *
-   * @param decompress decompress the underlying data and return a new value
-   *                   if compressed
-   * @param compress   compress the underlying data and return a new value
-   *                   if decompressed
+   * @param fetchRequest one of the {@link FetchRequest} values
    *
-   * @return a decompressed version of data if compressed when decompress is true
-   * or vice-versa if compress is true or else return as is if both are false
-   * @throws IllegalArgumentException if both decompress and compress are true
+   * @return possibly transformed data as per @{@link FetchRequest}
    */
-  public abstract ByteBufferReference getValueRetain(boolean decompress,
-      boolean compress) throws IllegalArgumentException;
+  public abstract ByteBufferReference getValueRetain(FetchRequest fetchRequest);
 
   /**
    * An optional explicit release of the underlying data. The buffer may no

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/FetchRequest.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/FetchRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package com.gemstone.gemfire.internal.shared;
+
+/**
+ * Request sent to {@link ByteBufferReference#getValueRetain}.
+ */
+public enum FetchRequest {
+  /**
+   * Return with original form of buffer.
+   */
+  ORIGINAL,
+  /**
+   * Return decompressed buffer and store in region if possible.
+   */
+  DECOMPRESS,
+  /**
+   * Return compressed buffer and store in region if required.
+   */
+  COMPRESS,
+  /**
+   * Return decompressed buffer only if decompressed form can be stored
+   * in memory (i.e. don't expend effort to decompress multiple times for
+   * every fetch) else return null if need to read from disk. Typically
+   * must be followed by a call with {@link #ORIGINAL} in case result is null.
+   */
+  DECOMPRESS_IF_IN_MEMORY,
+}

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
@@ -301,8 +301,12 @@ public abstract class UnsafeHolder {
    * this directly rather use BufferAllocator.allocate/release where possible.
    */
   public static void releaseIfDirectBuffer(ByteBuffer buffer) {
-    if (buffer != null && buffer.isDirect()) {
-      releaseDirectBuffer(buffer);
+    if (buffer != null) {
+      if (buffer.isDirect()) {
+        releaseDirectBuffer(buffer);
+      } else {
+        buffer.rewind().limit(0);
+      }
     }
   }
 
@@ -312,6 +316,7 @@ public abstract class UnsafeHolder {
       cleaner.clean();
       cleaner.clear();
     }
+    buffer.rewind().limit(0);
   }
 
   public static void releasePendingReferences() {

--- a/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientBlob.java
+++ b/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientBlob.java
@@ -323,6 +323,10 @@ public final class ClientBlob extends ClientLobBase implements BufferedBlob {
     }
   }
 
+  public BlobChunk getCurrentChunk() {
+    return this.currentChunk;
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -336,12 +340,11 @@ public final class ClientBlob extends ClientLobBase implements BufferedBlob {
       int nbytes = readBytes(offset, result, 0, length);
       if (nbytes == length) {
         return result;
-      } else {
+      } else if (nbytes > 0) {
         return Arrays.copyOf(result, nbytes);
       }
-    } else {
-      return ClientSharedData.ZERO_ARRAY;
     }
+    return ClientSharedData.ZERO_ARRAY;
   }
 
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
@@ -277,8 +277,8 @@ public interface GfxdConstants {
   /** property to set max size of chunks in DML operations */
   final String DML_MAX_CHUNK_SIZE_PROP = GFXD_PREFIX + "dml-max-chunk-size";
 
-  /** default max size of chunks in DML operations */
-  final long DML_MAX_CHUNK_SIZE_DEFAULT = 4194304L;
+  /** default max size of chunks in DML operations or query results */
+  final long DML_MAX_CHUNK_SIZE_DEFAULT = 4L * 1024L * 1024L;
 
   /**
    * property to set min size of results for which streaming or throttling is

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -3060,8 +3060,11 @@ public class GfxdSystemProcedures extends SystemProcedures {
             Authorizer.SQL_SELECT_OP);
       }
 
-      byte[] batchFilters = filters != null
-          ? filters.getBytes(1, (int)filters.length()) : null;
+      byte[] batchFilters = null;
+      if (filters != null) {
+        batchFilters = filters.getBytes(1, (int)filters.length());
+        filters.free();
+      }
       Set<Integer> bucketIds = lcc.getBucketIdsForLocalExecution();
       final CloseableIterator<ColumnTableEntry> iter =
           CallbackFactoryProvider.getStoreCallbacks().columnTableScan(
@@ -3084,7 +3087,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
             // mark chunk as having a reference set from outside (columnTableScan)
             if (!blob.getCurrentChunk().initChunkFromReference()) {
               throw StandardException.newException(SQLState.DATA_UNEXPECTED_EXCEPTION,
-                  new IllegalStateException("failed to increment reference count"));
+                  new IllegalStateException("failed to initialize chunk with buffer"));
             }
             template[3].setValue(blob);
             return true;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -1455,9 +1455,9 @@ public class GfxdSystemProcedures extends SystemProcedures {
     // get partitioning columns
     GfxdPartitionByExpressionResolver resolver =
         (GfxdPartitionByExpressionResolver)region.getPartitionResolver();
-    StringBuffer stringBuffer = new StringBuffer();
+    StringBuilder stringBuffer = new StringBuilder();
     for (String col : resolver.getColumnNames()) {
-      stringBuffer.append(col + ":");
+      stringBuffer.append(col).append(':');
     }
     partColumns[0] = stringBuffer.toString();
 
@@ -1474,7 +1474,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
     Map<InternalDistributedMember, String> mbrToServerMap = GemFireXDUtils
         .getGfxdAdvisor().getAllNetServersWithMembers();
 
-    StringBuffer stringBuffer = new StringBuffer();
+    StringBuilder stringBuffer = new StringBuilder();
     if (GemFireXDUtils.getMyVMKind().isStore()) {
       owners.add(Misc.getGemFireCache().getMyId());
     }
@@ -1482,7 +1482,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
     for (InternalDistributedMember node : owners) {
       String netServer = mbrToServerMap.get(node);
       if ( netServer != null) {
-        stringBuffer.append(netServer + ";");
+        stringBuffer.append(netServer).append(';');
       }
     }
     if (stringBuffer.length() > 0) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
@@ -32,7 +32,6 @@ import com.gemstone.gemfire.cache.hdfs.internal.hoplog.HDFSRegionDirector;
 import com.gemstone.gemfire.distributed.DistributedMember;
 import com.gemstone.gemfire.distributed.internal.DistributionManager;
 import com.gemstone.gemfire.distributed.internal.DistributionStats;
-import com.gemstone.gemfire.distributed.internal.InternalDistributedSystem;
 import com.gemstone.gemfire.distributed.internal.ReplyException;
 import com.gemstone.gemfire.internal.GFToSlf4jBridge;
 import com.gemstone.gemfire.internal.InternalDataSerializer;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/wan/messages/GfxdCBArgForSynchPrms.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/wan/messages/GfxdCBArgForSynchPrms.java
@@ -505,8 +505,8 @@ public final class GfxdCBArgForSynchPrms extends GfxdDataSerializable implements
   @Override
   public ResultSet getNewRowsAsResultSet() {
     if (this.isBulkInsert) {
-      return new RawStoreResultSet(this.bulkInsertRows, getExtraTableInfo()
-          .getRowFormatter());
+      return new RawStoreResultSet(this.bulkInsertRows.iterator(), null,
+          getExtraTableInfo().getRowFormatter());
     }
     else if (this.params != null) {
       return new DVDStoreResultSet(this.params, this.params.length, null, null,
@@ -530,7 +530,7 @@ public final class GfxdCBArgForSynchPrms extends GfxdDataSerializable implements
       final ExtraTableInfo tableInfo = getExtraTableInfo();
       final int[] pkCols = tableInfo.getPrimaryKeyColumns();
       if (pkCols != null) {
-        return new RawStoreResultSet(this.bulkInsertRows,
+        return new RawStoreResultSet(this.bulkInsertRows.iterator(),
             tableInfo.getRowFormatter(), pkCols, tableInfo
                 .getPrimaryKeyFormatter().getMetaData());
       }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/SnappyTableStatsVTI.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/SnappyTableStatsVTI.java
@@ -75,8 +75,8 @@ public class SnappyTableStatsVTI extends GfxdVTITemplate
         throw PublicAPI.wrapStandardException(se);
       } catch (RuntimeException re) {
         String message;
-        if ((re instanceof FunctionException) ||
-            (re instanceof FunctionExecutionException) &&
+        if (((re instanceof FunctionException) ||
+            (re instanceof FunctionExecutionException)) &&
                 re.getCause() != null) {
           message = re.getCause().getMessage();
         } else {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdDistributionAdvisor.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdDistributionAdvisor.java
@@ -1089,7 +1089,7 @@ public final class GfxdDistributionAdvisor extends DistributionAdvisor {
               serverSB.append(',');
             }
             if (s instanceof HostAddress) {
-              serverSB.append(((HostAddress)s).getHostString());
+              serverSB.append(((HostAddress)s).getHostAddressString());
             } else {
               serverSB.append(s);
             }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
@@ -160,6 +160,8 @@ public final class LeadNodeExecutorMsg extends MemberExecutorMessage<Object> {
   }
 
   private static class SparkExceptionWrapper extends Exception {
+    private static final long serialVersionUID = -4668836542769295434L;
+
     public SparkExceptionWrapper(Throwable ex) {
       super(ex.getClass().getName() + ": " + ex.getMessage(), ex.getCause());
       this.setStackTrace(ex.getStackTrace());

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/AbstractGemFireActivation.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/AbstractGemFireActivation.java
@@ -89,7 +89,7 @@ public abstract class AbstractGemFireActivation extends BaseActivation {
       this.row = new ExecRow[2];
     }
     // check authorization
-    lcc.getAuthorizer().authorize(this, ps, Authorizer.SQL_SKIP_OP + (this.qInfo
+    lcc.getAuthorizer().authorize(this, ps, null, Authorizer.SQL_SKIP_OP + (this.qInfo
         .isSelect() ? Authorizer.SQL_SELECT_OP : Authorizer.SQL_WRITE_OP));
 
     final int paramCnt = this.qInfo.getParameterCount();

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/CustomRowsResultSet.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/CustomRowsResultSet.java
@@ -73,10 +73,16 @@ public final class CustomRowsResultSet extends DVDStoreResultSet {
     }
   }
 
+  @Override
+  public void close() throws SQLException {
+    super.close();
+    this.fetchRows.close();
+  }
+
   /**
    * Allows fetching one row at a time as a DVD[] from arbitrary source.
    */
-  public static interface FetchDVDRows {
+  public interface FetchDVDRows {
 
     /**
      * If next row is available then fill in template and return true, else
@@ -84,5 +90,8 @@ public final class CustomRowsResultSet extends DVDStoreResultSet {
      */
     public boolean getNext(DataValueDescriptor[] template) throws SQLException,
         StandardException;
+
+    default void close() throws SQLException {
+    }
   }
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/DVDStoreResultSet.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/DVDStoreResultSet.java
@@ -961,7 +961,9 @@ public class DVDStoreResultSet extends NonUpdatableRowsResultSet implements
         }
         if (dvd != null && !dvd.isNull()) {
           this.wasNull = false;
-          return HarmonySerialBlob.wrapBytes(dvd.getBytes());
+          Object result = dvd.getObject();
+          return result instanceof byte[]
+              ? HarmonySerialBlob.wrapBytes((byte[])result) : (Blob)result;
         }
         else {
           this.wasNull = true;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/sql/conn/Authorizer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/sql/conn/Authorizer.java
@@ -40,8 +40,11 @@
 
 package com.pivotal.gemfirexd.internal.iapi.sql.conn;
 
+import java.util.List;
+
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
 import com.pivotal.gemfirexd.internal.iapi.sql.Activation;
+import com.pivotal.gemfirexd.internal.iapi.sql.dictionary.StatementPermission;
 import com.pivotal.gemfirexd.internal.iapi.sql.execute.ExecPreparedStatement;
 /**
   The Authorizer verifies a connected user has the authorization 
@@ -133,7 +136,7 @@ public interface Authorizer
 
 // GemStone changes BEGIN
 	public void authorize(Activation activation, ExecPreparedStatement eps,
-	    int operation) throws StandardException;
+	    List<StatementPermission> perms, int operation) throws StandardException;
 // GemStone changes END
     /**
 	  Get the Authorization ID for this Authorizer.

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -2044,6 +2044,18 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
           newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
 
     }
+    {
+      // COLUMN_TABLE_SCAN(String,String,String,Blob,ResultSet[])
+      String[] arg_names = new String[] { "TABLE", "PROJECTION", "FILTERS" };
+      TypeDescriptor[] arg_types = new TypeDescriptor[] {
+          DataTypeDescriptor.getCatalogType(Types.VARCHAR),
+          DataTypeDescriptor.getCatalogType(Types.VARCHAR),
+          DataTypeDescriptor.getCatalogType(Types.BLOB)
+      };
+      super.createSystemProcedureOrFunction("COLUMN_TABLE_SCAN", sysUUID,
+          arg_names, arg_types, 0, 1, RoutineAliasInfo.READS_SQL_DATA, null,
+          newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
+    }
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericAuthorizer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericAuthorizer.java
@@ -155,6 +155,9 @@ implements Authorizer
                 StatementContext ctx = this.lcc.getStatementContext();
                 if (ctx != null) {
                   sqlAllowed = ctx.getSQLAllowed();
+                } else if (perms != null && perms.size() > 0) {
+                  // direct call from GfxdSystemProcedures.authorizeColumnTableScan
+                  sqlAllowed = RoutineAliasInfo.READS_SQL_DATA;
                 }
                 /* (original code)
 		int sqlAllowed = lcc.getStatementContext().getSQLAllowed();
@@ -225,8 +228,8 @@ implements Authorizer
 				SanityManager.THROWASSERT("Bad operation code "+operation);
 		}
 // GemStone changes BEGIN
-	if (activation != null && (ps != null || perms != null
-	    || (ps = activation.getPreparedStatement()) != null)) {
+	if (perms != null || (activation != null && (ps != null
+	    || (ps = activation.getPreparedStatement()) != null))) {
 	/* (original code)
         if( activation != null)
         {
@@ -236,7 +239,7 @@ implements Authorizer
             boolean nestedTX = false;
             try {
               // check if ps is uptodate
-              activation.checkStatementValidity();
+              if (activation != null) activation.checkStatementValidity();
               List requiredPermissionsList = perms != null ? perms : ps.getRequiredPermissionsList();
               /*[originally]
                 List requiredPermissionsList = activation.getPreparedStatement().getRequiredPermissionsList();

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericAuthorizer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericAuthorizer.java
@@ -116,7 +116,7 @@ implements Authorizer
 	public void authorize( int operation) throws StandardException
 	{
 // GemStone changes BEGIN
-	  authorize(null, null, operation);
+	  authorize(null, null, null, operation);
 	  /* (original code)
 		authorize( (Activation) null, operation);
 	  */
@@ -131,12 +131,12 @@ implements Authorizer
 	public final void authorize(final Activation activation,
 	    final int operation) throws StandardException {
 	  authorize(activation, activation != null ? activation
-	      .getPreparedStatement() : null, operation);
+	      .getPreparedStatement() : null, null, operation);
 	}
 
 	public final void authorize(final Activation activation,
-	    ExecPreparedStatement ps, final int operation)
-	    throws StandardException
+	    ExecPreparedStatement ps, List<StatementPermission> perms,
+	    final int operation) throws StandardException
 	/* (original code)
 	public void authorize( Activation activation, int operation) throws StandardException
 	*/
@@ -225,7 +225,7 @@ implements Authorizer
 				SanityManager.THROWASSERT("Bad operation code "+operation);
 		}
 // GemStone changes BEGIN
-	if (activation != null && (ps != null
+	if (activation != null && (ps != null || perms != null
 	    || (ps = activation.getPreparedStatement()) != null)) {
 	/* (original code)
         if( activation != null)
@@ -237,7 +237,7 @@ implements Authorizer
             try {
               // check if ps is uptodate
               activation.checkStatementValidity();
-              List requiredPermissionsList = ps.getRequiredPermissionsList();
+              List requiredPermissionsList = perms != null ? perms : ps.getRequiredPermissionsList();
               /*[originally]
                 List requiredPermissionsList = activation.getPreparedStatement().getRequiredPermissionsList();
                 DataDictionary dd = lcc.getDataDictionary();

--- a/gemfirexd/core/src/main/resources/com/pivotal/gemfirexd/internal/loc/messages.xml
+++ b/gemfirexd/core/src/main/resources/com/pivotal/gemfirexd/internal/loc/messages.xml
@@ -4869,7 +4869,7 @@ ln=lower-case two-letter ISO-639 language code, CO=upper-case two-letter ISO-316
 
             <msg>
                 <name>XJ016.S</name>
-                <text>Method '{0}' not allowed on prepared statement.</text>
+                <text>Method or query '{0}' not allowed on prepared statement.</text>
                 <arg>methodName</arg>
             </msg>
 

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/BlobChunk.java
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/BlobChunk.java
@@ -31,6 +31,7 @@ import javax.annotation.Generated;
 
 import com.gemstone.gemfire.internal.shared.ByteBufferReference;
 import com.gemstone.gemfire.internal.shared.ClientSharedData;
+import com.gemstone.gemfire.internal.shared.FetchRequest;
 import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder;
 import io.snappydata.thrift.common.SocketTimeout;
 import io.snappydata.thrift.common.TProtocolDirectBinary;
@@ -86,6 +87,19 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
     // chunkReference will be incremented and released at the time of write
     this.chunk = ClientSharedData.NULL_BUFFER;
     this.chunkReference = reference;
+  }
+
+  /**
+   * Mark the ByteBufferReference refCount as having been already incremented.
+   */
+  public boolean initChunkFromReference() {
+    ByteBufferReference reference = this.chunkReference;
+    if (reference != null && this.chunk == ClientSharedData.NULL_BUFFER) {
+      this.chunk = reference.getBuffer();
+      return true;
+    } else {
+      return false;
+    }
   }
 
   public int size() {
@@ -467,21 +481,46 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
     throw new IllegalStateException();
   }
 
-  private ByteBuffer getCompressedBuffer(org.apache.thrift.protocol.TProtocol oprot) {
-    // compress if sending to remote else send as is
+  /**
+   * Compress if sending to remote or else decompress if the blob can be
+   * stored in memory (so future reads will not need to decompress)
+   * else send as is.
+   */
+  private ByteBuffer getBufferForWrite(org.apache.thrift.protocol.TProtocol oprot) {
     final ByteBufferReference reference = this.chunkReference;
     if (reference != null) {
-      // release already held reference count
-      if (this.chunk != ClientSharedData.NULL_BUFFER) {
-        reference.release();
-        this.chunk = ClientSharedData.NULL_BUFFER;
-      }
       TTransport transport = oprot.getTransport();
       if (transport instanceof SocketTimeout) {
-        boolean sameHost = ((SocketTimeout)transport).isSocketToSameHost();
-        this.chunkReference = reference.getValueRetain(sameHost, !sameHost);
+        // check if a reference is already held
+        boolean hasOldReference = this.chunk != ClientSharedData.NULL_BUFFER;
+        if (((SocketTimeout)transport).isSocketToSameHost()) {
+          // try to decompress only if the value can be stored in region else
+          // avoid decompression overhead on server rather do on client/connector
+          if (hasOldReference) {
+            // release reference upfront if this not the only remaining reference
+            // (under the lock on value to ensure atomicity of check and release)
+            synchronized (reference) {
+              if (reference.referenceCount() > 1) {
+                reference.release();
+                hasOldReference = false;
+              }
+              this.chunkReference = reference.getValueRetain(
+                  FetchRequest.DECOMPRESS_IF_IN_MEMORY);
+            }
+          } else {
+            this.chunkReference = reference.getValueRetain(
+                FetchRequest.DECOMPRESS_IF_IN_MEMORY);
+          }
+          if (this.chunkReference == null) {
+            this.chunkReference = reference.getValueRetain(FetchRequest.ORIGINAL);
+          }
+        } else {
+          // always send compressed to remote node
+          this.chunkReference = reference.getValueRetain(FetchRequest.COMPRESS);
+        }
         this.chunk = this.chunkReference.getBuffer();
-      } else {
+        if (hasOldReference) reference.release();
+      } else if (this.chunk == ClientSharedData.NULL_BUFFER) {
         this.chunk = reference.getBufferRetain();
       }
     }
@@ -804,7 +843,7 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
     public void write(org.apache.thrift.protocol.TProtocol oprot, BlobChunk struct)
         throws org.apache.thrift.TException {
       struct.validate();
-      final ByteBuffer chunk = struct.getCompressedBuffer(oprot);
+      final ByteBuffer chunk = struct.getBufferForWrite(oprot);
       try {
         writeData(oprot, struct, chunk);
       } finally {
@@ -856,7 +895,7 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
     @Override
     public void write(org.apache.thrift.protocol.TProtocol prot,
         BlobChunk struct) throws org.apache.thrift.TException {
-      final ByteBuffer buffer = struct.getCompressedBuffer(prot);
+      final ByteBuffer buffer = struct.getBufferForWrite(prot);
       try {
         writeData(prot, struct,
             buffer != null ? buffer : ClientSharedData.NULL_BUFFER);

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/HostAddress.java
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/HostAddress.java
@@ -521,6 +521,14 @@ public final class HostAddress extends HostLocationBase<HostAddress> implements
     return super.toString();
   }
 
+  public String getHostAddressString() {
+    if (this.ipAddress == null) {
+      return this.hostName + '[' + this.port + ']';
+    } else {
+      return this.hostName + '/' + this.ipAddress + '[' + this.port + ']';
+    }
+  }
+
   @Override
   public String toString() {
     ServerType serverType = this.serverType;

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/BlobChunk.java.tmpl
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/BlobChunk.java.tmpl
@@ -31,6 +31,7 @@ import javax.annotation.Generated;
 
 import com.gemstone.gemfire.internal.shared.ByteBufferReference;
 import com.gemstone.gemfire.internal.shared.ClientSharedData;
+import com.gemstone.gemfire.internal.shared.FetchRequest;
 import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder;
 import io.snappydata.thrift.common.SocketTimeout;
 import io.snappydata.thrift.common.TProtocolDirectBinary;
@@ -86,6 +87,19 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
     // chunkReference will be incremented and released at the time of write
     this.chunk = ClientSharedData.NULL_BUFFER;
     this.chunkReference = reference;
+  }
+
+  /**
+   * Mark the ByteBufferReference refCount as having been already incremented.
+   */
+  public boolean initChunkFromReference() {
+    ByteBufferReference reference = this.chunkReference;
+    if (reference != null && this.chunk == ClientSharedData.NULL_BUFFER) {
+      this.chunk = reference.getBuffer();
+      return true;
+    } else {
+      return false;
+    }
   }
 
   public int size() {
@@ -467,21 +481,46 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
     throw new IllegalStateException();
   }
 
-  private ByteBuffer getCompressedBuffer(org.apache.thrift.protocol.TProtocol oprot) {
-    // compress if sending to remote else send as is
+  /**
+   * Compress if sending to remote or else decompress if the blob can be
+   * stored in memory (so future reads will not need to decompress)
+   * else send as is.
+   */
+  private ByteBuffer getBufferForWrite(org.apache.thrift.protocol.TProtocol oprot) {
     final ByteBufferReference reference = this.chunkReference;
     if (reference != null) {
-      // release already held reference count
-      if (this.chunk != ClientSharedData.NULL_BUFFER) {
-        this.chunk = ClientSharedData.NULL_BUFFER;
-        reference.release();
-      }
       TTransport transport = oprot.getTransport();
       if (transport instanceof SocketTimeout) {
-        boolean sameHost = ((SocketTimeout)transport).isSocketToSameHost();
-        this.chunkReference = reference.getValueRetain(sameHost, !sameHost);
+        // check if a reference is already held
+        boolean hasOldReference = this.chunk != ClientSharedData.NULL_BUFFER;
+        if (((SocketTimeout)transport).isSocketToSameHost()) {
+          // try to decompress only if the value can be stored in region else
+          // avoid decompression overhead on server rather do on client/connector
+          if (hasOldReference) {
+            // release reference upfront if this not the only remaining reference
+            // (under the lock on value to ensure atomicity of check and release)
+            synchronized (reference) {
+              if (reference.referenceCount() > 1) {
+                reference.release();
+                hasOldReference = false;
+              }
+              this.chunkReference = reference.getValueRetain(
+                  FetchRequest.DECOMPRESS_IF_IN_MEMORY);
+            }
+          } else {
+            this.chunkReference = reference.getValueRetain(
+                FetchRequest.DECOMPRESS_IF_IN_MEMORY);
+          }
+          if (this.chunkReference == null) {
+            this.chunkReference = reference.getValueRetain(FetchRequest.ORIGINAL);
+          }
+        } else {
+          // always send compressed to remote node
+          this.chunkReference = reference.getValueRetain(FetchRequest.COMPRESS);
+        }
         this.chunk = this.chunkReference.getBuffer();
-      } else {
+        if (hasOldReference) reference.release();
+      } else if (this.chunk == ClientSharedData.NULL_BUFFER) {
         this.chunk = reference.getBufferRetain();
       }
     }
@@ -804,7 +843,7 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
     public void write(org.apache.thrift.protocol.TProtocol oprot, BlobChunk struct)
         throws org.apache.thrift.TException {
       struct.validate();
-      final ByteBuffer chunk = struct.getCompressedBuffer(oprot);
+      final ByteBuffer chunk = struct.getBufferForWrite(oprot);
       try {
         writeData(oprot, struct, chunk);
       } finally {
@@ -856,7 +895,7 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
     @Override
     public void write(org.apache.thrift.protocol.TProtocol prot,
         BlobChunk struct) throws org.apache.thrift.TException {
-      final ByteBuffer buffer = struct.getCompressedBuffer(prot);
+      final ByteBuffer buffer = struct.getBufferForWrite(prot);
       try {
         writeData(prot, struct,
             buffer != null ? buffer : ClientSharedData.NULL_BUFFER);

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/BlobChunk.java.tmpl
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/BlobChunk.java.tmpl
@@ -77,12 +77,15 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
 
   public BlobChunk(ByteBufferReference reference, boolean last) {
     this();
-    // Increment the reference immediately. Release should be done
-    // by holder once done (ClientBlob or ThriftRow).
-    this.chunk = reference.getBufferRetain();
-    this.chunkReference = reference;
+    assignChunkReference(reference);
     this.last = last;
     setLastIsSet(true);
+  }
+
+  private void assignChunkReference(ByteBufferReference reference) {
+    // chunkReference will be incremented and released at the time of write
+    this.chunk = ClientSharedData.NULL_BUFFER;
+    this.chunkReference = reference;
   }
 
   public int size() {
@@ -92,7 +95,9 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
   public void free() {
     final ByteBufferReference reference = this.chunkReference;
     if (reference != null) {
-      reference.release();
+      if (this.chunk != ClientSharedData.NULL_BUFFER) {
+        reference.release();
+      }
       this.chunkReference = null;
     } else {
       UnsafeHolder.releaseIfDirectBuffer(this.chunk);
@@ -214,8 +219,7 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
     __isset_bitfield = other.__isset_bitfield;
     ByteBufferReference reference = other.chunkReference;
     if (reference != null) {
-      this.chunk = reference.getBufferRetain();
-      this.chunkReference = reference;
+      assignChunkReference(reference);
     } else if (other.chunk != null) {
       // always own the chunk
       if (other.chunk.isDirect()) {
@@ -236,6 +240,7 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
 
   @Override
   public void clear() {
+    free();
     this.chunk = null;
     setLastIsSet(false);
     this.last = false;
@@ -252,12 +257,14 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
   }
 
   public BlobChunk setChunk(byte[] chunk) {
+    free();
     this.chunk = chunk == null ? (ByteBuffer)null : ByteBuffer.wrap(Arrays.copyOf(chunk, chunk.length));
     return this;
   }
 
   public BlobChunk setChunk(ByteBuffer chunk) {
-    this.chunk = ByteBuffer.wrap(ThriftUtils.toBytes(chunk));
+    free();
+    this.chunk = chunk != null ? ByteBuffer.wrap(ThriftUtils.toBytes(chunk)) : null;
     return this;
   }
 
@@ -276,6 +283,7 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
 
   public void setChunkIsSet(boolean value) {
     if (!value) {
+      free();
       this.chunk = null;
     }
   }
@@ -461,15 +469,20 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
 
   private ByteBuffer getCompressedBuffer(org.apache.thrift.protocol.TProtocol oprot) {
     // compress if sending to remote else send as is
-    if (isSetChunkReference()) {
+    final ByteBufferReference reference = this.chunkReference;
+    if (reference != null) {
+      // release already held reference count
+      if (this.chunk != ClientSharedData.NULL_BUFFER) {
+        this.chunk = ClientSharedData.NULL_BUFFER;
+        reference.release();
+      }
       TTransport transport = oprot.getTransport();
-      if (!(transport instanceof SocketTimeout) ||
-          !((SocketTimeout)transport).isSocketToSameHost()) {
-        ByteBufferReference compressed = this.chunkReference.getValueRetain(
-            false, true);
-        this.chunkReference.release();
-        this.chunkReference = compressed;
-        this.chunk = compressed.getBuffer();
+      if (transport instanceof SocketTimeout) {
+        boolean sameHost = ((SocketTimeout)transport).isSocketToSameHost();
+        this.chunkReference = reference.getValueRetain(sameHost, !sameHost);
+        this.chunk = this.chunkReference.getBuffer();
+      } else {
+        this.chunk = reference.getBufferRetain();
       }
     }
     return this.chunk;
@@ -790,9 +803,9 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
     @Override
     public void write(org.apache.thrift.protocol.TProtocol oprot, BlobChunk struct)
         throws org.apache.thrift.TException {
+      struct.validate();
+      final ByteBuffer chunk = struct.getCompressedBuffer(oprot);
       try {
-        struct.validate();
-        final ByteBuffer chunk = struct.getCompressedBuffer(oprot);
         writeData(oprot, struct, chunk);
       } finally {
         // free the blob once written
@@ -843,8 +856,8 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
     @Override
     public void write(org.apache.thrift.protocol.TProtocol prot,
         BlobChunk struct) throws org.apache.thrift.TException {
+      final ByteBuffer buffer = struct.getCompressedBuffer(prot);
       try {
-        final ByteBuffer buffer = struct.getCompressedBuffer(prot);
         writeData(prot, struct,
             buffer != null ? buffer : ClientSharedData.NULL_BUFFER);
       } finally {

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/HostAddress.java.tmpl
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/HostAddress.java.tmpl
@@ -521,6 +521,14 @@ public final class HostAddress extends HostLocationBase<HostAddress> implements
     return super.toString();
   }
 
+  public String getHostAddressString() {
+    if (this.ipAddress == null) {
+      return this.hostName + '[' + this.port + ']';
+    } else {
+      return this.hostName + '/' + this.ipAddress + '[' + this.port + ']';
+    }
+  }
+
   @Override
   public String toString() {
     ServerType serverType = this.serverType;

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/recovery/PersistenceRecoveryOrderDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/recovery/PersistenceRecoveryOrderDUnit.java
@@ -242,6 +242,7 @@ public class PersistenceRecoveryOrderDUnit extends DistributedSQLTestBase {
     VM server1 = this.serverVMs.get(0);
     VM server2 = this.serverVMs.get(1);
 
+    st1.execute("DROP TABLE IF EXISTS T1");
     st1.execute("CREATE TABLE T1 (COL1 int, COL2 int) partition by column (COL1) persistent redundancy 1 buckets 1");
 
     st1.execute("INSERT INTO T1 values(1,1)");
@@ -280,6 +281,7 @@ public class PersistenceRecoveryOrderDUnit extends DistributedSQLTestBase {
     VM server1 = this.serverVMs.get(0);
     VM server2 = this.serverVMs.get(1);
 
+    st1.execute("DROP TABLE IF EXISTS T1");
     st1.execute("CREATE TABLE T1 (COL1 int, COL2 int) partition by column (COL1) persistent redundancy 1 buckets 1");
 
     st1.execute("INSERT INTO T1 values(1,1)");


### PR DESCRIPTION
Store side changes required for SNAP-2243 and SNAP-2188 and other fixes seen in testing.
See snappydata PR for more details.

## Changes proposed in this pull request

- force decompress the underlying buffer in BlobChunk if remote node is on same host
- added free calls to BlobChunk in all relevant places when assigning new buffers
- add IP address to the server host names (host/address[port]) in GET_TABLE_METADATA
- added "decompressedReplaced" gfs stat to note the decompressions that
  were able to replace the underlying buffer ColumnFormatValue
- allow for null cache for LowMemoryException (in case of connector mode)
- Added "COLUMN_TABLE_SCAN" procedure to be invoked from smart connector and a
  corresponding "columnTableScan" method to StoreCallbacks.
- Implementation of columnTableScan returns iterator of "ColumnTableEntry" that encapsulates
  a single column of a batch that is converted to a ResultSet by procedure implementation.
- Send back Blob value as is from DVDStoreResultSet that is used by above procedure.
- Reference increment is done by columnTableScan, handed over to BlobChunk by ClientBlob,
  and released after thrift write by BlobChunk.
- BlobChunk now will release the previously held reference then get the buffer again with
  DECOMPRESS_IF_IN_MEMORY flag when target node is same host, else COMPRESS for
  remote sends.
- Fixed index column fetch in GET_TABLE_METADATA that would append indexes to "null"
- Added a new type of fetch from ColumnFormatValue: DECOMPRESS_IF_IN_MEMORY.
  This will decompress buffer only if it can be replaced in memory else return as is (or null).
  This allows smart connector to avoid decompression on server side if unable to store it on
  server. Changed boolean flags to a "FetchRequest" enumeration.
- Close bucket entries iterator before making it null else it leaks reference count of last batch.
- Set the disk RegionEntry itself in the ColumnFormatValue to read from disk in case
  entry is deleted from region (and some reader is holding a handle). Earlier setting
  of DiskId was not proper since it may change due to compaction.
- Zero the limit in case of full release of buffers to fail any further reads.
- Corrected parenthesis in FunctionException checks in SnappyTableStatsVTI

## Patch testing

precheckin -Pstore

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/979