### PR TITLE
Catalog repair procedure changes

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -604,6 +604,9 @@ public final class FabricDatabase implements ModuleControl,
           }
         }
       }
+      // publish the column table stats at this point because that
+      // requires the hive metastore
+      memStore.getDatabase().publishColumnStats();
     }
   }
 
@@ -676,10 +679,6 @@ public final class FabricDatabase implements ModuleControl,
         gfDBTablesMap, internalColumnTablesSet, externalCatalog, removeInconsistentEntries, removeTablesWithData);
     removeInconsistentHiveEntries(hiveDBTablesMap, gfDBTablesMap,
         externalCatalog, removeInconsistentEntries, removeTablesWithData);
-
-    // publish the column table stats at this point because that
-    // requires the hive metastore
-    memStore.getDatabase().publishColumnStats();
   }
 
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -602,7 +602,10 @@ public final class FabricDatabase implements ModuleControl,
                 GemFireXDUtils.waitForNodeInitialization();
                 embedConnection = GemFireXDUtils.createNewInternalConnection(
                     false);
-                checkSnappyCatalogConsistency(embedConnection, false, false);
+                checkSnappyCatalogConsistency(embedConnection, true, false);
+                // publish the column table stats at this point because that
+                // requires the hive metastore
+                memStore.getDatabase().publishColumnStats();
               } catch (StandardException | SQLException e) {
                 throw new GemFireXDRuntimeException(e);
               } finally {
@@ -687,10 +690,6 @@ public final class FabricDatabase implements ModuleControl,
         gfDBTablesMap, internalColumnTablesSet, externalCatalog, removeInconsistentEntries, removeTablesWithData);
     removeInconsistentHiveEntries(hiveDBTablesMap, gfDBTablesMap,
         externalCatalog, removeInconsistentEntries, removeTablesWithData);
-
-    // publish the column table stats at this point because that
-    // requires the hive metastore
-    memStore.getDatabase().publishColumnStats();
   }
 
   /**
@@ -728,7 +727,7 @@ public final class FabricDatabase implements ModuleControl,
           dropTables(embedConn, storeEntry.getKey(), storeTablesList, removeTablesWithData);
         } else {
           SanityManager.DEBUG_PRINT("warning",
-              "Use system procedure SYS.REPAIR_CATALOG() remove inconsistency");
+              "Use system procedure SYS.REPAIR_CATALOG() to remove inconsistency");
         }
       }
 
@@ -757,7 +756,7 @@ public final class FabricDatabase implements ModuleControl,
               tablesMissingColumnBuffer, externalCatalog);
         } else {
           SanityManager.DEBUG_PRINT("warning",
-              "Use system procedure SYS.REPAIR_CATALOG() remove inconsistency");
+              "Use system procedure SYS.REPAIR_CATALOG() to remove inconsistency");
         }
       }
     }
@@ -797,7 +796,7 @@ public final class FabricDatabase implements ModuleControl,
               externalCatalog);
         } else {
           SanityManager.DEBUG_PRINT("warning",
-              "Use system procedure SYS.REPAIR_CATALOG() remove inconsistency");
+              "Use system procedure SYS.REPAIR_CATALOG() to remove inconsistency");
         }
       }
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -592,6 +592,7 @@ public final class FabricDatabase implements ModuleControl,
       this.memStore.initExternalCatalog();
       EmbedConnection embedConnection = null;
       try {
+        GemFireXDUtils.waitForNodeInitialization();
         embedConnection = GemFireXDUtils.createNewInternalConnection(
             false);
         checkSnappyCatalogConsistency(embedConnection, false, false);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -592,7 +592,6 @@ public final class FabricDatabase implements ModuleControl,
       this.memStore.initExternalCatalog();
       EmbedConnection embedConnection = null;
       try {
-        GemFireXDUtils.waitForNodeInitialization();
         embedConnection = GemFireXDUtils.createNewInternalConnection(
             false);
         checkSnappyCatalogConsistency(embedConnection, false, false);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -582,6 +582,7 @@ public final class FabricDatabase implements ModuleControl,
      * changeOrAppend(Constant * .STORE_PROPERTY_PREFIX +com.pivotal.gemfirexd.Attribute.
      * SERVER_GROUPS, LeadImpl.LEADER_SERVERGROUP)
      */
