### PR TITLE
[SNAP-2248] Fixed the OOM issue 

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdConnectionWrapper.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/GfxdConnectionWrapper.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 import com.gemstone.gemfire.internal.Assert;
 import com.gemstone.gemfire.internal.cache.TXManagerImpl;
 import com.gemstone.gemfire.internal.cache.TXStateInterface;
+import com.gemstone.gemfire.internal.shared.SystemProperties;
 import com.gemstone.gemfire.internal.util.ArrayUtils;
 import com.gemstone.gnu.trove.THashMap;
 import com.koloboke.function.LongObjPredicate;
@@ -256,12 +257,15 @@ public final class GfxdConnectionWrapper {
             }
             this.stmntMap.justPut(stmtId, new StmntWeakReference(stmnt, stmtId,
                 this.refQueue));
-            this.sqlMap.justPut(stmtId, sql);
+            if (!(defaultSchema != null &&
+                defaultSchema.equalsIgnoreCase(SystemProperties.SNAPPY_HIVE_METASTORE))) {
+              this.sqlMap.justPut(stmtId, sql);
+            }
             if (GemFireXDUtils.TraceQuery | GemFireXDUtils.TraceNCJ) {
               SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_QUERYDISTRIB,
                   "GfxdConnectionWrapper: cached PreparedStatement with stmtId="
                       + stmtId + " for connId=" + this.incomingConnId
-                      + " SQL: " + sql + ", for " + this);
+                      + " SQL: " + sql + ", for " + this  + " SQLMapSize = "+ sqlMap.size());
             }
           }
         }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/PrepStatementExecutorMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/PrepStatementExecutorMessage.java
@@ -33,6 +33,7 @@ import com.gemstone.gemfire.internal.ByteArrayDataInput;
 import com.gemstone.gemfire.internal.HeapDataOutputStream;
 import com.gemstone.gemfire.internal.InternalDataSerializer;
 import com.gemstone.gemfire.internal.cache.LocalRegion;
+import com.gemstone.gemfire.internal.shared.SystemProperties;
 import com.pivotal.gemfirexd.Attribute;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
 import com.pivotal.gemfirexd.internal.engine.distributed.DVDIOUtil;
@@ -144,7 +145,9 @@ public final class PrepStatementExecutorMessage<T> extends
   @Override
   protected void setArgsForMember(final DistributedMember member,
       final Set<DistributedMember> messageAwareMembers) {
-    if (messageAwareMembers != null) {
+    if ((!(this.defaultSchema != null
+        && this.defaultSchema.equalsIgnoreCase(SystemProperties.SNAPPY_HIVE_METASTORE))
+        && messageAwareMembers != null)) {
       synchronized (messageAwareMembers) {
         if (messageAwareMembers.contains(member)) {
           if (GemFireXDUtils.TraceQuery | GemFireXDUtils.TraceNCJ) {


### PR DESCRIPTION
## Changes proposed in this pull request

The issue was due to prep statement cache, which was getting full due to hive queries.
The queries are fired due to UI service calls getHiveTables() method periodically. 
Have excluded hive queries to be in sqlMap.

We can think of caching all hive table metadata on the driver and integrate with DDL execution for invalidation. That can be taken up in a sperate PR. 
## Patch testing

precheckin pending

## ReleaseNotes changes

NA

## Other PRs 
NA