### PR TITLE
Disk Store Validate tool enhancement 

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskInitFile.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskInitFile.java
@@ -3049,4 +3049,16 @@ public class DiskInitFile implements DiskInitFileInterpreter {
   public Set<String> getDeletedIndexIds() {
     return this.deletedIndexIds;
   }
+
+  // These will be set only when DiskInitFile is
+  // created during validation of disk store
+  private transient String inconsistencyReport = null;
+
+  public void setInconsistent(String ir) {
+    this.inconsistencyReport = ir;
+  }
+
+  public String getInconsistencyReport() {
+    return this.inconsistencyReport;
+  }
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskInitFile.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskInitFile.java
@@ -3050,7 +3050,7 @@ public class DiskInitFile implements DiskInitFileInterpreter {
     return this.deletedIndexIds;
   }
 
-  // These will be set only when DiskInitFile is
+  // This will be set only when DiskInitFile is
   // created during validation of disk store
   private transient String inconsistencyReport = null;
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
@@ -4183,7 +4183,7 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
         + getLiveEntryCount());
     String r = getDiskInitFile().getInconsistencyReport();
     if (r != null) {
-      System.out.println(r);
+      System.out.print(r);
     }
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
@@ -4181,6 +4181,10 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
     }
     System.out.println("Total number of region entries in this disk store is: "
         + getLiveEntryCount());
+    String r = getDiskInitFile().getInconsistencyReport();
+    if (r != null) {
+      System.out.println(r);
+    }
   }
 
   private int liveEntryCount;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PersistentOplogSet.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PersistentOplogSet.java
@@ -397,7 +397,7 @@ public class PersistentOplogSet implements OplogSet {
         Map<String, List<VdrBucketId>> m = itr.next();
         if (m.containsKey(prName)) {
           List<VdrBucketId> s = m.get(prName);
-          if ( s != null ) {
+          if ( s == null ) {
             s = new ArrayList<>(10);
             m.put(prName, s);
           }
@@ -431,7 +431,7 @@ public class PersistentOplogSet implements OplogSet {
       }
     }
 
-    private List<VdrBucketId> findSmallestAndPrintMissing(Map<String, List<VdrBucketId>> oneSet) {
+    private void findSmallestAndPrintMissing(Map<String, List<VdrBucketId>> oneSet) {
       List<VdrBucketId> smallest = null;
       String rootRegion = null;
       boolean allSizesEqual = true;
@@ -447,6 +447,9 @@ public class PersistentOplogSet implements OplogSet {
           if (currlist.size() < smallest.size()) {
             smallest = currlist;
             rootRegion = e.getKey();
+            allSizesEqual = false;
+          }
+          if (currlist.size() > smallest.size()) {
             allSizesEqual = false;
           }
         }
@@ -471,7 +474,6 @@ public class PersistentOplogSet implements OplogSet {
         });
         System.out.println("###### End Root region = " + rootRegion + " ######");
       }
-      return smallest;
     }
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PersistentOplogSet.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PersistentOplogSet.java
@@ -436,7 +436,6 @@ public class PersistentOplogSet implements OplogSet {
           findInconsistencyInternal(x, sb);
         }
       });
-      sb.append("\n");
       if (inconsistent) {
         this.dif.setInconsistent(sb.toString());
       }
@@ -491,8 +490,8 @@ public class PersistentOplogSet implements OplogSet {
       }
 
       if (badBuckets.size() > 0) {
-        sb.append("In " + rootPR + " co-location set, parent bucket is missing for these buckets\n");
-        badBuckets.forEach(x -> sb.append(x.vdr.getName() + " "));
+        sb.append("In " + rootPR + " co-location group, parent bucket is missing for these buckets\n");
+        badBuckets.forEach(x -> sb.append(x.vdr.getName() + "\n"));
         sb.append("\n");
       }
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PersistentOplogSet.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PersistentOplogSet.java
@@ -422,6 +422,10 @@ public class PersistentOplogSet implements OplogSet {
         List<VdrBucketId> s = new ArrayList<>(10);
         s.add(vdb);
         m.put(prName, s);
+        if (colocateWith != null && colocateWith.length() > 0) {
+          List<VdrBucketId> sc = new ArrayList<>(10);
+          m.put(colocateWith, sc);
+        }
         this.prSetsWithBuckets.add(m);
       }
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PersistentOplogSet.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PersistentOplogSet.java
@@ -405,10 +405,6 @@ public class PersistentOplogSet implements OplogSet {
         Map<String, List<VdrBucketId>> m = itr.next();
         if (m.containsKey(prName)) {
           List<VdrBucketId> s = m.get(prName);
-          if ( s == null ) {
-            s = new ArrayList<>(10);
-            m.put(prName, s);
-          }
           s.add(vdb);
           added = true;
           break;
@@ -435,17 +431,14 @@ public class PersistentOplogSet implements OplogSet {
       sb.append("\n");
       sb.append("--- Child buckets with no parent buckets\n");
       sb.append("\n");
-      prSetsWithBuckets.forEach(x -> printInconsistencyInternal(x, sb));
+      prSetsWithBuckets.forEach(x -> {
+        if (x.size() > 1) {
+          findInconsistencyInternal(x, sb);
+        }
+      });
       sb.append("\n");
       if (inconsistent) {
         this.dif.setInconsistent(sb.toString());
-      }
-    }
-
-    private void printInconsistencyInternal(Map<String, List<VdrBucketId>> oneSet,
-                                            final StringBuffer sb) {
-      if (oneSet.size() > 1) {
-        findInconsistencyInternal(oneSet, sb);
       }
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request

Now running this tool prints all the child bucket region names for which there are no corresponding parent bucket.

## Patch testing

Manually tested by removing parent buckets using the modify-disk-store tool and then running the validate tool.

## ReleaseNotes changes

None.

## Other PRs 

No.