### PR TITLE
Snap 2235

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/admin/internal/AdminDistributedSystemImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/admin/internal/AdminDistributedSystemImpl.java
@@ -2478,9 +2478,12 @@ implements com.gemstone.gemfire.admin.AdminDistributedSystem,
     FlushToDiskRequest.send(dm, recipients);
     Map<DistributedMember, Set<PersistentID>> existingDataStores 
         = PrepareBackupRequest.send(dm, recipients);
-    Map<DistributedMember, Set<PersistentID>> successfulMembers 
-        = FinishBackupRequest.send(dm, recipients, targetDir, baselineDir);
-    
+    Map<DistributedMember, Set<PersistentID>> successfulMembers1
+        = FinishBackupRequest.send(dm, recipients, targetDir, baselineDir, FinishBackupRequest.DISKSTORE_DD);
+    Map<DistributedMember, Set<PersistentID>> successfulMembers2
+        = FinishBackupRequest.send(dm, recipients, targetDir, baselineDir, FinishBackupRequest.DISKSTORE_ALL_BUT_DD);
+    Map<DistributedMember, Set<PersistentID>> successfulMembers =
+        getAllSuccessfulMembers(successfulMembers1, successfulMembers2);
     // It's possible that when calling getMissingPersistentMembers, some members are 
     // still creating/recovering regions, and at FinishBackupRequest.send, the 
     // regions at the members are ready. Logically, since the members in successfulMembers
@@ -2496,7 +2499,12 @@ implements com.gemstone.gemfire.admin.AdminDistributedSystem,
     
     return new BackupStatusImpl(successfulMembers, missingMembers);
   }
