### PR TITLE
Fix for SNAP-2255. Reordering the if else if block so as to check per…

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericAuthorizer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericAuthorizer.java
@@ -152,12 +152,12 @@ implements Authorizer
                 }
                 checkAccess();
                 int sqlAllowed = RoutineAliasInfo.NO_SQL;
-                StatementContext ctx = this.lcc.getStatementContext();
+                StatementContext ctx = null;
                 if (perms != null && perms.size() > 0) {
                   // direct call from GfxdSystemProcedures.authorizeColumnTableScan
                   sqlAllowed = RoutineAliasInfo.READS_SQL_DATA;
                 }
-                else if (ctx != null) {
+                else if ((ctx = this.lcc.getStatementContext()) != null) {
 		              sqlAllowed = ctx.getSQLAllowed();
                 }
                 /* (original code)

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericAuthorizer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericAuthorizer.java
@@ -153,11 +153,12 @@ implements Authorizer
                 checkAccess();
                 int sqlAllowed = RoutineAliasInfo.NO_SQL;
                 StatementContext ctx = this.lcc.getStatementContext();
-                if (ctx != null) {
-                  sqlAllowed = ctx.getSQLAllowed();
-                } else if (perms != null && perms.size() > 0) {
+                if (perms != null && perms.size() > 0) {
                   // direct call from GfxdSystemProcedures.authorizeColumnTableScan
                   sqlAllowed = RoutineAliasInfo.READS_SQL_DATA;
+                }
+                else if (ctx != null) {
+		              sqlAllowed = ctx.getSQLAllowed();
                 }
                 /* (original code)
 		int sqlAllowed = lcc.getStatementContext().getSQLAllowed();


### PR DESCRIPTION
…missions from the passed list if not null, else check using statement context. Otherwise the query always gets no read access
Without this change, if the connection is returned to pool, then GenericStatementContext is not null & user will get NO READ PERMISSION.
## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 
[Corresponding PR in SnappyData](https://github.com/SnappyDataInc/snappydata/pull/995)
(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
