### PR TITLE
[SNAP-2337] use fallback system allocator for channels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -500,9 +500,12 @@ subprojects {
         environment 'GEMFIREXD'                           : productDir.getAbsolutePath(),
                     'JUNIT_JAR'                           : sourceSets.test.output.classesDir
 
-        int numTestClasses = test.getCandidateClassFiles().getFiles().size()
+        int numTestClasses = 0
         def testCount = new java.util.concurrent.atomic.AtomicInteger(0)
 
+        doFirst {
+          numTestClasses = test.getCandidateClassFiles().getFiles().size()
+        }
         beforeSuite { desc ->
           if (desc.className != null) {
             def count = testCount.incrementAndGet()

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/GemFireVersion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/GemFireVersion.java
@@ -184,6 +184,7 @@ public class GemFireVersion {
     else {
       try {
         props.load(is);
+        is.close();
       } 
       catch (Exception ex) {
         props.put(ERROR_PROPERTY, LocalizedStrings.GemFireVersion_COULD_NOT_READ_PROPERTIES_FROM_RESOURCE_COM_GEMSTONE_GEMFIRE_INTERNAL_0_BECAUSE_1.toLocalizedString(new Object[] {resourceName, ex}));

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/BufferAllocator.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/BufferAllocator.java
@@ -39,6 +39,14 @@ public abstract class BufferAllocator implements Closeable {
   public abstract ByteBuffer allocate(int size, String owner);
 
   /**
+   * Allocate using the default allocator and fallback to base JDK one in case
+   * allocation fails due to some reason (e.g. system stop).
+   */
+  public ByteBuffer allocateWithFallback(int size, String owner) {
+    return allocate(size, owner);
+  }
+
+  /**
    * Allocate a new ByteBuffer of given size for storage in a Region.
    */
   public abstract ByteBuffer allocateForStorage(int size);

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/ChannelBufferUnsafeInputStream.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/ChannelBufferUnsafeInputStream.java
@@ -101,7 +101,7 @@ public class ChannelBufferUnsafeInputStream extends InputStreamChannel {
 
   protected ByteBuffer allocateBuffer(int bufferSize) {
     // use allocator which will restrict total allocated size
-    ByteBuffer buffer = DirectBufferAllocator.instance().allocate(
+    ByteBuffer buffer = DirectBufferAllocator.instance().allocateWithFallback(
         bufferSize, "CHANNELINPUT");
     // set the order to native explicitly to skip any byte order conversions
     buffer.order(ByteOrder.nativeOrder());

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/ChannelBufferUnsafeOutputStream.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/ChannelBufferUnsafeOutputStream.java
@@ -113,7 +113,7 @@ public class ChannelBufferUnsafeOutputStream extends OutputStreamChannel {
               + " too small (minimum " + MIN_BUFFER_SIZE + ')');
     }
     // use allocator which will restrict total allocated size
-    final ByteBuffer buffer = DirectBufferAllocator.instance().allocate(
+    final ByteBuffer buffer = DirectBufferAllocator.instance().allocateWithFallback(
         bufferSize, "CHANNELOUTPUT");
     // set the order to native explicitly to skip any byte order conversions
     buffer.order(ByteOrder.nativeOrder());

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/DirectBufferAllocator.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/DirectBufferAllocator.java
@@ -83,6 +83,19 @@ public class DirectBufferAllocator extends BufferAllocator {
   }
 
   @Override
+  public ByteBuffer allocateWithFallback(int size, String owner) {
+    try {
+      return allocateForStorage(size);
+    } catch (RuntimeException re) {
+      if (instance() != globalInstance) {
+        return globalInstance.allocateForStorage(size);
+      } else {
+        throw re;
+      }
+    }
+  }
+
+  @Override
   public ByteBuffer allocateForStorage(int size) {
     ByteBuffer buffer = ByteBuffer.allocateDirect(size);
     if (MemoryAllocator.MEMORY_DEBUG_FILL_ENABLED) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/Misc.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/Misc.java
@@ -660,33 +660,6 @@ public abstract class Misc {
     return sw.toString();
   }
 
-  public static String serializeXMLAsString(Element el, String xsltFileName) {
-    try {
-      TransformerFactory tFactory = TransformerFactory.newInstance();
-      StringWriter sw = new StringWriter();
-      DOMSource source = new DOMSource(el);
-
-      ClassLoader cl = InternalDistributedSystem.class.getClassLoader();
-      // fix for bug 33274 - null classloader in Sybase app server
-      if (cl == null) {
-        cl = ClassLoader.getSystemClassLoader();
-      }
-      InputStream is = cl
-          .getResourceAsStream("com/pivotal/gemfirexd/internal/impl/tools/planexporter/resources/"
-              + xsltFileName);
-
-      Transformer transformer = tFactory
-          .newTransformer(new javax.xml.transform.stream.StreamSource(is));
-      StreamResult result = new StreamResult(sw);
-
-      transformer.transform(source, result);
-      return sw.toString();
-    } catch (TransformerException te) {
-      throw GemFireXDRuntimeException.newRuntimeException(
-          "serializeXMLAsString: unexpected exception", te);
-    }
-  }
-
   public static char[] serializeXMLAsCharArr(List<Element> el,
       String xsltFileName) {
     try {
@@ -723,8 +696,9 @@ public abstract class Misc {
         transformer.transform(source, result);
       }
 
+      is.close();
       return cw.toCharArray();
-    } catch (TransformerException te) {
+    } catch (Exception te) {
       throw GemFireXDRuntimeException.newRuntimeException(
           "serializeXMLAsCharArr: unexpected exception", te);
     }

--- a/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/iapi/services/info/ProductVersionHolder.java
+++ b/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/iapi/services/info/ProductVersionHolder.java
@@ -540,6 +540,7 @@ public final class ProductVersionHolder implements java.security.PrivilegedActio
 		Properties p = new Properties();
 		try {
 			p.load(is);
+			is.close();
 			return p;
 		}
 		catch (IOException ioe) {

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/ThriftUtils.java
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/ThriftUtils.java
@@ -154,7 +154,8 @@ public abstract class ThriftUtils {
     // sun.misc.VM.maxDirectMemory()
     ByteBuffer buffer;
     try {
-      buffer = DirectBufferAllocator.instance().allocate(length, "THRIFT");
+      buffer = DirectBufferAllocator.instance().allocateWithFallback(
+          length, "THRIFT");
     } catch (OutOfMemoryError | RuntimeException ignored) {
       // fallback to heap buffer
       buffer = ByteBuffer.allocate(length);

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/snappydata.thrift
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/snappydata.thrift
@@ -458,7 +458,7 @@ exception SnappyException {
 }
 
 // default batch size
-const i32 DEFAULT_RESULTSET_BATCHSIZE                      = 1024
+const i32 DEFAULT_RESULTSET_BATCHSIZE                      = 262144
 // default LOB chunk size
 const i32 DEFAULT_LOB_CHUNKSIZE                            = 2097152 // 2MB
 

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/snappydataConstants.java
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/snappydataConstants.java
@@ -58,7 +58,7 @@ public class snappydataConstants {
 
   public static final int DEFAULT_SESSION_TOKEN_SIZE = 16;
 
-  public static final int DEFAULT_RESULTSET_BATCHSIZE = 1024;
+  public static final int DEFAULT_RESULTSET_BATCHSIZE = 262144;
 
   public static final int DEFAULT_LOB_CHUNKSIZE = 2097152;
 

--- a/native/src/snappyclient/headers/snappydata_constants.h
+++ b/native/src/snappyclient/headers/snappydata_constants.h
@@ -27,7 +27,7 @@ class snappydataConstants {
   static const int8_t DRIVER_JDBC = 1;
   static const int8_t DRIVER_ODBC = 2;
   static const int32_t DEFAULT_SESSION_TOKEN_SIZE = 16;
-  static const int32_t DEFAULT_RESULTSET_BATCHSIZE = 1024;
+  static const int32_t DEFAULT_RESULTSET_BATCHSIZE = 262144;
   static const int32_t DEFAULT_LOB_CHUNKSIZE = 2097152;
   static const int8_t TRANSACTION_NONE = 0;
   static const int8_t TRANSACTION_READ_UNCOMMITTED = 1;


### PR DESCRIPTION
## Changes proposed in this pull request

- in case of allocation failure on channels (due to node stopping, for example) fallback
  to default ByteBuffer.allocateDirect else all messaging will fail
- added BufferAllocator.allocateWithFallback for above and use it for channels
- increased default thrift row batch size to 256K from 1K to improve large data pulls
  (size limit of 4M still applies if reached first)
- close some dangling file handles

## Patch testing

precheckin in progress

## ReleaseNotes changes

NA

## Other PRs 

NA