### PR TITLE
Fix for SNAP-2264. The column types like EXTERNAL etc are now aliased…

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedDatabaseMetaData.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedDatabaseMetaData.java
@@ -1808,7 +1808,7 @@ public class EmbedDatabaseMetaData extends ConnectionChild
 			typeParams[i] = null;
 		
 		for (int i = 0; i<types.length; i++){
-			if ("TABLE".equals(types[i]) || "ROW TABLE".equals(types[i]))
+			if ("TABLE".equals(types[i]) || "ROW TABLE".equals(types[i]) || "ROW_TABLE".equals(types[i]))
 				typeParams[0] = "T";
 			else if ("VIEW".equals(types[i])) {
 				typeParams[1] = "V";
@@ -1823,13 +1823,13 @@ public class EmbedDatabaseMetaData extends ConnectionChild
 			else if ("COLUMN TABLE".equals(types[i]) ||
 			    "COLUMN_TABLE".equals(types[i])) // In case we treat it like SYSTEM_TABLE
 			    typeParams[4] = "COLUMN";
-			else if ("EXTERNAL TABLE".equals(types[i]))
+			else if ("EXTERNAL TABLE".equals(types[i]) || "EXTERNAL_TABLE".equals(types[i]) )
 			    typeParams[5] = "EXTERNAL";
-			else if ("STREAM TABLE".equals(types[i]))
+			else if ("STREAM TABLE".equals(types[i]) || "STREAM_TABLE".equals(types[i]) )
 			    typeParams[6] = "STREAM";
-			else if ("SAMPLE TABLE".equals(types[i]))
+			else if ("SAMPLE TABLE".equals(types[i]) || "SAMPLE_TABLE".equals(types[i]))
 			    typeParams[7] = "SAMPLE";
-			else if ("TOPK TABLE".equals(types[i]))
+			else if ("TOPK TABLE".equals(types[i]) || "TOPK_TABLE".equals(types[i]))
 			    typeParams[8] = "TOPK";
 			//GemStone changes END
 			// If user puts in other types we simply ignore.


### PR DESCRIPTION
… as EXTERNAL_TABLE  etc

Adding aliases for the table types as in Qlik reporting tool, white space in the name is not supported.
Pls refer to bug SNAP-2264

[SNAP-2264](https://jira.snappydata.io/browse/SNAP-2264)

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
