### PR TITLE
[SNAP-2399] Fix for LME during recovery.

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
@@ -4843,8 +4843,11 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
           DiskStoreObserver.startAsyncValueRecovery(DiskStoreImpl.this);
           // defer regions marked in first pass
           for (Oplog oplog : oplogSet) {
-            oplog.recoverValuesIfNeeded(currentAsyncValueRecoveryMap,
-                deferredRegions, currentAsyncValueRecoveryMap);
+            // If returns false further recovery is not possible due to UMM limit.
+            if (!oplog.recoverValuesIfNeeded(currentAsyncValueRecoveryMap,
+                deferredRegions, currentAsyncValueRecoveryMap)){
+              break;
+            }
           }
         } catch (CancelException ignore) {
           // do nothing
@@ -4886,8 +4889,11 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
               }
             }
             for (Oplog oplog : oplogSet) {
-              oplog.recoverValuesIfNeeded(deferredRegions, null,
-                  currentAsyncValueRecoveryMap);
+              // If returns false further recovery is not possible due to UMM limit.
+              if (!oplog.recoverValuesIfNeeded(deferredRegions, null,
+                  currentAsyncValueRecoveryMap)){
+                break;
+              }
             }
           } catch (CancelException ignore) {
             // do nothing

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -3464,7 +3464,7 @@ public class LocalRegion extends AbstractRegion
     if (this.concurrencyChecksEnabled && this.versionVector == null) {
       createVersionVector();
     }
-    // System.out.println("preinitialize of regions " + getFullPath() + " And data policy = " + this.getDataPolicy().withPersistence());
+    
     DiskRegion dskRgn = getDiskRegion();
     
     if(dskRgn != null && dskRgn.isRecreated()) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -3464,7 +3464,7 @@ public class LocalRegion extends AbstractRegion
     if (this.concurrencyChecksEnabled && this.versionVector == null) {
       createVersionVector();
     }
-    
+
     DiskRegion dskRgn = getDiskRegion();
     
     if(dskRgn != null && dskRgn.isRecreated()) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -3464,7 +3464,7 @@ public class LocalRegion extends AbstractRegion
     if (this.concurrencyChecksEnabled && this.versionVector == null) {
       createVersionVector();
     }
-    
+    // System.out.println("preinitialize of regions " + getFullPath() + " And data policy = " + this.getDataPolicy().withPersistence());
     DiskRegion dskRgn = getDiskRegion();
     
     if(dskRgn != null && dskRgn.isRecreated()) {
@@ -14543,6 +14543,13 @@ public class LocalRegion extends AbstractRegion
           size, buffer, shouldEvict, false)) {
         throwLowMemoryException(size);
       }
