### PR TITLE
[GITHUB-982] negative bucket size with eviction

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractDiskRegionEntry.java
@@ -45,9 +45,9 @@ public abstract class AbstractDiskRegionEntry
 
   @Override
   public  void setValue(RegionEntryContext context, Object v) throws RegionClearedException {
+    initContextForDiskBuffer(context, v);
     Helper.update(this, (LocalRegion) context, v);
     setRecentlyUsed(); // fix for bug #42284 - entry just put into the cache is evicted
-    initDiskIdForDiskBuffer(context, v);
   }
 
   /**
@@ -57,8 +57,8 @@ public abstract class AbstractDiskRegionEntry
    */
   @Override
   public void setValueWithContext(RegionEntryContext context, Object value) {
+    initContextForDiskBuffer(context, value);
     _setValue(context, value);
-    initDiskIdForDiskBuffer(context, value);
     if (value != null && context != null && context instanceof LocalRegion
         && ((LocalRegion)context).isThisRegionBeingClosedOrDestroyed()
         && isOffHeap()) {
@@ -66,13 +66,6 @@ public abstract class AbstractDiskRegionEntry
       ((LocalRegion)context).checkReadiness();
     }
   }
-
-  /**
-   * Set the RegionEntry DiskId into SerializedDiskBuffer value, if present,
-   * so that the value can access data from disk when required independently.
-   */
-  protected abstract void initDiskIdForDiskBuffer(RegionEntryContext context,
-      Object value);
 
   @Override
   public void handleValueOverflow(RegionEntryContext context) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractOplogDiskRegionEntry.java
@@ -56,9 +56,8 @@ public abstract class AbstractOplogDiskRegionEntry
   protected abstract void setDiskId(RegionEntry oldRe);
 
   @Override
-  protected final void initDiskIdForDiskBuffer(RegionEntryContext context,
+  protected final void initContextForDiskBuffer(RegionEntryContext context,
       Object value) {
-    // copy self to value if required
     if (value instanceof SerializedDiskBuffer) {
       ((SerializedDiskBuffer)value).setDiskEntry(this, context);
     }
@@ -68,7 +67,7 @@ public abstract class AbstractOplogDiskRegionEntry
       RegionEntry oldRe) {
     setDiskId(oldRe);
     if (!isOffHeap()) {
-      initDiskIdForDiskBuffer(context, getValueField());
+      initContextForDiskBuffer(context, getValueField());
     }
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
@@ -1482,7 +1482,7 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
             setContainerInfo(null, val);
           }
           if (!isOffHeap && context != null) {
-            context.updateMemoryStats(getRawKey(), rawOldVal, val);
+            context.updateMemoryStats(rawOldVal, val);
           }
           return;
         } catch (IllegalAccessException e) {
@@ -1717,14 +1717,13 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
     try {
     // update the memory stats if required
     if (owner != previousOwner && !isOffHeap()) {
-      final Object key = getRawKey();
       // set the context into the value if required
       initContextForDiskBuffer(owner, val);
       // add for new owner
-      if (owner != null) owner.updateMemoryStats(key, null, val);
+      if (owner != null) owner.updateMemoryStats(null, val);
       // reduce from previous owner
       if (previousOwner instanceof RegionEntryContext) {
-        ((RegionEntryContext)previousOwner).updateMemoryStats(key, val, null);
+        ((RegionEntryContext)previousOwner).updateMemoryStats(val, null);
       }
     }
     final StaticSystemCallbacks sysCb =

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
@@ -1475,14 +1475,14 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
             setValueField(val);
             _setRawKey(null);
           }
-          if (!isOffHeap && context != null) {
-            context.updateMemoryStats(rawOldVal, val);
-          }
           // also upgrade GemFireXD schema information if required; there is no
           // problem of concurrency since GFXD DDL cannot happen concurrently
           // with DML operations
           if (val != null) {
             setContainerInfo(null, val);
+          }
+          if (!isOffHeap && context != null) {
+            context.updateMemoryStats(getRawKey(), rawOldVal, val);
           }
           return;
         } catch (IllegalAccessException e) {
@@ -1507,6 +1507,17 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
         OffHeapHelper.releaseWithNoTracking(oldValue);
       }
       throw sysCb.checkCacheForNullKeyValue("RegionEntry#_setValue");
