### PR TITLE
[SNAP-2370] dunit hangs and other fixes

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/cache/query/internal/IndexUpdater.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/cache/query/internal/IndexUpdater.java
@@ -109,8 +109,6 @@ public interface IndexUpdater {
    *          the {@link DiskRegion} to be used; normally is the DiskRegion of
    *          the "region", but can be different in case a bucket region has not
    *          yet been created in a failed GII when destroying the disk data
-   * @param lockForGII
-   *          if true then also acquire the {@link #lockForGII()}
    * @param holdIndexLock
    *          if true then hold on to the index level lock acquired by
    *          {@link #lockForGII()} at the end of this method which will block
@@ -125,12 +123,12 @@ public interface IndexUpdater {
    *
    * @return returns whether write lock was acquired by clearIndex or not
    */
-  boolean clearIndexes(LocalRegion region, DiskRegion dr, boolean lockForGII,
+  boolean clearIndexes(LocalRegion region, DiskRegion dr,
       boolean holdIndexLock, Iterator<?> bucketEntriesIter, int bucketId);
 
   /**
    * should be invoked if "holdIndexLock" argument was true in
-   * {@link #clearIndexes(LocalRegion, DiskRegion, boolean, boolean, Iterator, int)}
+   * {@link #clearIndexes}
    */
   public void releaseIndexLock(LocalRegion region);
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -2711,7 +2711,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     // concurrent operations that are also updating these stats. For example,
     //a destroy could have already been applied to the map, and then updates
     //the stat after we reset it, making the state negative.
-    
+
     final PartitionedRegionDataStore prDs = this.partitionedRegion.getDataStore();
 //     this.debugMap.clear();
 //     this.createCount.set(0);
@@ -3000,9 +3000,9 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   }
 
   @Override
-  protected boolean clearIndexes(IndexUpdater indexUpdater, boolean lockForGII,
-      boolean setIsDestroyed) {
-      BucketRegionIndexCleaner cleaner = new BucketRegionIndexCleaner(lockForGII, !setIsDestroyed, this);
+  protected boolean clearIndexes(IndexUpdater indexUpdater, boolean setIsDestroyed) {
+      BucketRegionIndexCleaner cleaner = new BucketRegionIndexCleaner(
+          !setIsDestroyed, this);
       bucketRegionIndexCleaner.set(cleaner);
       return false;
   }
@@ -3095,7 +3095,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     }
   }
 
-  void updateBucketMemoryStats(final int memoryDelta) {
+  private void updateBucketMemoryStats(final int memoryDelta) {
     if (memoryDelta != 0) {
 
       final long bSize = bytesInMemory.compareAddAndGet(BUCKET_DESTROYED, memoryDelta);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegionIndexCleaner.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegionIndexCleaner.java
@@ -21,25 +21,21 @@ import java.util.List;
 import com.gemstone.gemfire.cache.query.internal.IndexUpdater;
 
 public class BucketRegionIndexCleaner {
-    private final boolean lockForGII ;
-    private final boolean holdIndexLock;
-    private final LocalRegion region;
-    
-    public BucketRegionIndexCleaner(boolean lockForGII, boolean holdIndexLock,
-        BucketRegion region) {
-      this.lockForGII = lockForGII;
-      this.holdIndexLock = holdIndexLock;      
-      this.region = region;
-     
-    }
+  private final boolean holdIndexLock;
+  private final LocalRegion region;
+
+  public BucketRegionIndexCleaner(boolean holdIndexLock, BucketRegion region) {
+    this.holdIndexLock = holdIndexLock;
+    this.region = region;
+  }
 
   public void clearEntries(List<RegionEntry> entries) {
     IndexUpdater indexUpdater = region.getIndexUpdater();
     if (indexUpdater == null) return;
     boolean indexGiiLockTaken = indexUpdater.clearIndexes(region, region.getDiskRegion(),
-        lockForGII, holdIndexLock, entries.iterator(), KeyInfo.UNKNOWN_BUCKET);
+        holdIndexLock, entries.iterator(), KeyInfo.UNKNOWN_BUCKET);
     if (indexGiiLockTaken && holdIndexLock) {
       indexUpdater.unlockForGII(true);
     }
-  }    
+  }
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CachePerfStats.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CachePerfStats.java
@@ -173,6 +173,7 @@ public class CachePerfStats implements HashingStats {
   protected static final int compressionSkippedBytesId;
   protected static final int compressionDecompressedReplacedId;
   protected static final int compressionDecompressedReplaceSkippedId;
+  protected static final int compressionCompressedReplacedId;
   protected static final int compressionCompressedReplaceSkippedId;
 
   protected static final int evictByCriteria_evictionsId;// total actual evictions (entries evicted)
@@ -302,6 +303,8 @@ public class CachePerfStats implements HashingStats {
         "replaced buffer after decompression.";
     final String compressionDecompressedReplaceSkippedDesc = "The total number times storage " +
         "skipped replacing buffer after decompression due to active usage.";
+    final String compressionCompressedReplacedDesc = "The total number times storage " +
+        "replaced buffer after compression.";
     final String compressionCompressedReplaceSkippedDesc = "The total number times storage " +
         "skipped replacing buffer after compression due to active usage.";
     final String evictByCriteria_evictionsDesc = "The total number of entries evicted";// total actual evictions (entries evicted)
@@ -451,6 +454,8 @@ public class CachePerfStats implements HashingStats {
             compressionDecompressedReplacedDesc, "operations"),
         f.createLongCounter("decompressedReplaceSkipped",
             compressionDecompressedReplaceSkippedDesc, "operations"),
+        f.createLongCounter("compressedReplaced",
+            compressionCompressedReplacedDesc, "operations"),
         f.createLongCounter("compressedReplaceSkipped",
             compressionCompressedReplaceSkippedDesc, "operations"),
 
@@ -597,6 +602,7 @@ public class CachePerfStats implements HashingStats {
     compressionSkippedBytesId = type.nameToId("compressSkippedBytes");
     compressionDecompressedReplacedId = type.nameToId("decompressedReplaced");
     compressionDecompressedReplaceSkippedId = type.nameToId("decompressedReplaceSkipped");
+    compressionCompressedReplacedId = type.nameToId("compressedReplaced");
     compressionCompressedReplaceSkippedId = type.nameToId("compressedReplaceSkipped");
 
     evictByCriteria_evictionsId = type.nameToId("evictByCriteria_evictions");
@@ -872,6 +878,10 @@ public class CachePerfStats implements HashingStats {
    public void incDecompressedReplaceSkipped() {
      stats.incLong(compressionDecompressedReplaceSkippedId, 1);
    }
+
+  public void incCompressedReplaced() {
+    stats.incLong(compressionCompressedReplacedId, 1);
+  }
 
    public void incCompressedReplaceSkipped() {
      stats.incLong(compressionCompressedReplaceSkippedId, 1);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -2439,7 +2439,7 @@ public class LocalRegion extends AbstractRegion
    * this region as long as it does not overflow.
    * 
    * @throws IllegalStateException
-   *           thrown when UUIDs have been exhaused in the distributed system;
+   *           thrown when UUIDs have been exhausted in the distributed system;
    *           note that it is not necessary that all possible integer values
    *           would have been used by someone (e.g. a VM goes down without
    *           using its "block" of IDs)
@@ -9006,14 +9006,14 @@ public class LocalRegion extends AbstractRegion
     }
   }
 
-  protected boolean clearIndexes(IndexUpdater indexUpdater, boolean lockForGII,
+  protected boolean clearIndexes(IndexUpdater indexUpdater,
       boolean setIsDestroyed) {
     // by default need to clear indexes only if this is not the case of region
     // being destroyed (i.e. after GII failure) otherwise the region as well as
     // complete index is going to be blown away; bucket region will need to
     // override to clear in every case
     if (!setIsDestroyed) {
-      return indexUpdater.clearIndexes(this, getDiskRegion(), lockForGII,
+      return indexUpdater.clearIndexes(this, getDiskRegion(),
           true, null, KeyInfo.UNKNOWN_BUCKET);
     }
     return false;
@@ -9070,7 +9070,7 @@ public class LocalRegion extends AbstractRegion
     IndexUpdater indexUpdater = this.getIndexUpdater();
     if (indexUpdater != null) {
       if (forInitFailure || event.getDiskException() != null) {
-        indexGiiLockTaken = this.clearIndexes(indexUpdater, true, setIsDestroyed);
+        indexGiiLockTaken = this.clearIndexes(indexUpdater, setIsDestroyed);
       }
       else if (isExplicitRegionDestroy(event)) {
         // In OffHeap Gfxd race can happen between GII thread inserting an
@@ -9078,7 +9078,7 @@ public class LocalRegion extends AbstractRegion
         // the failed initialization bucket, in which case index may contain
         // entry which has been released by the resource manager thread.
         // The lock below should prevent that situation.
-        indexGiiLockTaken = this.clearIndexes(indexUpdater, true, setIsDestroyed);
+        indexGiiLockTaken = this.clearIndexes(indexUpdater, setIsDestroyed);
       }
     }
     // for the case of restarting GII, reset the profile exchanged flag
@@ -13568,6 +13568,12 @@ public class LocalRegion extends AbstractRegion
     }
 
     @Override
+    public void incCompressedReplaced() {
+      stats.incLong(compressionCompressedReplacedId, 1);
+      cachePerfStats.stats.incLong(compressionCompressedReplacedId, 1);
+    }
+
+    @Override
     public void incCompressedReplaceSkipped() {
       stats.incLong(compressionCompressedReplaceSkippedId, 1);
       cachePerfStats.stats.incLong(compressionCompressedReplaceSkippedId, 1);
@@ -14562,6 +14568,7 @@ public class LocalRegion extends AbstractRegion
 
   public static boolean isMetaTable(String fullpath) {
     return fullpath.startsWith(SystemProperties.SNAPPY_HIVE_METASTORE_PATH) ||
+        fullpath.startsWith("/SYS/") ||
         fullpath.startsWith(PersistentUUIDAdvisor.UUID_PERSIST_REGION_PATH) ||
         fullpath.startsWith(SystemProperties.DDL_STMTS_REGION_PATH) ||
         fullpath.startsWith(ManagementConstants.MONITORING_REGION_PATH);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyBucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyBucketRegion.java
@@ -551,7 +551,7 @@ public final class ProxyBucketRegion implements Bucket {
           logger.fine("Going to clear indexes in ProxyBucketRegion: " + this.diskRegion);
         }
         iup.clearIndexes(this.partitionedRegion, getDiskRegion(),
-            true, false, rmap.regionEntries().iterator(), getBucketId());
+            false, rmap.regionEntries().iterator(), getBucketId());
       }
     }
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/tcp/TCPConduit.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/tcp/TCPConduit.java
@@ -1034,12 +1034,18 @@ public class TCPConduit implements Runnable {
               getLogger().fine("Closing old connection.  conn=" + conn + " before retrying.  remoteID=" + remoteId
                 + " memberInTrouble=" + memberInTrouble);
             }
-            conn.closeForReconnect("closing before retrying"); 
-          } 
+            conn.closeForReconnect("closing before retrying");
+          }
           catch (CancelException ex) {
             throw ex;
           }
-          catch (Exception ex) {
+          catch (Exception ignored) {
+          }
+          finally {
+            if (useNIOStream()) {
+              releasePooledConnection(conn);
+            }
+            conn = null;
           }
         }
       } // not first time in loop

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/HeapBufferAllocator.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/HeapBufferAllocator.java
@@ -18,7 +18,6 @@ package com.gemstone.gemfire.internal.shared;
 
 import java.nio.ByteBuffer;
 
-import com.gemstone.gemfire.internal.shared.unsafe.DirectBufferAllocator;
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.memory.MemoryAllocator;
 
@@ -116,11 +115,7 @@ public final class HeapBufferAllocator extends BufferAllocator {
     } else {
       ByteBuffer newBuffer = super.transfer(buffer, owner);
       // release the incoming direct buffer eagerly
-      if (buffer.isDirect()) {
-        DirectBufferAllocator.instance().release(buffer);
-      } else {
-        release(buffer);
-      }
+      releaseBuffer(buffer);
       return newBuffer;
     }
   }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/GfxdIndexManager.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/GfxdIndexManager.java
@@ -638,8 +638,7 @@ public final class GfxdIndexManager implements Dependent, IndexUpdater,
       if (lockForGII) {
         // the container GII lock is to synchronize with any index list changes
         // in refreshIndexListAndConstraintDesc()
-        lockForGII(false, tc);
-        lockedForGII = true;
+        lockedForGII = lockForGII(false, tc);
       }
 
       // check for region destroyed
@@ -4355,7 +4354,7 @@ public final class GfxdIndexManager implements Dependent, IndexUpdater,
   }
 
   @Override
-  public boolean clearIndexes(LocalRegion region, DiskRegion dr, boolean lockForGII,
+  public boolean clearIndexes(LocalRegion region, DiskRegion dr,
       boolean holdIndexLock, Iterator<?> bucketEntriesIter, int bucketId) {
     EmbedConnection conn = null;
     GemFireContainer gfc = null;
@@ -4396,9 +4395,7 @@ public final class GfxdIndexManager implements Dependent, IndexUpdater,
         }
       }
       if (needToAcquireWriteLockOnGIILock) {
-        if (lockForGII) {
-          giiLockAcquired = lockForGII(holdIndexLock, tc);
-        }
+        giiLockAcquired = lockForGII(holdIndexLock, tc);
       }
 
       // for the case of replicated region, simply blow away the entire
@@ -4454,7 +4451,7 @@ public final class GfxdIndexManager implements Dependent, IndexUpdater,
       handleException(t, "GfxdIndexManager#clearIndexes: unexpected exception",
           lcc, null, null);
     } finally {
-      if (!holdIndexLock) {
+      if (!holdIndexLock && giiLockAcquired) {
         unlockForGII(false, tc);
       }
       if (tableLockAcquired) {

--- a/tests/core/src/main/java/com/gemstone/gemfire/internal/cache/Bug43522DUnit.java
+++ b/tests/core/src/main/java/com/gemstone/gemfire/internal/cache/Bug43522DUnit.java
@@ -188,7 +188,7 @@ public class Bug43522DUnit extends CacheTestCase {
               }
 
               @Override
-              public boolean clearIndexes(LocalRegion region, DiskRegion dr, boolean lockForGII,
+              public boolean clearIndexes(LocalRegion region, DiskRegion dr,
                   boolean holdIndexLock, Iterator<?> bucketEntriesIter, int bucketId) {
                 return false;
               }
@@ -518,7 +518,7 @@ public class Bug43522DUnit extends CacheTestCase {
               }
 
               @Override
-              public boolean clearIndexes(LocalRegion region, DiskRegion dr, boolean lockForGII,
+              public boolean clearIndexes(LocalRegion region, DiskRegion dr,
                   boolean holdIndexLock, Iterator<?> bucketEntriesIter, int bucketId) {
                 return false;
               }
@@ -851,7 +851,7 @@ public class Bug43522DUnit extends CacheTestCase {
               }
 
               @Override
-              public boolean clearIndexes(LocalRegion region, DiskRegion dr, boolean lockForGII,
+              public boolean clearIndexes(LocalRegion region, DiskRegion dr,
                   boolean holdIndexLock, Iterator<?> bucketEntriesIter, int bucketId) {
                 return false;
               }


### PR DESCRIPTION
## Changes proposed in this pull request

- use Connection.getId() for sorting in lock acquisition in MsgChannelStreamer
- return back pool connection in case of early return when member is no longer in View
- clearIndexes causing IllegalMonitorStateExpion during shutdown;
  removing unused "lockForGII" flag and make the locking acquire/release
  be always in pair (in BucketRegionIndexCleaner and clear in GfxdIndexManager)
- added a stats counter "compressedReplaced" for entries that were replaced with compressed 
  versions; similar ones already exist for decompression but this one got missed
- skip /SYS/ meta-tables from memory accounting

## Patch testing

precheckin

## ReleaseNotes changes

NA

## Other PRs 

NA