### PR TITLE
Snap 2404 2

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/PersistenceAdvisorImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/PersistenceAdvisorImpl.java
@@ -89,7 +89,7 @@ public class PersistenceAdvisorImpl implements PersistenceAdvisor {
   private boolean DISALLOW_CLUSTER_RESTART_CHECK = Boolean.getBoolean(
       "gemfire.DISALLOW_CLUSTER_RESTART_CHECK");
 
-  public static final boolean TRACE = Boolean.getBoolean("gemfire.TRACE_PERSISTENCE_ADVISOR");
+  public static final boolean TRACE = true;//Boolean.getBoolean("gemfire.TRACE_PERSISTENCE_ADVISOR");
   
   public PersistenceAdvisorImpl(CacheDistributionAdvisor advisor, DistributedLockService dl, PersistentMemberView storage, String regionPath, DiskRegionStats diskStats, PersistentMemberManager memberManager) {
     this.advisor = advisor;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/PersistenceAdvisorImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/PersistenceAdvisorImpl.java
@@ -89,7 +89,7 @@ public class PersistenceAdvisorImpl implements PersistenceAdvisor {
   private boolean DISALLOW_CLUSTER_RESTART_CHECK = Boolean.getBoolean(
       "gemfire.DISALLOW_CLUSTER_RESTART_CHECK");
 
-  public static final boolean TRACE = true;//Boolean.getBoolean("gemfire.TRACE_PERSISTENCE_ADVISOR");
+  public static final boolean TRACE = Boolean.getBoolean("gemfire.TRACE_PERSISTENCE_ADVISOR");
   
   public PersistenceAdvisorImpl(CacheDistributionAdvisor advisor, DistributedLockService dl, PersistentMemberView storage, String regionPath, DiskRegionStats diskStats, PersistentMemberManager memberManager) {
     this.advisor = advisor;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/StartupSequenceQueryMesasge.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/StartupSequenceQueryMesasge.java
@@ -81,6 +81,7 @@ public class StartupSequenceQueryMesasge extends
       if (region instanceof DistributedRegion) {
         persistenceAdvisor = ((DistributedRegion)region).getPersistenceAdvisor();
         PersistentMembershipView view = persistenceAdvisor.getMembershipView();
+        HashSet<PersistentMemberID> onlineOrEqual = persistenceAdvisor.getPersistedOnlineOrEqualMembers();
         // find out a member whose DDLReplay is completed.
         Map<InternalDistributedMember, PersistentMemberID> onlineMembers = view.getOnlineMembers();
         dm.getLoggerI18n().info(LocalizedStrings.DEBUG, "The view is " + view);
@@ -99,6 +100,8 @@ public class StartupSequenceQueryMesasge extends
         if (!isInitialized) {
           // check which are offline members
           offlineMembers = view.getOfflineMembers();
+          //remove equal members too.
+          offlineMembers.removeAll(onlineOrEqual);
           if (offlineMembers != null) {
             offlineMembers.forEach(pId -> {
               dm.getLoggerI18n().info(LocalizedStrings.DEBUG, "The offline members are " + pId + " the disk store " +

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/StartupSequenceQueryMesasge.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/StartupSequenceQueryMesasge.java
@@ -83,12 +83,14 @@ public class StartupSequenceQueryMesasge extends
         PersistentMembershipView view = persistenceAdvisor.getMembershipView();
         // find out a member whose DDLReplay is completed.
         Map<InternalDistributedMember, PersistentMemberID> onlineMembers = view.getOnlineMembers();
-
+        dm.getLoggerI18n().info(LocalizedStrings.DEBUG, "The view is " + view);
         boolean isInitialized = false;
         // Check how many online members
         for (InternalDistributedMember m : onlineMembers.keySet()) {
+          dm.getLoggerI18n().info(LocalizedStrings.DEBUG, "The online members are " + m);
           if ((m.getVmKind() == DistributionManager.NORMAL_DM_TYPE) && cache.isSnappyDataStore(m)) {
             isInitialized = !cache.isUnInitializedMember(m);
+            dm.getLoggerI18n().info(LocalizedStrings.DEBUG, "The online members is initialized " + isInitialized);
           }
           if (isInitialized)
             break;
@@ -97,9 +99,13 @@ public class StartupSequenceQueryMesasge extends
         if (!isInitialized) {
           // check which are offline members
           offlineMembers = view.getOfflineMembers();
-          offlineMembers.forEach(pId -> {
-            diskStoreId.add(pId.diskStoreId);
-          });
+          if (offlineMembers != null) {
+            offlineMembers.forEach(pId -> {
+              dm.getLoggerI18n().info(LocalizedStrings.DEBUG, "The offline members are " + pId + " the disk store " +
+                      "id : " + pId.diskStoreId);
+              diskStoreId.add(pId.diskStoreId);
+            });
+          }
         }
       } else if (region == null) {
         dm.getLoggerI18n().info(LocalizedStrings.DEBUG, "This shouldn't have happened. ");
@@ -128,7 +134,8 @@ public class StartupSequenceQueryMesasge extends
         StartupSequenceQueryMesasge.StartupSequenceQueryReplyMesasge persistentReplyMessage =
             new StartupSequenceQueryMesasge.StartupSequenceQueryReplyMesasge();
         //persistentReplyMessage.diskStoreId = diskStoreId;
-        persistentReplyMessage.persistentMemberIDS.addAll(offlineMembers);
+        if (offlineMembers != null)
+          persistentReplyMessage.persistentMemberIDS.addAll(offlineMembers);
         replyMsg = persistentReplyMessage;
       } else {
         replyMsg = new ReplyMessage();

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/StartupSequenceQueryMesasge.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/StartupSequenceQueryMesasge.java
@@ -84,14 +84,14 @@ public class StartupSequenceQueryMesasge extends
         HashSet<PersistentMemberID> onlineOrEqual = persistenceAdvisor.getPersistedOnlineOrEqualMembers();
         // find out a member whose DDLReplay is completed.
         Map<InternalDistributedMember, PersistentMemberID> onlineMembers = view.getOnlineMembers();
-        dm.getLoggerI18n().info(LocalizedStrings.DEBUG, "The view is " + view);
+        if (dm.getLoggerI18n().fineEnabled()) {
+          dm.getLoggerI18n().fine("The view is " + view);
+        }
         boolean isInitialized = false;
         // Check how many online members
         for (InternalDistributedMember m : onlineMembers.keySet()) {
-          dm.getLoggerI18n().info(LocalizedStrings.DEBUG, "The online members are " + m);
           if ((m.getVmKind() == DistributionManager.NORMAL_DM_TYPE) && cache.isSnappyDataStore(m)) {
             isInitialized = !cache.isUnInitializedMember(m);
-            dm.getLoggerI18n().info(LocalizedStrings.DEBUG, "The online members is initialized " + isInitialized);
           }
           if (isInitialized)
             break;
@@ -104,8 +104,10 @@ public class StartupSequenceQueryMesasge extends
           offlineMembers.removeAll(onlineOrEqual);
           if (offlineMembers != null) {
             offlineMembers.forEach(pId -> {
-              dm.getLoggerI18n().info(LocalizedStrings.DEBUG, "The offline members are " + pId + " the disk store " +
-                      "id : " + pId.diskStoreId);
+              if (dm.getLoggerI18n().fineEnabled()) {
+                dm.getLoggerI18n().fine("The offline members are " + pId + " the disk store " +
+                        "id : " + pId.diskStoreId);
+              }
               diskStoreId.add(pId.diskStoreId);
             });
           }


### PR DESCRIPTION
## Changes proposed in this pull request

Removed EQUAL members from the list of offline members, as getOfflineMembers members used to return members that are NOT online.
This used to cause a scenario where two concurrently started members used to look for each others initialization status and one of them used to fail.

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