+    final GemFireCacheImpl cache = GemFireCacheImpl.getExisting();
     HashSet<String> leadGroup = CallbackFactoryProvider.getClusterCallbacks().getLeaderGroup();
     final boolean isLead = this.memStore.isSnappyStore() && (leadGroup != null && leadGroup
         .size() > 0) && (ServerGroupUtils.isGroupMember(leadGroup)
@@ -590,19 +591,29 @@ public final class FabricDatabase implements ModuleControl,
     if (this.memStore.isSnappyStore() && (this.memStore.getMyVMKind() ==
         GemFireStore.VMKind.DATASTORE || (isLead /*&& servers.size() > 0*/))) {
       this.memStore.initExternalCatalog();
-      EmbedConnection embedConnection = null;
-      try {
-        GemFireXDUtils.waitForNodeInitialization();
-        embedConnection = GemFireXDUtils.createNewInternalConnection(
-            false);
-        checkSnappyCatalogConsistency(embedConnection, false, false);
-      } finally {
-        if (embedConnection != null) {
-          try {
-            embedConnection.close();
-          } catch (Exception ignore) {
-          }
-        }
+      if (isLead /*&& servers.size() > 0*/) {
+        // submit the task to check for catalog consistency
+        this.memStore.setExternalCatalogInit(cache.getDistributionManager()
+            .getFunctionExcecutor().submit(() -> {
+              // don't wait for self in catalog initialization
+              GemFireStore.externalCatalogInitThread.set(Boolean.TRUE);
+              EmbedConnection embedConnection = null;
+              try {
+                GemFireXDUtils.waitForNodeInitialization();
+                embedConnection = GemFireXDUtils.createNewInternalConnection(
+                    false);
+                checkSnappyCatalogConsistency(embedConnection, false, false);
+              } catch (StandardException | SQLException e) {
+                throw new GemFireXDRuntimeException(e);
+              } finally {
+                if (embedConnection != null) {
+                  try {
+                    embedConnection.close();
+                  } catch (Exception ignore) {
+                  }
+                }
+              }
+            }));
       }
     }
   }
@@ -628,7 +639,7 @@ public final class FabricDatabase implements ModuleControl,
       boolean removeInconsistentEntries, boolean removeTablesWithData)
       throws StandardException, SQLException {
     final GemFireStore memStore = Misc.getMemStoreBooting();
-    final ExternalCatalog externalCatalog = memStore.getExternalCatalog();
+    final ExternalCatalog externalCatalog = memStore.getExternalCatalog(false);
     if (externalCatalog == null) {
       return;
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -604,9 +604,6 @@ public final class FabricDatabase implements ModuleControl,
           }
         }
       }
-      // publish the column table stats at this point because that
-      // requires the hive metastore
-      memStore.getDatabase().publishColumnStats();
     }
   }
 
@@ -679,6 +676,10 @@ public final class FabricDatabase implements ModuleControl,
         gfDBTablesMap, internalColumnTablesSet, externalCatalog, removeInconsistentEntries, removeTablesWithData);
     removeInconsistentHiveEntries(hiveDBTablesMap, gfDBTablesMap,
         externalCatalog, removeInconsistentEntries, removeTablesWithData);
+
+    // publish the column table stats at this point because that
+    // requires the hive metastore
+    memStore.getDatabase().publishColumnStats();
   }
 
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -41,7 +41,6 @@
 
 package com.pivotal.gemfirexd.internal.engine.db;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.PrivilegedExceptionAction;
@@ -64,7 +63,6 @@ import com.gemstone.gemfire.internal.ClassPathLoader;
 import com.gemstone.gemfire.internal.GFToSlf4jBridge;
 import com.gemstone.gemfire.internal.LogWriterImpl;
 import com.gemstone.gemfire.internal.cache.*;
-import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import com.gemstone.gemfire.internal.shared.SystemProperties;
 import com.gemstone.gemfire.internal.util.ArrayUtils;
 import com.gemstone.gnu.trove.THashMap;
@@ -604,7 +602,7 @@ public final class FabricDatabase implements ModuleControl,
                 GemFireXDUtils.waitForNodeInitialization();
                 embedConnection = GemFireXDUtils.createNewInternalConnection(
                     false);
