### PR TITLE
potential fix for servers not stopping and the shutdown command getti…

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
@@ -774,7 +774,11 @@ public class CacheServerLauncher extends LauncherBase {
     serverConnector.start();
     
     while(true) {
-      serverConnector.join(500);
+      try {
+        serverConnector.join(500);
+      } catch (InterruptedException ie) {
+        //ignore
+      }
       if (serverConnector.isAlive()) {
         Status s = readStatus();
         if (s.state == SHUTDOWN_PENDING || s.state == SHUTDOWN) {
@@ -1090,6 +1094,7 @@ public class CacheServerLauncher extends LauncherBase {
         this.status = createStatus(SHUTDOWN_PENDING, this.status.pid);
         writeStatus(this.status);
       }
+     ;
 
       // poll the Cache Server for a response to our shutdown request (passes through if the Cache Server
       // has already shutdown)...


### PR DESCRIPTION
…ng timed out. With the change the hangs got resolved
Pls refer to bug 
[SNAP-2252](https://jira.snappydata.io/browse/SNAP-2252)
With the change the stop all command is now executing successfully. 
Though I am not sure its worth spending time to find out from where this launcher thread which is stopping the server connector thread ,  is getting a spurious interrupt flag set on it , causing join to get interrupted. If you have any clue let me know or I will spend time to find out where it is, in case it needs to be probed further

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
