### PR TITLE
Avoid creating meta store on locator

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -252,6 +252,9 @@ public final class FabricDatabase implements ModuleControl,
   public static boolean skipIndexCheck = SystemProperties.getServerInstance().getBoolean(
       com.pivotal.gemfirexd.Property.DDLREPLAY_NO_INDEX_CHECK, false);
 
+  public static final boolean disallowMetastoreOnLocator = SystemProperties.getServerInstance().getBoolean(
+          "snappydata.DISALLOW_METASTORE_ON_LOCATOR", false);
+
   /**
    * Creates a new FabricDatabase object.
    */
@@ -883,6 +886,7 @@ public final class FabricDatabase implements ModuleControl,
     return gfDBTablesMap;
   }
 
+
   /**
    * Replays the initial DDL received by GII from other nodes or recovered from
    * disc.
@@ -1122,7 +1126,8 @@ public final class FabricDatabase implements ModuleControl,
             final DDLConflatable conflatable = (DDLConflatable)qVal;
             String schemaForTable = conflatable.getSchemaForTableNoThrow();
             if (this.memStore.restrictedDDLStmtQueue() &&
-                !(schemaForTable != null && Misc.isSnappyHiveMetaTable(schemaForTable))) {
+                !(!disallowMetastoreOnLocator &&
+                        schemaForTable != null && Misc.isSnappyHiveMetaTable(schemaForTable))) {
               continue;
             }
             // check for any merged DDLs

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLMessage.java
@@ -43,6 +43,7 @@ import com.pivotal.gemfirexd.internal.engine.GfxdDataSerializable;
 import com.pivotal.gemfirexd.internal.engine.GfxdSerializable;
 import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.access.GemFireTransaction;
+import com.pivotal.gemfirexd.internal.engine.db.FabricDatabase;
 import com.pivotal.gemfirexd.internal.engine.distributed.GfxdConnectionHolder;
 import com.pivotal.gemfirexd.internal.engine.distributed.GfxdConnectionWrapper;
 import com.pivotal.gemfirexd.internal.engine.distributed.GfxdDistributionAdvisor;
@@ -255,7 +256,8 @@ public final class GfxdDDLMessage extends GfxdMessage implements
     // skip DDL execution on locators/agents/admins (not for HiveMetaTable
     String schemaForTable = ddl.getSchemaForTableNoThrow();
     if (!GemFireXDUtils.getMyVMKind().isAccessorOrStore() &&
-        !(schemaForTable != null && Misc.isSnappyHiveMetaTable(schemaForTable))) {
+        !(!FabricDatabase.disallowMetastoreOnLocator &&
+                schemaForTable != null && Misc.isSnappyHiveMetaTable(schemaForTable))) {
       if (GemFireXDUtils.TraceDDLQueue) {
         SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_DDLQUEUE, toString()
             + " Skipping execution of DDL on " + GemFireXDUtils.getMyVMKind()


### PR DESCRIPTION
Added a boolean system property snappydata.DISALLOW_METASTORE_ON_LOCATOR to
avoid creating meta store on locator
By default, it is false and meta store will be created on locator too

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