-                checkSnappyCatalogConsistency(embedConnection);
+                checkSnappyCatalogConsistency(embedConnection, false, false);
               } catch (StandardException | SQLException e) {
                 throw new GemFireXDRuntimeException(e);
               } finally {
@@ -632,10 +630,13 @@ public final class FabricDatabase implements ModuleControl,
    * Detect catalog inconsistencies (between store DD and Hive MetaStore)
    * and remove those
    * @param embedConn
+   * @param removeInconsistentEntries if true remove inconsistent entries from catalog
+   * @param removeTablesWithData remove entries for tables even if there is data in tables
    * @throws StandardException
    * @throws SQLException
    */
-  public static void checkSnappyCatalogConsistency(EmbedConnection embedConn)
+  public static void checkSnappyCatalogConsistency(EmbedConnection embedConn,
+      boolean removeInconsistentEntries, boolean removeTablesWithData)
       throws StandardException, SQLException {
     final GemFireStore memStore = Misc.getMemStoreBooting();
     final ExternalCatalog externalCatalog = memStore.getExternalCatalog(false);
@@ -683,9 +684,9 @@ public final class FabricDatabase implements ModuleControl,
 //     SanityManager.DEBUG_PRINT("info", "tables in hive store = " + hiveDBTablesMap);
 //     SanityManager.DEBUG_PRINT("info", "tables in DD  = " + gfDBTablesMap);
     removeInconsistentDDEntries(embedConn, hiveDBTablesMap,
-        gfDBTablesMap, internalColumnTablesSet, externalCatalog);
+        gfDBTablesMap, internalColumnTablesSet, externalCatalog, removeInconsistentEntries, removeTablesWithData);
     removeInconsistentHiveEntries(hiveDBTablesMap, gfDBTablesMap,
-        externalCatalog);
+        externalCatalog, removeInconsistentEntries, removeTablesWithData);
 
     // publish the column table stats at this point because that
     // requires the hive metastore
@@ -700,13 +701,16 @@ public final class FabricDatabase implements ModuleControl,
    * @param hiveDBTablesMap  schema to tables map of hive metastore entries
    * @param gfDBTablesMap   schema to tables map of DD entries
    * @param internalColumnTablesSet internal column buffer tables
+   * @param removeInconsistentEntries if true remove inconsistent entries from catalog
+   * @param removeTablesWithData remove entries for tables even if there is data in tables
    * @throws SQLException
    */
   private static void removeInconsistentDDEntries(EmbedConnection embedConn,
       HashMap<String, List<String>> hiveDBTablesMap,
       HashMap<String, List<String>> gfDBTablesMap,
       Set<String> internalColumnTablesSet,
-      ExternalCatalog externalCatalog) throws SQLException {
+      ExternalCatalog externalCatalog, boolean removeInconsistentEntries,
+      boolean removeTablesWithData) throws SQLException {
     for (Map.Entry<String, List<String>> storeEntry : gfDBTablesMap.entrySet()) {
       List<String> hiveTableList = hiveDBTablesMap.get(storeEntry.getKey());
       List<String> storeTablesList = new LinkedList<>(storeEntry.getValue());
@@ -716,11 +720,16 @@ public final class FabricDatabase implements ModuleControl,
         storeTablesList.removeAll(hiveTableList);
       }
       if (!storeTablesList.isEmpty()) {
-        SanityManager.DEBUG_PRINT("info",
+        SanityManager.DEBUG_PRINT("warning",
             "Catalog inconsistency detected: following tables " +
                 "in datadictionary are not in Hive metastore: " +
                 "schema = " + storeEntry.getKey() + " tables = " + storeTablesList);
-        dropTables(embedConn, storeEntry.getKey(), storeTablesList);
+        if (removeInconsistentEntries) {
+          dropTables(embedConn, storeEntry.getKey(), storeTablesList, removeTablesWithData);
+        } else {
+          SanityManager.DEBUG_PRINT("warning",
+              "Use system procedure SYS.REPAIR_CATALOG() remove inconsistency");
+        }
       }
 
       // DD contains row buffer but not the column buffer of the table
@@ -738,13 +747,18 @@ public final class FabricDatabase implements ModuleControl,
         }
       }
       if (!tablesMissingColumnBuffer.isEmpty()) {
-        SanityManager.DEBUG_PRINT("info",
+        SanityManager.DEBUG_PRINT("warning",
             "Catalog inconsistency detected: following column tables " +
                 "do not have column buffer: " +
                 "schema = " + storeEntry.getKey() + " tables = " + tablesMissingColumnBuffer);
-        dropTables(embedConn, storeEntry.getKey(), tablesMissingColumnBuffer);
-        removeTableFromHivestore(storeEntry.getKey(),
-            tablesMissingColumnBuffer, externalCatalog);
+        if (removeInconsistentEntries) {
+          dropTables(embedConn, storeEntry.getKey(), tablesMissingColumnBuffer, removeTablesWithData);
+          removeTableFromHivestore(storeEntry.getKey(),
+              tablesMissingColumnBuffer, externalCatalog);
+        } else {
+          SanityManager.DEBUG_PRINT("warning",
+              "Use system procedure SYS.REPAIR_CATALOG() remove inconsistency");
+        }
       }
     }
   }