-  
+
+  private static Map<DistributedMember, Set<PersistentID>> getAllSuccessfulMembers(
+      Map<DistributedMember, Set<PersistentID>> first, Map<DistributedMember, Set<PersistentID>> second) {
+    return null;
+  }
+
   public Map<DistributedMember, Set<PersistentID>> compactAllDiskStores() throws AdminException {
     connectAdminDS();
     DM dm = getDistributionManager();

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/admin/internal/AdminDistributedSystemImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/admin/internal/AdminDistributedSystemImpl.java
@@ -20,17 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -2501,8 +2491,15 @@ implements com.gemstone.gemfire.admin.AdminDistributedSystem,
   }
 
   private static Map<DistributedMember, Set<PersistentID>> getAllSuccessfulMembers(
-      Map<DistributedMember, Set<PersistentID>> first, Map<DistributedMember, Set<PersistentID>> second) {
-    return null;
+      final Map<DistributedMember, Set<PersistentID>> first, final Map<DistributedMember, Set<PersistentID>> second) {
+    second.forEach((dm, idset) -> {
+      Set<PersistentID> val1 = first.get(dm);
+      if (val1 != null) {
+        idset.addAll(val1);
+      }
+      first.put(dm, idset);
+    } );
+    return first;
   }
 
   public Map<DistributedMember, Set<PersistentID>> compactAllDiskStores() throws AdminException {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/admin/internal/FinishBackupRequest.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/admin/internal/FinishBackupRequest.java
@@ -49,21 +49,28 @@ import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
  *
  */
 public class FinishBackupRequest  extends AdminRequest {
-  
+
+  public static final byte DISKSTORE_DD = 1;
+  public static final byte DISKSTORE_ALL_BUT_DD = 2;
+  public static final byte DISKSTORE_ALL = 1;
+
   private File targetDir;
   private File baselineDir;
-  
+  private byte diskstoresToBackup;
+
   public FinishBackupRequest() {
     super();
   }
 
-  public FinishBackupRequest(File targetDir,File baselineDir) {
+  public FinishBackupRequest(File targetDir, File baselineDir, byte dses) {
     this.targetDir = targetDir;
     this.baselineDir = baselineDir;
+    this.diskstoresToBackup = dses;
   }
   
-  public static Map<DistributedMember, Set<PersistentID>> send(DM dm, Set recipients, File targetDir, File baselineDir) {
-    FinishBackupRequest request = new FinishBackupRequest(targetDir,baselineDir);
+  public static Map<DistributedMember, Set<PersistentID>> send(DM dm,
+      Set recipients, File targetDir, File baselineDir, byte diskstores) {
+    FinishBackupRequest request = new FinishBackupRequest(targetDir, baselineDir, diskstores);
     request.setRecipients(recipients);
 
     FinishBackupReplyProcessor replyProcessor = new FinishBackupReplyProcessor(dm, recipients);
@@ -92,7 +99,7 @@ public class FinishBackupRequest  extends AdminRequest {
       persistentIds = new HashSet<PersistentID>();
     } else {
       try {
-        persistentIds = cache.getBackupManager().finishBackup(targetDir, baselineDir);
+        persistentIds = cache.getBackupManager().finishBackup(targetDir, baselineDir, diskstoresToBackup);
       } catch (IOException e) {
         return AdminFailureResponse.create(dm, getSender(), e);
       }
@@ -109,6 +116,7 @@ public class FinishBackupRequest  extends AdminRequest {
     super.fromData(in);
     targetDir = DataSerializer.readFile(in);
     baselineDir = DataSerializer.readFile(in);
+    this.diskstoresToBackup = in.readByte();
   }
 
   @Override
@@ -116,6 +124,7 @@ public class FinishBackupRequest  extends AdminRequest {
     super.toData(out);
     DataSerializer.writeFile(targetDir, out);
     DataSerializer.writeFile(baselineDir, out);
+    out.writeByte(diskstoresToBackup);
   }
 
   private static class FinishBackupReplyProcessor extends AdminMultipleReplyProcessor {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/admin/internal/FinishBackupRequest.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/admin/internal/FinishBackupRequest.java
@@ -52,7 +52,7 @@ public class FinishBackupRequest  extends AdminRequest {
 
   public static final byte DISKSTORE_DD = 1;
   public static final byte DISKSTORE_ALL_BUT_DD = 2;
-  public static final byte DISKSTORE_ALL = 1;
+  public static final byte DISKSTORE_ALL = 3;
 
   private File targetDir;
   private File baselineDir;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/BackupManager.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/BackupManager.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
 import com.gemstone.gemfire.InternalGemFireError;
+import com.gemstone.gemfire.admin.internal.FinishBackupRequest;
 import com.gemstone.gemfire.cache.persistence.PersistentID;
 import com.gemstone.gemfire.distributed.DistributedSystem;
 import com.gemstone.gemfire.distributed.internal.DM;
@@ -166,7 +167,7 @@ public class BackupManager implements MembershipListener {
     return baselineDir;
   }
   
-  public HashSet<PersistentID> finishBackup(File targetDir, File baselineDir) throws IOException {
+  public HashSet<PersistentID> finishBackup(File targetDir, File baselineDir, byte diskStoresToBackup) throws IOException {
     try {
       File backupDir = getBackupDir(targetDir);
       
@@ -198,7 +199,10 @@ public class BackupManager implements MembershipListener {
         store.releaseBackupLock();
       }
 
-      allowDestroys.countDown();
+      if (diskStoresToBackup == FinishBackupRequest.DISKSTORE_ALL_BUT_DD
+          || diskStoresToBackup == FinishBackupRequest.DISKSTORE_ALL) {
+        allowDestroys.countDown();
+      }
 
       for(DiskStoreImpl store : diskStores) {
         store.finishBackup(this);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/BackupManager.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/BackupManager.java
@@ -80,6 +80,7 @@ public class BackupManager implements MembershipListener {
   private void cleanup() {
     isCancelled = true;
     allowDestroys.countDown();
+    this.incompleteRestoreScript = null;
     Collection<DiskStoreImpl> diskStores = cache.listDiskStoresIncludingRegionOwned();
     for(DiskStoreImpl store : diskStores) {
       store.releaseBackupLock();

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/management/internal/beans/DistributedSystemBridge.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/management/internal/beans/DistributedSystemBridge.java
@@ -520,7 +520,9 @@ public class DistributedSystemBridge {
       Map<DistributedMember, Set<PersistentID>> existingDataStores = PrepareBackupRequest
           .send(dm, recipients);
       Map<DistributedMember, Set<PersistentID>> successfulMembers = FinishBackupRequest
-          .send(dm, recipients, targetDir, null /*TODO rishi update this for new backup features */);
+          .send(dm, recipients, targetDir,
+              null /*TODO rishi update this for new backup features */,
+              FinishBackupRequest.DISKSTORE_ALL);
 
       Iterator<DistributedMember> it = successfulMembers.keySet().iterator();
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/management/internal/beans/MemberMBeanBridge.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/management/internal/beans/MemberMBeanBridge.java
@@ -42,6 +42,7 @@ import javax.management.ObjectName;
 
 import com.gemstone.gemfire.Statistics;
 import com.gemstone.gemfire.StatisticsType;
+import com.gemstone.gemfire.admin.internal.FinishBackupRequest;
 import com.gemstone.gemfire.cache.CacheClosedException;
 import com.gemstone.gemfire.cache.DiskStore;
 import com.gemstone.gemfire.cache.Region;
@@ -1118,7 +1119,7 @@ public class MemberMBeanBridge {
         Set<PersistentID> existingDataStores = manager.prepareBackup();
 
         Set<PersistentID> successfulDataStores = manager
-          .finishBackup(targetDir, null/* TODO rishi */);
+          .finishBackup(targetDir, null/* TODO rishi */, FinishBackupRequest.DISKSTORE_ALL);
         diskBackUpResult = new DiskBackupResult[existingDataStores.size()];
         int j = 0;
 

--- a/gemfire-junit/src/main/java/com/gemstone/gemfire/internal/cache/BackupJUnitTest.java
+++ b/gemfire-junit/src/main/java/com/gemstone/gemfire/internal/cache/BackupJUnitTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Random;
 
+import com.gemstone.gemfire.admin.internal.FinishBackupRequest;
 import junit.framework.TestCase;
 
 import com.gemstone.gemfire.cache.CacheFactory;
@@ -187,7 +188,7 @@ public class BackupJUnitTest extends TestCase {
     
     BackupManager backup = cache.startBackup(cache.getDistributedSystem().getDistributedMember());
     backup.prepareBackup();
-    backup.finishBackup(backupDir,null);
+    backup.finishBackup(backupDir,null, FinishBackupRequest.DISKSTORE_ALL);
     
     //Put another key to make sure we restore
     //from a backup that doesn't contain this key
@@ -234,7 +235,7 @@ public class BackupJUnitTest extends TestCase {
 
     BackupManager backup = cache.startBackup(cache.getDistributedSystem().getDistributedMember());
     backup.prepareBackup();
-    backup.finishBackup(backupDir,null);
+    backup.finishBackup(backupDir,null, FinishBackupRequest.DISKSTORE_ALL);
     assertEquals("No backup files should have been created", Collections.emptyList(), Arrays.asList(backupDir.list()));
   }
   
@@ -247,7 +248,7 @@ public class BackupJUnitTest extends TestCase {
 
     BackupManager backup = cache.startBackup(cache.getDistributedSystem().getDistributedMember());
     backup.prepareBackup();
-    backup.finishBackup(backupDir,null);
+    backup.finishBackup(backupDir,null, FinishBackupRequest.DISKSTORE_ALL);
     
     
     assertEquals("No backup files should have been created", Collections.emptyList(), Arrays.asList(backupDir.list()));
@@ -302,7 +303,7 @@ public class BackupJUnitTest extends TestCase {
 
     BackupManager backup = cache.startBackup(cache.getDistributedSystem().getDistributedMember());
     backup.prepareBackup();
-    backup.finishBackup(backupDir,null);
+    backup.finishBackup(backupDir,null, FinishBackupRequest.DISKSTORE_ALL);
     File cacheXmlBackup = FileUtil.find(backupDir, ".*config.cache.xml");
     assertTrue(cacheXmlBackup.exists());
     byte[] expectedBytes = getBytes(CACHE_XML_FILE);

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/MVCCBackupRestoreDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/MVCCBackupRestoreDUnit.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
 
+import com.gemstone.gemfire.admin.internal.FinishBackupRequest;
 import com.gemstone.gemfire.cache.IsolationLevel;
 import com.gemstone.gemfire.cache.Region;
 import com.gemstone.gemfire.cache.persistence.PersistentID;
@@ -90,7 +91,7 @@ public class MVCCBackupRestoreDUnit extends DistributedSQLTestBase {
         try {
           BackupManager backup = Misc.getGemFireCache().startBackup(Misc.getGemFireCache().getDistributedSystem().getDistributedMember());
           backup.prepareBackup();
-          HashSet<PersistentID> set = backup.finishBackup(getBackupDir(), null);
+          HashSet<PersistentID> set = backup.finishBackup(getBackupDir(), null, FinishBackupRequest.DISKSTORE_ALL);
           File incompleteBackup = FileUtil.find(getBackupDir(), ".*INCOMPLETE.*");
           assertNull(incompleteBackup);
           return set;

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/IndexPersistenceTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/IndexPersistenceTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import com.gemstone.gemfire.admin.internal.FinishBackupRequest;
 import com.gemstone.gemfire.cache.persistence.PersistentID;
 import com.gemstone.gemfire.internal.FileUtil;
 import com.gemstone.gemfire.internal.cache.AbstractRegionEntry;
@@ -163,7 +164,7 @@ public class IndexPersistenceTest extends JdbcTestBase {
   private HashSet<PersistentID> backup(File backupDir, File baseDir) throws IOException {
     BackupManager backup = Misc.getGemFireCache().startBackup(Misc.getGemFireCache().getDistributedSystem().getDistributedMember());
     backup.prepareBackup();
-    HashSet<PersistentID> set = backup.finishBackup(backupDir, baseDir);
+    HashSet<PersistentID> set = backup.finishBackup(backupDir, baseDir, FinishBackupRequest.DISKSTORE_ALL);
     File incompleteBackup = FileUtil.find(backupDir, ".*INCOMPLETE.*");
     assertNull(incompleteBackup);
     return set;


### PR DESCRIPTION
## Changes proposed in this pull request

Broke the backup in two phases. In the first phase it will take the backup of the DD store and will partially right the restore script. In the second phase it will take the backup of the rest of the diskstores and then complete the restore script for the disk stores added in the second phase.

## Patch testing

Added a test - core/src/test/scala/io/snappydata/CommandLineToolsSuite.scala

## ReleaseNotes changes

None

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/983
