### PR TITLE
Fix to SNAP-2380 and SNAP-2375

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
@@ -895,7 +895,7 @@ public class CacheServerLauncher extends LauncherBase {
         }
         if (!reconnected) {
           // shutdown-all disconnected the DS
-          if(externalShutDown) {
+          if (externalShutDown) {
             //delete the status file
             deleteStatus();
           }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
@@ -858,6 +858,9 @@ public class CacheServerLauncher extends LauncherBase {
             this.disconnect(cache);
             status.state = SHUTDOWN;
             writeStatus(status);
+            // No point reconnecting if explicit stop has been called
+            system.stopReconnecting();
+            waitTillReconnectStopped(system);
             externalShutDown = false;
         } else {
           Thread.sleep(150);
@@ -869,20 +872,46 @@ public class CacheServerLauncher extends LauncherBase {
 //        System.out.println("System is disconnected.  isReconnecting = " + system.isReconnecting());
         boolean reconnected = false;
         if (system.isReconnecting()) {
-          reconnected = system.waitUntilReconnected(-1, TimeUnit.SECONDS);
-          if (reconnected) {
-            system = (InternalDistributedSystem)system.getReconnectedSystem();
-            cache = GemFireCacheImpl.getInstance();
+          while (true) {
+            // Timed check is there so that if explicit stop has been called then
+            // we stop faster until waiting for the entire reconnect attempt to get over
+            reconnected = system.waitUntilReconnected(150, TimeUnit.MILLISECONDS);
+            status = readStatus();
+            if (status.state == SHUTDOWN_PENDING) {
+              // No point reconnecting if explicit stop has been called
+              system.stopReconnecting();
+              waitTillReconnectStopped(system);
+            }
+
+            if (reconnected) {
+              system = (InternalDistributedSystem) system.getReconnectedSystem();
+              cache = GemFireCacheImpl.getInstance();
+              break;
+            }
+            if (status.state == SHUTDOWN_PENDING) {
+              break;
+            }
           }
         }
         if (!reconnected) {
           // shutdown-all disconnected the DS
-          if( externalShutDown) {
+          if( externalShutDown ) {
             //delete the status file
             deleteStatus();
           }
           System.exit(0);
         }
+      }
+    }
+  }
+
+  private void waitTillReconnectStopped(InternalDistributedSystem system) throws Exception {
+    while (true) {
+      if (system.isReconnecting()) {
+        Thread.sleep(150);
+      }
+      else {
+        break;
       }
     }
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
@@ -881,6 +881,7 @@ public class CacheServerLauncher extends LauncherBase {
               // No point reconnecting if explicit stop has been called
               system.stopReconnecting();
               waitTillReconnectStopped(system);
+              externalShutDown = false;
             }
 
             if (reconnected) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
@@ -874,7 +874,7 @@ public class CacheServerLauncher extends LauncherBase {
         if (system.isReconnecting()) {
           while (true) {
             // Timed check is there so that if explicit stop has been called then
-            // we stop faster until waiting for the entire reconnect attempt to get over
+            // we stop faster rather waiting for the entire reconnect attempt to get over
             reconnected = system.waitUntilReconnected(150, TimeUnit.MILLISECONDS);
             status = readStatus();
             if (status.state == SHUTDOWN_PENDING) {
@@ -895,7 +895,7 @@ public class CacheServerLauncher extends LauncherBase {
         }
         if (!reconnected) {
           // shutdown-all disconnected the DS
-          if( externalShutDown ) {
+          if(externalShutDown) {
             //delete the status file
             deleteStatus();
           }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
@@ -1916,6 +1916,7 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
         // the above checkCancelInProgress will throw a CancelException
         // when we are being shutdown
       } catch (Throwable t) {
+        getCache().getCancelCriterion().checkCancelInProgress(t);
         if (!(t instanceof IOException)) {
           terminateFlusherThread = false;
           throw new GemFireIOException("Exception encountered in flusher thread: " + t.getMessage(), t);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
@@ -56,6 +56,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
 import com.gemstone.gemfire.CancelCriterion;
 import com.gemstone.gemfire.CancelException;
+import com.gemstone.gemfire.GemFireIOException;
 import com.gemstone.gemfire.StatisticsFactory;
 import com.gemstone.gemfire.SystemFailure;
 import com.gemstone.gemfire.cache.Cache;
@@ -63,6 +64,7 @@ import com.gemstone.gemfire.cache.CacheClosedException;
 import com.gemstone.gemfire.cache.DiskAccessException;
 import com.gemstone.gemfire.cache.DiskStore;
 import com.gemstone.gemfire.cache.DiskStoreFactory;
+import com.gemstone.gemfire.cache.LowMemoryException;
 import com.gemstone.gemfire.cache.RegionDestroyedException;
 import com.gemstone.gemfire.cache.persistence.PersistentID;
 import com.gemstone.gemfire.cache.query.IndexMaintenanceException;
@@ -1580,6 +1582,9 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
     }
     while (!this.flusherThreadTerminated) {
       try {
+        // check if cache is going down and in that case also terminate the
+        // flusher thread.
+        getCache().getCancelCriterion().checkCancelInProgress(null);
         this.flusherThread.join(100);
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
@@ -1818,6 +1823,7 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
         logger.fine("Async writer thread started");
       }
       boolean doingFlush = false;
+      boolean terminateFlusherThread = true;
       try {
         while (waitUntilFlushIsReady()) {
           int drainCount = fillDrainList();
@@ -1909,7 +1915,11 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
         // logger.info(LocalizedStrings.DEBUG, "DEBUG", ignore);
         // the above checkCancelInProgress will throw a CancelException
         // when we are being shutdown
-      } catch(Throwable t) {
+      } catch (Throwable t) {
+        if (!(t instanceof IOException)) {
+          terminateFlusherThread = false;
+          throw new GemFireIOException("Exception encountered in flusher thread: " + t.getMessage(), t);
+        }
         logger.severe(LocalizedStrings.DiskStoreImpl_FATAL_ERROR_ON_FLUSH, t);
         fatalDae = new DiskAccessException(LocalizedStrings.DiskStoreImpl_FATAL_ERROR_ON_FLUSH.toLocalizedString(), t, DiskStoreImpl.this);
       } finally {
@@ -1919,11 +1929,13 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
           logger.fine("Async writer thread stopped. Pending opcount="
               + asyncQueue.size());
         }
-        flusherThreadTerminated = true;
-        stopFlusher = true; // set this before calling handleDiskAccessException
-        // or it will hang
-        if (fatalDae != null) {
-          handleDiskAccessException(fatalDae, true);
+        if (terminateFlusherThread) {
+          flusherThreadTerminated = true;
+          stopFlusher = true; // set this before calling handleDiskAccessException
+          // or it will hang
+          if (fatalDae != null) {
+            handleDiskAccessException(fatalDae, true);
+          }
         }
       }
     }


### PR DESCRIPTION
## Changes proposed in this pull request

1. Do not let the region close in case of LME. This has been done by not letting non IOException get wrapped in DiskAccessException.
2. The stop request to a component might go into a "stopping" hang for quite sometime if the component has gone into a reconnecting attempt. Making sure that if an explicit stop has been issued from the stop scripts then reconnect is not attempted indefinitely and honors stop.

## Patch testing

hydra test which caught the two problems. 

## ReleaseNotes changes

None.

## Other PRs 

No