@@ -753,11 +767,13 @@ public final class FabricDatabase implements ModuleControl,
    * Remove Hive entries for which there is no DD entry
    * @param hiveDBTablesMap schema to tables map of hive metastore entries
    * @param gfDBTablesMap schema to tables map of DD entries
+   * @param removeInconsistentEntries if true remove inconsistent entries from catalog
+   * @param removeTablesWithData remove entries for tables even if there is data in tables
    */
   private static void removeInconsistentHiveEntries(
       HashMap<String, List<String>> hiveDBTablesMap,
       HashMap<String, List<String>> gfDBTablesMap,
-      ExternalCatalog externalCatalog) {
+      ExternalCatalog externalCatalog, boolean removeInconsistentEntries, boolean removeTablesWithData) {
     // remove tables that are in Hive store but not in datadictionary
     for (Map.Entry<String, List<String>> hiveEntry : hiveDBTablesMap.entrySet()) {
       List<String> storeTableList = gfDBTablesMap.get(hiveEntry.getKey());
@@ -772,12 +788,17 @@ public final class FabricDatabase implements ModuleControl,
       }
 
       if (!hiveTableList.isEmpty()) {
-        SanityManager.DEBUG_PRINT("info",
+        SanityManager.DEBUG_PRINT("warning",
             "Catalog inconsistency detected: following tables " +
                 "in Hive metastore are not in datadictionary: " +
                 "schema = " + hiveEntry.getKey() + " tables = " + hiveTableList);
-        removeTableFromHivestore(hiveEntry.getKey(), hiveTableList,
-            externalCatalog);
+        if (removeInconsistentEntries) {
+          removeTableFromHivestore(hiveEntry.getKey(), hiveTableList,
+              externalCatalog);
+        } else {
+          SanityManager.DEBUG_PRINT("warning",
+              "Use system procedure SYS.REPAIR_CATALOG() remove inconsistency");
+        }
       }
     }
   }