+    }
+  }
+
+
+  public void relaseMemoryForInternalRegions(){
+    if (this.reservedTable() && needAccounting()) {
+      callback.dropStorageMemory(getFullPath(), 0L);
     }
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
@@ -7278,15 +7278,17 @@ public final class Oplog implements CompactableOplog {
    * If the defer regions argument is non-null, then disk regions that are marked to be
    * deferred ({@link DiskRegionFlag#DEFER_RECOVERY}) are skipped from recovery
    * and those regions are filled in the passed map as the result.
-   * @param diskRecoveryStores 
+   * @param diskRecoveryStores
+   * @return if further recovery is possible or not.
+   * This is to avoid unnecessary SortedLiveEntries if UMM limit has been reached.
    */
-  public void recoverValuesIfNeeded(
+  public boolean recoverValuesIfNeeded(
       Map<Long, DiskRecoveryStore> diskRecoveryStores,
       Map<Long, DiskRecoveryStore> deferredRegions, Object sync) {
     //Early out if we start closing the parent.
     if (getParent().isClosing() || diskRecoveryStores.isEmpty()
         || this.regionMap.isEmpty()) {
-      return;
+      return true;
     }
 
     List<KRFEntry> sortedLiveEntries;
@@ -7338,13 +7340,13 @@ public final class Oplog implements CompactableOplog {
 
     if (targetRegions.isEmpty()) {
       // no regions to recover
-      return;
+      return true;
     }
 
     sortedLiveEntries = getSortedLiveEntries(targetRegions.values());
     if(sortedLiveEntries == null) {
       //There are no live entries in this oplog to recover.
-      return;
+      return true;
     }
 
     if (this.logger.infoEnabled()) {
@@ -7355,7 +7357,7 @@ public final class Oplog implements CompactableOplog {
     for(KRFEntry entry : sortedLiveEntries) {
       //Early out if we start closing the parent.
       if(getParent().isClosing() || diskRecoveryStores.isEmpty()) {
-        return;
+        return true;
       }
 
       DiskEntry diskEntry = entry.getDiskEntry();
@@ -7385,8 +7387,8 @@ public final class Oplog implements CompactableOplog {
           this.logger.info(LocalizedStrings.ONE_ARG,
               "Oplog::recoverValuesIfNeeded: stopping recovery of " +
                   diskRegionId + " as memory consumed is 90% of maxStorageSize");
-          // Breaking the loop here as all regions will face the same memory constraint.
-          break;
+          // Returning false here as all regions will face the same memory constraint.
+          return false;
         }
 
         synchronized(diskEntry) {
@@ -7419,6 +7421,7 @@ public final class Oplog implements CompactableOplog {
         }
       }
     }
+    return true;
   }
 
   public static String getParentRegionID(DiskRegionView drv) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
@@ -7385,7 +7385,8 @@ public final class Oplog implements CompactableOplog {
           this.logger.info(LocalizedStrings.ONE_ARG,
               "Oplog::recoverValuesIfNeeded: stopping recovery of " +
                   diskRegionId + " as memory consumed is 90% of maxStorageSize");
-          continue;
+          // Breaking the loop here as all regions will face the same memory constraint.
+          break;
         }
 
         synchronized(diskEntry) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PlaceHolderDiskRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PlaceHolderDiskRegion.java
@@ -112,7 +112,7 @@ import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
     }
     public DiskEntry initializeRecoveredEntry(Object key, DiskEntry.RecoveredEntry value) {
       RegionEntry re = getRecoveredEntryMap().initRecoveredEntry(key, value);
-      if (!re.isTombstone()) {
+      if (!re.isTombstone() && callback.isSnappyStore()) {
         long size = calculateEntryOverhead(re);
         callback.acquireStorageMemory(getFullPath(), size, null, false, false);
       }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PlaceHolderDiskRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PlaceHolderDiskRegion.java
@@ -210,11 +210,7 @@ import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
 
     protected long calculateEntryOverhead(RegionEntry entry) {
       if (entryOverHead == -1L && callback.isSnappyStore()) {
-        synchronized (this) {
-          if (entryOverHead == -1L) {
             entryOverHead = getEntryOverhead(entry);
-          }
-        }
       }
       return entryOverHead;
     }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PlaceHolderDiskRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PlaceHolderDiskRegion.java
@@ -112,7 +112,7 @@ import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
     }
     public DiskEntry initializeRecoveredEntry(Object key, DiskEntry.RecoveredEntry value) {
       RegionEntry re = getRecoveredEntryMap().initRecoveredEntry(key, value);
-      if (!re.isTombstone() && callback.isSnappyStore()) {
+      if (!(re.isTombstone() || re.isInvalidOrRemoved()) && callback.isSnappyStore()) {
         long size = calculateEntryOverhead(re);
         callback.acquireStorageMemory(getFullPath(), size, null, false, false);
       }


### PR DESCRIPTION
## Changes proposed in this pull request

Recovery for a region is scheduled asynchronously. The  UMM accounting during recovery was done in two steps.
a) The keys & region entry overhead was accounted while changeOwner is called for a disk region. 
b) The value accounting was done by recovery thread. Once value recovery thread finds insufficient memory it used to stop the recovery process.

However, these posed a problem if the number of keys is significantly large i.e. many row tables are used. If recovery has consumed a lot of memory, the umm allocation for keys during change owner results in an LME. Basically accounting during changeOwner is too late.

Fix
Changed to code to account for keys in PlaceHolderRegion itself. So recovery thread will get a correct picture of memory consumption. The challenge was to avoid accounting for reserved regions, as placeholder region would not know the nature of the region. 
Now we are accounting for reserved regions also in PlaceHolderRegion and put a reversal entry during changeOwner. It may cause recovery to stop a little before it should have, but that should be ok. 

## Patch testing

precheckin pending. 

## ReleaseNotes changes

NA

## Other PRs 
Na
