### PR TITLE
[SNAP-2356] cleanup buffer release calls

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskRegionEntry.java
@@ -47,7 +47,7 @@ public abstract class AbstractDiskRegionEntry
   public  void setValue(RegionEntryContext context, Object v) throws RegionClearedException {
     Helper.update(this, (LocalRegion) context, v);
     setRecentlyUsed(); // fix for bug #42284 - entry just put into the cache is evicted
-    initDiskIdForOffHeap(context, v);
+    initDiskIdForDiskBuffer(context, v);
   }
 
   /**
@@ -58,7 +58,7 @@ public abstract class AbstractDiskRegionEntry
   @Override
   public void setValueWithContext(RegionEntryContext context, Object value) {
     _setValue(context, value);
-    initDiskIdForOffHeap(context, value);
+    initDiskIdForDiskBuffer(context, value);
     if (value != null && context != null && context instanceof LocalRegion
         && ((LocalRegion)context).isThisRegionBeingClosedOrDestroyed()
         && isOffHeap()) {
@@ -71,7 +71,7 @@ public abstract class AbstractDiskRegionEntry
    * Set the RegionEntry DiskId into SerializedDiskBuffer value, if present,
    * so that the value can access data from disk when required independently.
    */
-  protected abstract void initDiskIdForOffHeap(RegionEntryContext context,
+  protected abstract void initDiskIdForDiskBuffer(RegionEntryContext context,
       Object value);
 
   @Override

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
@@ -56,7 +56,7 @@ public abstract class AbstractOplogDiskRegionEntry
   protected abstract void setDiskId(RegionEntry oldRe);
 
   @Override
-  protected final void initDiskIdForOffHeap(RegionEntryContext context,
+  protected final void initDiskIdForDiskBuffer(RegionEntryContext context,
       Object value) {
     // copy self to value if required
     if (value instanceof SerializedDiskBuffer) {
@@ -64,10 +64,11 @@ public abstract class AbstractOplogDiskRegionEntry
     }
   }
 
-  public final void setDiskIdForRegion(RegionEntry oldRe) {
+  public final void setDiskIdForRegion(RegionEntryContext context,
+      RegionEntry oldRe) {
     setDiskId(oldRe);
-    if (GemFireCacheImpl.hasNewOffHeap()) {
-      initDiskIdForOffHeap(null, getValueField());
+    if (!isOffHeap()) {
+      initDiskIdForDiskBuffer(context, getValueField());
     }
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
@@ -883,7 +883,7 @@ abstract class AbstractRegionMap implements RegionMap {
             continue;
           }
           RegionEntry newRe = getEntryFactory().createEntry(owner, key, value);
-          copyRecoveredEntry(oldRe, newRe, currentTime);
+          copyRecoveredEntry(oldRe, newRe, owner, currentTime);
           // newRe is now in this._getMap().
           if (newRe.isTombstone()) {
             VersionTag tag = newRe.getVersionStamp().asVersionTag();
@@ -935,7 +935,8 @@ abstract class AbstractRegionMap implements RegionMap {
     
   }
   
-  protected void copyRecoveredEntry(RegionEntry oldRe, RegionEntry newRe, long dummyVersionTs) {
+  protected void copyRecoveredEntry(RegionEntry oldRe, RegionEntry newRe,
+      LocalRegion owner, long dummyVersionTs) {
     long lastModifiedTime = oldRe.getLastModified();
     if (lastModifiedTime != 0) {
       newRe.setLastModified(lastModifiedTime);
@@ -956,7 +957,7 @@ abstract class AbstractRegionMap implements RegionMap {
 
     if (newRe instanceof AbstractOplogDiskRegionEntry) {
       AbstractOplogDiskRegionEntry newDe = (AbstractOplogDiskRegionEntry)newRe;
-      newDe.setDiskIdForRegion(oldRe);
+      newDe.setDiskIdForRegion(owner, oldRe);
       _getOwner().getDiskRegion().replaceIncompatibleEntry((DiskEntry) oldRe, newDe);
     }
     _getMap().put(newRe.getKey(), newRe);

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/HeapBufferAllocator.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/HeapBufferAllocator.java
@@ -126,14 +126,6 @@ public final class HeapBufferAllocator extends BufferAllocator {
   }
 
   @Override
-  public void release(ByteBuffer buffer) {
-    if (MemoryAllocator.MEMORY_DEBUG_FILL_ENABLED) {
-      buffer.rewind();
-      fill(buffer, MemoryAllocator.MEMORY_DEBUG_FILL_FREED_VALUE);
-    }
-  }
-
-  @Override
   public boolean isDirect() {
     return false;
   }

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/DirectBufferAllocator.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/DirectBufferAllocator.java
@@ -166,16 +166,6 @@ public class DirectBufferAllocator extends BufferAllocator {
   }
 
   @Override
-  public void release(ByteBuffer buffer) {
-    if (MemoryAllocator.MEMORY_DEBUG_FILL_ENABLED) {
-      buffer.rewind();
-      fill(buffer, MemoryAllocator.MEMORY_DEBUG_FILL_FREED_VALUE);
-    }
-    // reserved bytes will be decremented via FreeMemory implementations
-    UnsafeHolder.releaseDirectBuffer(buffer);
-  }
-
-  @Override
   public boolean isDirect() {
     return true;
   }

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
@@ -297,19 +297,9 @@ public abstract class UnsafeHolder {
   }
 
   /**
-   * Release explicitly if the passed ByteBuffer is a direct one. Avoid using
+   * Release explicitly assuming passed ByteBuffer is a direct one. Avoid using
    * this directly rather use BufferAllocator.allocate/release where possible.
    */
-  public static void releaseIfDirectBuffer(ByteBuffer buffer) {
-    if (buffer != null) {
-      if (buffer.isDirect()) {
-        releaseDirectBuffer(buffer);
-      } else {
-        buffer.rewind().limit(0);
-      }
-    }
-  }
-
   public static void releaseDirectBuffer(ByteBuffer buffer) {
     sun.misc.Cleaner cleaner = ((sun.nio.ch.DirectBuffer)buffer).cleaner();
     if (cleaner != null) {

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/BlobChunk.java
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/BlobChunk.java
@@ -29,10 +29,10 @@ import java.nio.ByteBuffer;
 import java.util.*;
 import javax.annotation.Generated;
 
+import com.gemstone.gemfire.internal.shared.BufferAllocator;
 import com.gemstone.gemfire.internal.shared.ByteBufferReference;
 import com.gemstone.gemfire.internal.shared.ClientSharedData;
 import com.gemstone.gemfire.internal.shared.FetchRequest;
-import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder;
 import io.snappydata.thrift.common.SocketTimeout;
 import io.snappydata.thrift.common.TProtocolDirectBinary;
 import io.snappydata.thrift.common.ThriftUtils;
@@ -113,8 +113,8 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
         reference.release();
       }
       this.chunkReference = null;
-    } else {
-      UnsafeHolder.releaseIfDirectBuffer(this.chunk);
+    } else if (this.chunk != null) {
+      BufferAllocator.releaseBuffer(this.chunk);
     }
     this.chunk = ClientSharedData.NULL_BUFFER;
   }

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/StatementAttrs.java
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/StatementAttrs.java
@@ -286,7 +286,7 @@ public class StatementAttrs implements org.apache.thrift.TBase<StatementAttrs, S
   }
 
   public StatementAttrs() {
-    this.batchSize = 262144;
+    this.batchSize = 8192;
 
   }
 
@@ -364,7 +364,7 @@ public class StatementAttrs implements org.apache.thrift.TBase<StatementAttrs, S
     this.requireAutoIncCols = false;
     this.autoIncColumns = null;
     this.autoIncColumnNames = null;
-    this.batchSize = 262144;
+    this.batchSize = 8192;
 
     setFetchReverseIsSet(false);
     this.fetchReverse = false;

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/BlobChunk.java.tmpl
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/BlobChunk.java.tmpl
@@ -29,10 +29,10 @@ import java.nio.ByteBuffer;
 import java.util.*;
 import javax.annotation.Generated;
 
+import com.gemstone.gemfire.internal.shared.BufferAllocator;
 import com.gemstone.gemfire.internal.shared.ByteBufferReference;
 import com.gemstone.gemfire.internal.shared.ClientSharedData;
 import com.gemstone.gemfire.internal.shared.FetchRequest;
-import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder;
 import io.snappydata.thrift.common.SocketTimeout;
 import io.snappydata.thrift.common.TProtocolDirectBinary;
 import io.snappydata.thrift.common.ThriftUtils;
@@ -113,8 +113,8 @@ public class BlobChunk implements org.apache.thrift.TBase<BlobChunk, BlobChunk._
         reference.release();
       }
       this.chunkReference = null;
-    } else {
-      UnsafeHolder.releaseIfDirectBuffer(this.chunk);
+    } else if (this.chunk != null) {
+      BufferAllocator.releaseBuffer(this.chunk);
     }
     this.chunk = ClientSharedData.NULL_BUFFER;
   }

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/snappydata.thrift
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/snappydata.thrift
@@ -458,7 +458,7 @@ exception SnappyException {
 }
 
 // default batch size
-const i32 DEFAULT_RESULTSET_BATCHSIZE                      = 262144
+const i32 DEFAULT_RESULTSET_BATCHSIZE                      = 8192
 // default LOB chunk size
 const i32 DEFAULT_LOB_CHUNKSIZE                            = 2097152 // 2MB
 

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/snappydataConstants.java
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/snappydataConstants.java
@@ -58,7 +58,7 @@ public class snappydataConstants {
 
   public static final int DEFAULT_SESSION_TOKEN_SIZE = 16;
 
-  public static final int DEFAULT_RESULTSET_BATCHSIZE = 262144;
+  public static final int DEFAULT_RESULTSET_BATCHSIZE = 8192;
 
   public static final int DEFAULT_LOB_CHUNKSIZE = 2097152;
 

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/DistributedSQLTestBase.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/DistributedSQLTestBase.java
@@ -33,7 +33,13 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
 import com.gemstone.gemfire.LogWriter;
-import com.gemstone.gemfire.cache.*;
+import com.gemstone.gemfire.cache.Cache;
+import com.gemstone.gemfire.cache.CacheException;
+import com.gemstone.gemfire.cache.CacheListener;
+import com.gemstone.gemfire.cache.DiskAccessException;
+import com.gemstone.gemfire.cache.PartitionAttributesFactory;
+import com.gemstone.gemfire.cache.Region;
+import com.gemstone.gemfire.cache.RegionAttributes;
 import com.gemstone.gemfire.cache.asyncqueue.AsyncEventQueue;
 import com.gemstone.gemfire.cache.hdfs.internal.HDFSStoreImpl;
 import com.gemstone.gemfire.cache.wan.GatewayReceiver;
@@ -48,7 +54,6 @@ import com.gemstone.gemfire.internal.cache.LocalRegion;
 import com.gemstone.gemfire.internal.cache.PartitionAttributesImpl;
 import com.gemstone.gemfire.internal.concurrent.ConcurrentHashSet;
 import com.pivotal.gemfirexd.NetworkInterface.ConnectionListener;
-import com.pivotal.gemfirexd.ddl.IndexPersistenceDUnit;
 import com.pivotal.gemfirexd.internal.engine.GemFireXDQueryObserverAdapter;
 import com.pivotal.gemfirexd.internal.engine.GemFireXDQueryObserverHolder;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
@@ -342,7 +347,54 @@ public class DistributedSQLTestBase extends DistributedTestBase {
   @Override
   public void setUp() throws Exception {
     baseSetUp();
-    IndexPersistenceDUnit.deleteAllOplogFiles();
+    deleteAllOplogFiles();
+  }
+
+  public static void deleteAllOplogFiles() throws IOException {
+    try {
+      File currDir = new File(".");
+      File[] files = currDir.listFiles();
+      getGlobalLogger().info("current dir is: " + currDir.getCanonicalPath());
+
+      if (files != null) {
+        for (File f : files) {
+          if (f.getAbsolutePath().contains("BACKUPGFXD-DEFAULT-DISKSTORE")) {
+            getGlobalLogger().info("deleting file: " + f + " from dir: " + currDir);
+            f.delete();
+          }
+          if (f.isDirectory()) {
+            File newDir = new File(f.getCanonicalPath());
+            File[] newFiles = newDir.listFiles();
+            for (File nf : newFiles) {
+              if (nf.getAbsolutePath().contains("BACKUPGFXD-DEFAULT-DISKSTORE")) {
+                getGlobalLogger().info(
+                    "deleting file: " + nf + " from dir: " + newDir);
+                nf.delete();
+              }
+            }
+          }
+        }
+        for (File f : files) {
+          if (f.getAbsolutePath().contains("GFXD-DD-DISKSTORE")) {
+            getGlobalLogger().info("deleting file: " + f + " from dir: " + currDir);
+            f.delete();
+          }
+          if (f.isDirectory()) {
+            File newDir = new File(f.getCanonicalPath());
+            File[] newFiles = newDir.listFiles();
+            for (File nf : newFiles) {
+              if (nf.getAbsolutePath().contains("GFXD-DD-DISKSTORE")) {
+                getGlobalLogger().info(
+                    "deleting file: " + nf + " from dir: " + newDir);
+                nf.delete();
+              }
+            }
+          }
+        }
+      }
+    } catch (IOException e) {
+      // ignore ...
+    }
   }
 
   protected void reduceLogLevelForTest(String logLevel) {

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/DistributedSQLTestBase.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/DistributedSQLTestBase.java
@@ -152,11 +152,6 @@ public class DistributedSQLTestBase extends DistributedTestBase {
   public static final char fileSeparator = System.getProperty("file.separator")
       .charAt(0);
 
-  /** this indicates whether beforeClass has been executed for current class */
-  protected static boolean beforeClassDone;
-  /** this stores the last test method in the current class for afterClass */
-  protected static String lastTest;
-
   private static transient DistributedSQLTestBase testInstance = null;
   
   private volatile boolean configureDefaultOffHeap = false;

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/IndexPersistenceDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/IndexPersistenceDUnit.java
@@ -18,7 +18,6 @@
 package com.pivotal.gemfirexd.ddl;
 
 import java.io.File;
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -47,7 +46,6 @@ import com.pivotal.gemfirexd.internal.engine.access.index.GfxdIndexManager;
 import com.pivotal.gemfirexd.internal.engine.store.GemFireContainer;
 import com.pivotal.gemfirexd.internal.engine.store.GemFireStore;
 import com.pivotal.gemfirexd.internal.iapi.types.RowLocation;
-
 import io.snappydata.test.dunit.SerializableRunnable;
 import io.snappydata.test.dunit.VM;
 import io.snappydata.test.util.TestException;
@@ -568,53 +566,6 @@ public class IndexPersistenceDUnit extends DistributedSQLTestBase {
       invokeInEveryVM(IndexPersistenceDUnit.class, "setSystemProperty",
           new Object[] { GfxdConstants.GFXD_PERSIST_INDEXES, "false" });
       invokeInEveryVM(IndexPersistenceDUnit.class, "unsetTestOplogToTestForCompaction");
-    }
-  }
-  
-  public static void deleteAllOplogFiles() throws IOException {
-    try {
-      File currDir = new File(".");
-      File[] files = currDir.listFiles();
-      getGlobalLogger().info("current dir is: " + currDir.getCanonicalPath());
-
-      if (files != null) {
-        for (File f : files) {
-          if (f.getAbsolutePath().contains("BACKUPGFXD-DEFAULT-DISKSTORE")) {
-            getGlobalLogger().info("deleting file: " + f + " from dir: " + currDir);
-            f.delete();
-          }
-          if (f.isDirectory()) {
-            File newDir = new File(f.getCanonicalPath());
-            File[] newFiles = newDir.listFiles();
-            for (File nf : newFiles) {
-              if (nf.getAbsolutePath().contains("BACKUPGFXD-DEFAULT-DISKSTORE")) {
-                getGlobalLogger().info(
-                    "deleting file: " + nf + " from dir: " + newDir);
-                nf.delete();
-              }
-            }
-          }
-        }
-        for (File f : files) {
-          if (f.getAbsolutePath().contains("GFXD-DD-DISKSTORE")) {
-            getGlobalLogger().info("deleting file: " + f + " from dir: " + currDir);
-            f.delete();
-          }
-          if (f.isDirectory()) {
-            File newDir = new File(f.getCanonicalPath());
-            File[] newFiles = newDir.listFiles();
-            for (File nf : newFiles) {
-              if (nf.getAbsolutePath().contains("GFXD-DD-DISKSTORE")) {
-                getGlobalLogger().info(
-                    "deleting file: " + nf + " from dir: " + newDir);
-                nf.delete();
-              }
-            }
-          }
-        }
-      }
-    } catch (IOException e) {
-      // ignore ...
     }
   }
 

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/TransactionDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/TransactionDUnit.java
@@ -83,14 +83,22 @@ public class TransactionDUnit extends DistributedSQLTestBase {
     super(name);
   }
 
+  // static lists to transfer clientVMs/serverVMs between tests since each test
+  // creates a new test object
   private static List<VM> globalClientVMs;
   private static List<VM> globalServerVMs;
 
   @Override
   public void beforeClass() throws Exception {
+    globalClientVMs = null;
+    globalServerVMs = null;
     super.beforeClass();
     super.baseShutDownAll();
+    deleteAllOplogFiles();
+    getLogWriter().info(getClass() + ".beforeClass: starting 1+3 VMs");
     startVMs(1, 3);
+    getLogWriter().info(getClass() + ".beforeClass: started 1+3 VMs: " +
+        clientVMs + " ; " + serverVMs);
   }
 
   @Override
@@ -109,6 +117,8 @@ public class TransactionDUnit extends DistributedSQLTestBase {
     setupConnection(userName);
     invokeInEveryVM(TransactionDUnit.class, "setupConnection",
         new Object[]{userName});
+    getLogWriter().info(getClass() + "." + getTestName() + ".setUp VMs: " +
+        clientVMs + " ; " + serverVMs);
   }
 
   public static void setupConnection(String userName) throws SQLException {
@@ -130,6 +140,8 @@ public class TransactionDUnit extends DistributedSQLTestBase {
 
   @Override
   public void afterClass() throws Exception {
+    globalClientVMs = null;
+    globalServerVMs = null;
     super.baseShutDownAll();
     super.afterClass();
   }

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/internal/engine/distributed/query/CharPartitionTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/internal/engine/distributed/query/CharPartitionTest.java
@@ -27,7 +27,7 @@ import com.pivotal.gemfirexd.jdbc.JdbcTestBase;
 import junit.framework.TestSuite;
 import junit.textui.TestRunner;
 
-public class CharPartitionTest extends JdbcTestBase{
+public class CharPartitionTest extends JdbcTestBase {
 
   private static volatile Connection derbyConn = null;
   
@@ -131,7 +131,7 @@ public class CharPartitionTest extends JdbcTestBase{
   private void partitionBy(String partitionStrategy) throws Exception {
 
     try {
-
+      Class.forName("org.apache.derby.jdbc.EmbeddedDriver").newInstance();
 
       // create a table with char columns of different lengths
 

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/BugsTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/BugsTest.java
@@ -196,7 +196,7 @@ public class BugsTest extends JdbcTestBase {
       rs = st.executeQuery("select st, cty, client_id from ODS.POSTAL_ADDRESS "
           + "where ST='ST" + (i + 20) + "' AND CLIENT_ID=" + (i + 20));
       if (i >= 0 && i < 150) {
-        assertTrue(rs.next());
+        assertTrue("failed to find result for " + i, rs.next());
         assertEquals("ST" + (i + 20), rs.getString(1));
         if (i < 100) {
           assertEquals("CTY" + (i + 20), rs.getString(2));

--- a/native/src/snappyclient/headers/snappydata_constants.h
+++ b/native/src/snappyclient/headers/snappydata_constants.h
@@ -27,7 +27,7 @@ class snappydataConstants {
   static const int8_t DRIVER_JDBC = 1;
   static const int8_t DRIVER_ODBC = 2;
   static const int32_t DEFAULT_SESSION_TOKEN_SIZE = 16;
-  static const int32_t DEFAULT_RESULTSET_BATCHSIZE = 262144;
+  static const int32_t DEFAULT_RESULTSET_BATCHSIZE = 8192;
   static const int32_t DEFAULT_LOB_CHUNKSIZE = 2097152;
   static const int8_t TRANSACTION_NONE = 0;
   static const int8_t TRANSACTION_READ_UNCOMMITTED = 1;

--- a/native/src/snappyclient/headers/snappydata_struct_StatementAttrs.h
+++ b/native/src/snappyclient/headers/snappydata_struct_StatementAttrs.h
@@ -54,7 +54,7 @@ class StatementAttrs {
   StatementAttrs(StatementAttrs&&) noexcept;
   StatementAttrs& operator=(const StatementAttrs&);
   StatementAttrs& operator=(StatementAttrs&&) noexcept;
-  StatementAttrs() : resultSetType(0), updatable(0), holdCursorsOverCommit(0), requireAutoIncCols(0), batchSize(262144), fetchReverse(0), lobChunkSize(0), maxRows(0), maxFieldSize(0), timeout(0), cursorName(), possibleDuplicate(0), poolable(0), doEscapeProcessing(0), bucketIdsTable() {
+  StatementAttrs() : resultSetType(0), updatable(0), holdCursorsOverCommit(0), requireAutoIncCols(0), batchSize(8192), fetchReverse(0), lobChunkSize(0), maxRows(0), maxFieldSize(0), timeout(0), cursorName(), possibleDuplicate(0), poolable(0), doEscapeProcessing(0), bucketIdsTable() {
   }
 
   virtual ~StatementAttrs() noexcept;


### PR DESCRIPTION
## Changes proposed in this pull request

- moved common code in BufferAllocator.releaseBuffer depending on kind of buffer (rather than allocator)
  and avoid using UnsafeHolder.releaseDirectBuffer directly; this is to address corner cases where
  current allocator might be different from allocated buffer during bootup/shutdown
- removed UnsafeHolder.releaseIfDirectBuffer

## Patch testing

precheckin in progress

## ReleaseNotes changes

NA

## Other PRs 

see snappy PR