### PR TITLE
Part of SNAP-2398 and SNAP-645

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
@@ -7277,6 +7277,9 @@ public class PartitionedRegion extends LocalRegion implements
       }
     }
 
+    private boolean DISALLOW_REMOTE_FETCH = Boolean.getBoolean(
+        "snappydata.DISALLOW_REMOTE_FETCH");
+
     // For snapshot isolation, Get the iterator on the txRegionstate maps entry iterator too
     public boolean hasNext() {
       if (this.moveNext) {
@@ -7371,6 +7374,12 @@ public class PartitionedRegion extends LocalRegion implements
                 logger.fine("PRLocalScanIterator#hasNext: bucket not "
                     + "available for ID " + bucketId + ", PR: "
                     + PartitionedRegion.this.toString() + ". Fetching from remote node");
+              }
+              if (DISALLOW_REMOTE_FETCH) {
+                throw new BucketMovedException(LocalizedStrings
+                    .PartitionedRegionDataStore_BUCKET_ID_0_NOT_FOUND_ON_VM_1
+                    .toLocalizedString(new Object[] { bucketStringForLogs(bucketId),
+                        getMyId() }), bucketId, getFullPath());
               }
               setRemoteBucketEntriesIterator(bucketId);
               this.remoteEntryFetched = true;
@@ -7568,7 +7577,7 @@ public class PartitionedRegion extends LocalRegion implements
     }
     catch (FunctionException fe) {
       checkShutdown();
-      this.logger.warning(LocalizedStrings.PR_CONTAINSVALUE_WARNING,fe.getCause());  
+      this.logger.warning(LocalizedStrings.PR_CONTAINSVALUE_WARNING,fe.getCause());
     }
     return false;
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/CallbackFactoryProvider.java
@@ -17,6 +17,8 @@
 
 package com.gemstone.gemfire.internal.snappy;
 
+import java.net.URI;
+import java.net.URLClassLoader;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
@@ -186,6 +188,9 @@ public abstract class CallbackFactoryProvider {
     @Override
     public void clearConnectionPools() {
     }
+
+    @Override
+    public URLClassLoader getLeadClassLoader() { return null; }
   };
 
   public static void setStoreCallbacks(StoreCallbacks cb) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/snappy/StoreCallbacks.java
@@ -17,6 +17,7 @@
 
 package com.gemstone.gemfire.internal.snappy;
 
+import java.net.URLClassLoader;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Set;
@@ -129,4 +130,9 @@ public interface StoreCallbacks {
    * authentication service changes, for example).
    */
   void clearConnectionPools();
+
+  /**
+   * Get the class loader of the lead
+   */
+  URLClassLoader getLeadClassLoader();
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdDataSerializable.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdDataSerializable.java
@@ -280,6 +280,8 @@ public abstract class GfxdDataSerializable implements GfxdSerializable {
         () -> new LeadNodeGetStatsMessage());
     DSFIDFactory.registerGemFireXDClass(PROJECTION_ROW,
         () -> new ProjectionRow());
