### PR TITLE
Modified the parser to consider BINARY also as a definition of Blob.

### DIFF
--- a/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
+++ b/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
@@ -5267,7 +5267,7 @@ LOBType() throws StandardException :
 			throw StandardException.newException(SQLState.NOT_IMPLEMENTED, type);
 		}
 	|
-		<BINARY> <LARGE> <OBJECT> [ length = lengthAndModifier() ]
+		<BINARY> [ <LARGE> <OBJECT> ] [ length = lengthAndModifier() ]
 		{
 			type = TypeId.BLOB_NAME;
 		}


### PR DESCRIPTION
## Changes proposed in this pull request

Snappy sends only 'BINARY' as column type which gemxd parser does not understands. So modified the parser accordingly.

## Patch testing

manual testing. adding a small test.

## ReleaseNotes changes

None

## Other PRs 

No