### PR TITLE
Fixes for SNAP-2433:

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/MemberStatisticsMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/MemberStatisticsMessage.java
@@ -30,6 +30,7 @@ import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
 import com.gemstone.gemfire.internal.statistics.VMStats;
 import com.gemstone.gemfire.management.internal.ManagementConstants;
 import com.gemstone.gemfire.management.internal.beans.stats.StatsKey;
+import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
 import com.pivotal.gemfirexd.internal.engine.distributed.GfxdDistributionAdvisor;
 import com.pivotal.gemfirexd.internal.engine.distributed.message.GfxdFunctionMessage;
 import com.pivotal.gemfirexd.internal.engine.distributed.message.MemberExecutorMessage;
@@ -43,8 +44,6 @@ import org.apache.log4j.FileAppender;
 import org.apache.log4j.Logger;
 
 public class MemberStatisticsMessage extends MemberExecutorMessage {
-
-  private static final long MBFactor = 1024 * 1024;
 
   private GemFireCacheImpl gemFireCache;
 
@@ -170,7 +169,7 @@ public class MemberStatisticsMessage extends MemberExecutorMessage {
       Collection<DiskStoreImpl> diskStores = this.gemFireCache.listDiskStores();
       long totalDiskSpace = 0;
       for (DiskStoreImpl dsi : diskStores) {
-        if (dsi.getName().equals(GemFireCacheImpl.getDefaultDiskStoreName())) {
+        if (dsi.getName().equals(GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME)) {
           this.diskStoreUUID = dsi.getDiskStoreUUID();
           this.diskStoreName = dsi.getName();
         }


### PR DESCRIPTION
## Changes proposed in this pull request

**Problem:** Same member node is listed twice, in the UI, with different status. 
**Cause:** Multiple Disk Store UUIDs are found when same member is shuts down and comes back again. 
**Solution:**
  - Making use of GfxdConstants.GFXD_DEFAULT_DISKSTORE_NAME instead of
    GemFireCacheImpl.getDefaultDiskStoreName() to obtain members Disk Store UUID and Name.

## Patch testing

 - Tested manually 
 - Tested using Cluster Recovery BT.

## ReleaseNotes changes

 - None

## Other PRs 

SnappyData: 