+    DSFIDFactory.registerGemFireXDClass(LEAD_NODE_DATA_MSG,
+        () -> new GetLeadNodeInfoAsStringMessage());
 
     // register SnappyData specific types
     CallbackFactoryProvider.getStoreCallbacks().registerTypes();

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdSerializable.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdSerializable.java
@@ -213,6 +213,8 @@ public interface GfxdSerializable extends GfxdDSFID {
 
   byte MEMBER_LOGS_MESSAGE = 59;
 
+  byte LEAD_NODE_DATA_MSG = 60;
+
   /**
    * Marker to indicate that tests can use an ID >= this. Note whenever adding a
    * new message increment this to be greater than the last one.

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -77,6 +77,7 @@ import com.pivotal.gemfirexd.internal.engine.distributed.GfxdListResultCollector
 import com.pivotal.gemfirexd.internal.engine.distributed.GfxdMessage;
 import com.pivotal.gemfirexd.internal.engine.distributed.QueryCancelFunction;
 import com.pivotal.gemfirexd.internal.engine.distributed.QueryCancelFunction.QueryCancelFunctionArgs;
+import com.pivotal.gemfirexd.internal.engine.distributed.message.GetLeadNodeInfoAsStringMessage;
 import com.pivotal.gemfirexd.internal.engine.distributed.message.LeadNodeGetStatsMessage;
 import com.pivotal.gemfirexd.internal.engine.distributed.message.LeadNodeSmartConnectorOpMsg;
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
@@ -1671,6 +1672,24 @@ public class GfxdSystemProcedures extends SystemProcedures {
             null, null, null, null, addOrDropCol, columnName, columnType, columnNullable);
 
     sendConnectorOpToLead(ctx);
+  }
+
+  public static void GET_DEPLOYED_JARS(String[] jarStrings) throws SQLException {
+    try {
+      if (GemFireXDUtils.TraceSysProcedures) {
+        SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_SYS_PROCEDURES,
+            "executing GET_DEPLOYED_JARS ");
+      }
+      GfxdListResultCollector collector = new GfxdListResultCollector();
+      GetLeadNodeInfoAsStringMessage msg = new GetLeadNodeInfoAsStringMessage(
+          collector, GetLeadNodeInfoAsStringMessage.DataReqType.GET_JARS, (Object[])null);
+      msg.executeFunction();
+      List result = (ArrayList) collector.getResult();
+      String resJarStrings = (String) result.get(0);
+      jarStrings[0] = resJarStrings;
+    } catch (StandardException se) {
+      throw PublicAPI.wrapStandardException(se);
+    }
   }
 
   private static void sendConnectorOpToLead(LeadNodeSmartConnectorOpContext ctx)

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/GetLeadNodeInfoAsStringMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/GetLeadNodeInfoAsStringMessage.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package com.pivotal.gemfirexd.internal.engine.distributed.message;
+
+import com.gemstone.gemfire.DataSerializer;
+import com.gemstone.gemfire.cache.execute.ResultCollector;
+import com.gemstone.gemfire.distributed.DistributedMember;
+import com.gemstone.gemfire.internal.snappy.CallbackFactoryProvider;
+import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
+import com.pivotal.gemfirexd.internal.engine.Misc;
+import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
+import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
+import com.pivotal.gemfirexd.internal.shared.common.sanity.SanityManager;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+public class GetLeadNodeInfoAsStringMessage extends MemberExecutorMessage<Object> {
+
+  private Object[] additionalArgs;
+  private DataReqType requestType;
+
+  public enum DataReqType {GET_JARS}
+
+  public GetLeadNodeInfoAsStringMessage(final ResultCollector<Object, Object> rc, DataReqType reqType, Object... args) {
+    super(rc, null, false, true);
+    this.requestType = reqType;
+    this.additionalArgs = args;
+  }
+
+  public GetLeadNodeInfoAsStringMessage() {
+    super(true);
+  }
+
+  @Override
+  public Set<DistributedMember> getMembers() {
+    return Misc.getLeadNode();
+  }
+
+  @Override
+  public void postExecutionCallback() {
+  }
+
+  @Override
+  public boolean isHA() {
+    return true;
+  }
+
+  @Override
+  public boolean optimizeForWrite() {
+    return false;
+  }
+
+  @Override
+  protected void execute() throws Exception {
+    if (GemFireXDUtils.TraceQuery) {
+      SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_QUERYDISTRIB,
+          "GetLeadNodeInfoAsStringMessage.execute: ");
+    }
+    try {
+      String result = null;
+      switch (this.requestType) {
+        case GET_JARS:
+          result = handleGetJarsRequest();
+          break;
+
+        default:
+          throw new IllegalArgumentException("GetLeadNodeInfoAsStringMessage:" +
+              " Unknown data request type: " + this.requestType);
+
+      }
+      lastResult(result, false, false, true);
+    } catch (Exception ex) {
+      throw LeadNodeExecutorMsg.getExceptionToSendToServer(ex);
+    }
+  }
+
+  private String handleGetJarsRequest() {
+    URLClassLoader ul = CallbackFactoryProvider.getStoreCallbacks().getLeadClassLoader();
+    URL[] allJarUris = ul.getURLs();
+    StringBuffer res = new StringBuffer();
+    for (URL u : allJarUris) {
+      res.append(u);
+      res.append(',');
+    }
+    if (res.length() > 0) {
+      return res.substring(0, res.length() - 1);
+    }
+    return null;
+  }
+
+  @Override
+  protected void executeFunction(boolean enableStreaming)
+      throws StandardException, SQLException {
+    try {
+      super.executeFunction(enableStreaming);
+    } catch (RuntimeException re) {
+      throw LeadNodeExecutorMsg.handleLeadNodeRuntimeException(re);
+    }
+  }
+
+  @Override
+  protected LeadNodeGetStatsMessage clone() {
+    final LeadNodeGetStatsMessage msg = new LeadNodeGetStatsMessage(this.userCollector);
+    return msg;
+  }
+
+  @Override
+  public byte getGfxdID() {
+    return LEAD_NODE_DATA_MSG;
+  }
+
+  @Override
+  public void fromData(DataInput in) throws IOException, ClassNotFoundException {
+    super.fromData(in);
+    this.requestType = DataSerializer.readObject(in);
+    this.additionalArgs = DataSerializer.readObjectArray(in);
+  }
+
+  @Override
+  public void toData(final DataOutput out) throws IOException {
+    super.toData(out);
+    DataSerializer.writeObject(this.requestType, out);
+    DataSerializer.writeObjectArray(this.additionalArgs, out);
+  }
+
+  public void appendFields(final StringBuilder sb) {
+  }
+
+}
+

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -1838,6 +1838,17 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
           newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
     }
 
+
+    {
+      // GET_JARS -- Smart Connectors will pull all the jars
+      String[] arg_names = new String[] { "JAR_PATHS"};
+      TypeDescriptor[] arg_types = new TypeDescriptor[] {
+          DataTypeDescriptor.getCatalogType(Types.VARCHAR)};
+      super.createSystemProcedureOrFunction("GET_DEPLOYED_JARS",
+          sysUUID, arg_names, arg_types, 1, 0, RoutineAliasInfo.READS_SQL_DATA, null,
+          newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
+    }
+
     {
       // GET_BUCKET_TO_SERVER_MAPPING
       String[] arg_names = new String[] { "FQTN", "BKT_TO_SERVER_MAPPING" };


### PR DESCRIPTION
  Enabling Smart Connector to pull deployed packages and jars during initialization and add in SparkContext.
- RemoteFetch of data in PRLocalEntriesIterator can throw exception now
  based on System Property.

## Changes proposed in this pull request

Added a generic method to bring any data from LeadNode as String. Any future re which Smart Connector has for such thing can use this.
Added a system property to throw error when remote fetch happens.

## Patch testing

Manual

## ReleaseNotes changes

None

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/1071