@@ -785,18 +806,18 @@ public final class FabricDatabase implements ModuleControl,
   private static final void removeTableFromHivestore(String schema,
       List<String> tables, ExternalCatalog externalCatalog) {
     for (String table : tables) {
-      SanityManager.DEBUG_PRINT("info", "Removing table " +
+      SanityManager.DEBUG_PRINT("warning", "Removing table " +
           schema + "." + table + " from Hive metastore");
       externalCatalog.removeTable(schema, table, false);
     }
   }
 
   private static final void dropTables(EmbedConnection embedConn,
-      String schema, List<String> tables) throws SQLException {
+      String schema, List<String> tables, boolean removeTablesWithData) throws SQLException {
     for (String table : tables) {
       try {
         String tableName = schema + "." + table;
-        SanityManager.DEBUG_PRINT("info", "FabricDatabase.dropTables " +
+        SanityManager.DEBUG_PRINT("warning", "FabricDatabase.dropTables " +
             " processing " + tableName);
 
         // drop column batch table
@@ -805,21 +826,21 @@ public final class FabricDatabase implements ModuleControl,
             columnBatchTableName(tableName);
         // set to true only if column batch table is present and could not be removed
         boolean columnBatchTableExists = false;
-        final Region<?, ?> targetRegion =
+        final Region<?, ?> columnBuffer =
             Misc.getRegionForTable(columnBatchTableName, false);
-        if (targetRegion != null) {
+        if (columnBuffer != null) {
           // make sure that corresponding row buffer also does not contain data
-          final Region<?, ?> rowTableRegion =
+          final Region<?, ?> rowBuffer =
               Misc.getRegionForTable(tableName, false);
-          if (targetRegion.size() == 0 &&
-              (rowTableRegion == null || rowTableRegion.size() == 0)) {
-            SanityManager.DEBUG_PRINT("info", "Dropping table " +
+          boolean tableContainsData = (columnBuffer.size() != 0) || (rowBuffer != null && rowBuffer.size() != 0);
+          if (!tableContainsData || (tableContainsData && removeTablesWithData)) {
+            SanityManager.DEBUG_PRINT("warning", "Dropping table " +
                 columnBatchTableName);
             embedConn.createStatement().execute(
                 "DROP TABLE IF EXISTS " + columnBatchTableName);
           } else {
             columnBatchTableExists = true;
-            SanityManager.DEBUG_PRINT("info", "Not dropping table " +
+            SanityManager.DEBUG_PRINT("warning", "Not dropping table " +
                 columnBatchTableName + " as it is not empty");
           }
         }
@@ -831,7 +852,7 @@ public final class FabricDatabase implements ModuleControl,
           final Region<?, ?> rowTableRegion =
               Misc.getRegionForTable(tableName, false);
           if (rowTableRegion != null) {
-            if (rowTableRegion.size() == 0) {
+            if (rowTableRegion.size() == 0 || removeTablesWithData) {
               SanityManager.DEBUG_PRINT("info", "Dropping table " + tableName);
               embedConn.createStatement().execute(
                   "DROP TABLE IF EXISTS " + tableName);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
@@ -1437,45 +1437,6 @@ public final class GfxdSystemProcedureMessage extends
       }
     },
 
-    repairCatalog {
-      @Override
-      boolean allowExecution(Object[] params) {
-        // allow execution only on lead node
-        final boolean isLead = GemFireXDUtils.getGfxdAdvisor().getMyProfile().hasSparkURL();
-        return isLead;
-      }
-
-      @Override
-      public void processMessage(Object[] params, DistributedMember sender) throws
-          StandardException {
-        Object repair = params[0];
-        SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_SYS_PROCEDURES,
-            "GfxdSystemProcedureMessage: invoking REPAIR_CATALOG() procedure");
-        try {
-          GfxdSystemProcedures.runCatalogConsistencyChecks();
-        } catch (SQLException sq) {
-          throw StandardException.unexpectedUserException(sq);
-        }
-      }
-
-      @Override
-      public Object[] readParams(DataInput in, short flags) throws IOException,
-          ClassNotFoundException {
-        return new Object[] { DataSerializer.readInteger(in) };
-      }
-
-      @Override
-      public void writeParams(Object[] params, DataOutput out)
-          throws IOException {
-        DataSerializer.writeInteger((Integer)params[0], out);
-      }
-
-      @Override
-      String getSQLStatement(Object[] params) throws StandardException {
-        return "CALL SYS.REPAIR_CATALOG()";
-      }
-    },
-    
     forceHDFSWriteonlyFileRollover {
 
       @Override

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -112,6 +112,7 @@ import com.pivotal.gemfirexd.internal.engine.ddl.GfxdDDLMessage;
 import com.pivotal.gemfirexd.internal.engine.ddl.GfxdDDLRegionQueue;
 import com.pivotal.gemfirexd.internal.engine.ddl.callbacks.CallbackProcedures;
 import com.pivotal.gemfirexd.internal.engine.ddl.resolver.GfxdPartitionResolver;
+import com.pivotal.gemfirexd.internal.engine.diag.HiveTablesVTI;
 import com.pivotal.gemfirexd.internal.engine.distributed.DistributedConnectionCloseExecutorFunction;
 import com.pivotal.gemfirexd.internal.engine.distributed.GfxdConnectionHolder;
 import com.pivotal.gemfirexd.internal.engine.distributed.GfxdDistributionAdvisor;
@@ -2485,6 +2486,7 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
     return getExternalCatalog(true);
   }
 
+  /** fullInit = true is to wait for any catalog inconsistencies to be cleared */
   public ExternalCatalog getExternalCatalog(boolean fullInit) {
     final ExternalCatalog externalCatalog;
     if ((externalCatalog = this.externalCatalog) != null &&

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -384,11 +384,6 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
    */
   private volatile ExternalCatalog externalCatalog;
 
-  private volatile Future<?> externalCatalogInit;
-
-  public static final ThreadLocal<Boolean> externalCatalogInitThread =
-      new ThreadLocal<>();
-
   private Region<String, String> snappyGlobalCmdRgn;
 
   /**
@@ -2436,10 +2431,6 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
     }
   }
 
-  public void setExternalCatalogInit(Future<?> init) {
-    this.externalCatalogInit = init;
-  }
-
   public static boolean handleCatalogInit(Future<?> init) {
     try {
       init.get(60, TimeUnit.SECONDS);
@@ -2482,20 +2473,9 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
   }
 
   public ExternalCatalog getExternalCatalog() {
-    return getExternalCatalog(true);
-  }
-
-  public ExternalCatalog getExternalCatalog(boolean fullInit) {
     final ExternalCatalog externalCatalog;
     if ((externalCatalog = this.externalCatalog) != null &&
         externalCatalog.waitForInitialization()) {
-      if (fullInit) {
-        final Future<?> init = this.externalCatalogInit;
-        if (init != null && !Boolean.TRUE.equals(externalCatalogInitThread.get())
-            && !handleCatalogInit(init)) {
-          return null;
-        }
-      }
       return externalCatalog;
     } else {
       return null;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -384,6 +384,11 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
    */
   private volatile ExternalCatalog externalCatalog;
 
+  private volatile Future<?> externalCatalogInit;
+
+  public static final ThreadLocal<Boolean> externalCatalogInitThread =
+      new ThreadLocal<>();
+
   private Region<String, String> snappyGlobalCmdRgn;
 
   /**
@@ -2431,6 +2436,10 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
     }
   }
 
+  public void setExternalCatalogInit(Future<?> init) {
+    this.externalCatalogInit = init;
+  }
+
   public static boolean handleCatalogInit(Future<?> init) {
     try {
       init.get(60, TimeUnit.SECONDS);
@@ -2473,9 +2482,20 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
   }
 
   public ExternalCatalog getExternalCatalog() {
+    return getExternalCatalog(true);
+  }
+
+  public ExternalCatalog getExternalCatalog(boolean fullInit) {
     final ExternalCatalog externalCatalog;
     if ((externalCatalog = this.externalCatalog) != null &&
         externalCatalog.waitForInitialization()) {
+      if (fullInit) {
+        final Future<?> init = this.externalCatalogInit;
+        if (init != null && !Boolean.TRUE.equals(externalCatalogInitThread.get())
+            && !handleCatalogInit(init)) {
+          return null;
+        }
+      }
       return externalCatalog;
     } else {
       return null;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -2000,8 +2000,16 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
     }
 
     {
+
+      // procedure argument names
+      String[] argNames = new String[] { "REMOVE_INCONSISTENT_ENTRIES", "REMOVE_TABLES_WITH_DATA" };
+      // procedure argument types
+      TypeDescriptor[] argTypes = new TypeDescriptor[] {
+          DataTypeDescriptor.getCatalogType(Types.BOOLEAN),
+          DataTypeDescriptor.getCatalogType(Types.BOOLEAN) };
+
       super.createSystemProcedureOrFunction("REPAIR_CATALOG", sysUUID,
-          null, null, 0, 0, RoutineAliasInfo.READS_SQL_DATA,
+          argNames, argTypes, 0, 0, RoutineAliasInfo.READS_SQL_DATA,
           null, newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, true);
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request

Changes to procedure  sys.repair_catalog to execute it on the server (earlier used to run on lead by sending a message to it). This will be useful to repair catalog even when lead is down. Also it now accepts two boolean params:
removeInconsistentEntries - if true then only remove the entries, otherwise just logs warnings for those
removeTablesWithData- if true will remove entries even if table contains data.


## Patch testing
Updated the tests (in snappy repo).
Precheckin in progress
Manual tests to be done

## ReleaseNotes changes
Doc changes to be added

## Other PRs 
https://github.com/SnappyDataInc/snappydata/pull/1113