+    }
+  }
+
+  /**
+   * Set the RegionEntry into SerializedDiskBuffer value, if present,
+   * so that the value can access data from disk when required independently.
+   */
+  protected void initContextForDiskBuffer(RegionEntryContext context,
+      Object value) {
+    if (value instanceof SerializedDiskBuffer) {
+      ((SerializedDiskBuffer)value).setDiskEntry(null, context);
     }
   }
 
@@ -1706,11 +1717,14 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
     try {
     // update the memory stats if required
     if (owner != previousOwner && !isOffHeap()) {
+      final Object key = getRawKey();
+      // set the context into the value if required
+      initContextForDiskBuffer(owner, val);
       // add for new owner
-      if (owner != null) owner.updateMemoryStats(null, val);
+      if (owner != null) owner.updateMemoryStats(key, null, val);
       // reduce from previous owner
       if (previousOwner instanceof RegionEntryContext) {
-        ((RegionEntryContext)previousOwner).updateMemoryStats(val, null);
+        ((RegionEntryContext)previousOwner).updateMemoryStats(key, val, null);
       }
     }
     final StaticSystemCallbacks sysCb =

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionMap.java
@@ -372,10 +372,7 @@ abstract class AbstractRegionMap implements RegionMap {
       // [sumedh] indexes are now updated by IndexRecoveryTask
     }
     // iterate over the entries of the map to call setOwner for each RegionEntry
-    final Iterator<RegionEntry> iter = r.getRegionMap().regionEntries()
-        .iterator();
-    while (iter.hasNext()) {
-      final RegionEntry re = iter.next();
+    for (RegionEntry re : r.getRegionMap().regionEntries()) {
       re.setOwner(r, currentOwner);
     }
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/management/internal/beans/PartitionedRegionBridge.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/management/internal/beans/PartitionedRegionBridge.java
@@ -309,8 +309,7 @@ public class PartitionedRegionBridge<K, V>  extends RegionMBeanBridge<K, V> {
       Set<BucketRegion> localPrimaryBucketRegions = parRegion.getDataStore().getAllLocalPrimaryBucketRegions();
       if (localPrimaryBucketRegions != null && localPrimaryBucketRegions.size() > 0) {
         for (BucketRegion br : localPrimaryBucketRegions) {
-          numLocalEntries += br.getRegionMap().sizeInVM() - br.getTombstoneCount();
-
+          numLocalEntries += br.getRegionSize();
         }
       }
       return numLocalEntries;
@@ -341,6 +340,8 @@ public class PartitionedRegionBridge<K, V>  extends RegionMBeanBridge<K, V> {
   
   @Override
   public long getRowsInReservoir() {
+    // TODO: this needs to be made efficient and PRStats must be updated during
+    // creation rather than iterate in every call
     if (parRegion.isDataStore()) {
       int numLocalEntries = 0;
       Iterator itr = parRegion.localEntriesIterator((InternalRegionFunctionContext)null, true, false, true, null);


### PR DESCRIPTION
## Changes proposed in this pull request

- Reason is that the "regionContext" set inside ColumnFormatValue (via base
  SerializedDiskBuffer) always remains a PlaceHolderRegion and never changes to a Region.
  So ColumnFormatValue cannot update the size stats when required.
- Now invoke the setDiskEntry method in AbstractRegionEntry.setOwner too to fix above.
- Other minor cleanups and a method rename.

## Patch testing

manual testing, precheckin in progress

## ReleaseNotes changes

NA

## Other PRs 

NA