### PR TITLE
Encrypt password utility

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -90,6 +90,7 @@ import com.pivotal.gemfirexd.internal.iapi.db.PropertyInfo;
 import com.pivotal.gemfirexd.internal.iapi.error.PublicAPI;
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
 import com.pivotal.gemfirexd.internal.iapi.jdbc.AuthenticationService;
+import com.pivotal.gemfirexd.internal.iapi.reference.Limits;
 import com.pivotal.gemfirexd.internal.iapi.reference.Property;
 import com.pivotal.gemfirexd.internal.iapi.services.io.FormatableBitSet;
 import com.pivotal.gemfirexd.internal.iapi.services.property.PropertyUtil;
@@ -626,6 +627,72 @@ public class GfxdSystemProcedures extends SystemProcedures {
       EmbedResultSetMetaData.getResultColumnDescriptor("TYPE", Types.VARCHAR,
           false, 8)
   };
+
+
+  /**
+   * Encrypts a password and returns the encrypted text in result set
+   *
+   * @param userID userId whose password is to be encrypted
+   * @param password plain text password
+   * @param transformation algorithm to be used, default is AES, if null is passed for arg
+   * @param keySize encryption key size, default is 128 if a value <=0 is passed for this arg
+   * @param encryptedPwdRs
+   * @throws Exception
+   */
+  public static void ENCRYPT_PASSWORD(String userID, String password,
+      String transformation, int keySize, ResultSet[] encryptedPwdRs)
+      throws SQLException {
+
+    if (GemFireXDUtils.TraceAuthentication || GemFireXDUtils.TraceSysProcedures) {
+      SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_AUTHENTICATION,
+          "executing SYS.ENCRYPT_PASSWORD(), " +
+              "userID=" + userID + ", transformation=" + transformation + ", keySize=" + keySize);
+    }
+
+    try {
+      String user = IdUtil.getDBUserId(userID, false);
+
+      String algo = transformation == null
+          ? GfxdConstants.PASSWORD_PRIVATE_KEY_ALGO_DEFAULT : GemFireXDUtils
+          .getPrivateKeyAlgorithm(transformation);
+      if (keySize <= 0) {
+        keySize = GfxdConstants.PASSWORD_PRIVATE_KEY_SIZE_DEFAULT;
+      }
+      GemFireXDUtils.initializePrivateKey(algo, keySize, null);
+
+      final String encryptedString = AuthenticationServiceBase.ID_PATTERN_LDAP_SCHEME_V1 +
+          GemFireXDUtils.encrypt(password, transformation,
+              GemFireXDUtils.getUserPasswordCipherKeyBytes(user,
+                  transformation, keySize));
+
+      final CustomRowsResultSet.FetchDVDRows fetchRows =
+          new CustomRowsResultSet.FetchDVDRows() {
+
+            boolean resultReturned = false;
+
+            @Override
+            public boolean getNext(DataValueDescriptor[] template)
+                throws SQLException, StandardException {
+              if (!resultReturned) {
+                template[0].setValue(userID + " = " + encryptedString);
+                resultReturned = true;
+                return true;
+              }
+              return false;
+            }
+
+          };
+      encryptedPwdRs[0] = new CustomRowsResultSet(fetchRows, encryptColumnInfo);
+    } catch (Throwable t) {
+      throw TransactionResourceImpl.wrapInSQLException(t);
+    }
+  }
+
+  private static final ResultColumnDescriptor[] encryptColumnInfo = {
+      EmbedResultSetMetaData.getResultColumnDescriptor("ENCRYPTED_PASSWORD", Types.VARCHAR,
+          false, Limits.DB2_VARCHAR_MAXWIDTH),
+  };
+
 
   /**
    * Set the percentage of heap at or above which the GFXD server instance is
@@ -2967,6 +3034,8 @@ public class GfxdSystemProcedures extends SystemProcedures {
     } catch (javax.naming.NamingException ne) {
       throw PublicAPI.wrapStandardException(StandardException
           .newException(SQLState.AUTH_INVALID_LDAP_GROUP, ne, ldapGroup));
+    } catch (Throwable t) {
+      throw TransactionResourceImpl.wrapInSQLException(t);
     }
 
     // lock the DataDictionary for writing

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -637,7 +637,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
    * @param transformation algorithm to be used, default is AES, if null is passed for arg
    * @param keySize encryption key size, default is 128 if a value <=0 is passed for this arg
    * @param encryptedPwdRs
-   * @throws Exception
+   * @throws SQLException
    */
   public static void ENCRYPT_PASSWORD(String userID, String password,
       String transformation, int keySize, ResultSet[] encryptedPwdRs)

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
@@ -78,6 +78,7 @@ import com.pivotal.gemfirexd.internal.impl.jdbc.Util;
 import com.pivotal.gemfirexd.internal.impl.services.monitor.FileMonitor;
 import com.pivotal.gemfirexd.internal.shared.common.reference.MessageId;
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState;
+import com.pivotal.gemfirexd.internal.shared.common.sanity.AssertFailure;
 import com.pivotal.gemfirexd.internal.shared.common.sanity.SanityManager;
 import io.snappydata.jdbc.AutoloadedDriver;
 import io.snappydata.thrift.ServerType;
@@ -444,6 +445,15 @@ public abstract class FabricServiceImpl implements FabricService {
       else {
         logger.warn("exception while shutting down " + ex);
         exception = ex;
+      }
+    } catch (AssertFailure ae) {
+      // ignore security failure in shutdown
+      if (!ae.getMessage().contains("There is no valid authentication service")) {
+        logger.warn("exception while shutting down " + ae);
+      }
+      GemFireCacheImpl cache = GemFireCacheImpl.getInstance();
+      if (cache != null && !cache.isClosed()) {
+        cache.close();
       }
     }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/authentication/AuthenticationServiceBase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/authentication/AuthenticationServiceBase.java
@@ -171,6 +171,7 @@ public abstract class AuthenticationServiceBase
 	public static final String ID_PATTERN_NEW_SCHEME_V3 = "v33b60";
 	public static final String ID_PATTERN_NEW_SCHEME_V2 = "v23b60";
 	public static final String ID_PATTERN_NEW_SCHEME_V1 = "3b60";
+	public static final String ID_PATTERN_LDAP_SCHEME_V1 = "v13b607k2j6";
 	/* (original code)
 	public static final String ID_PATTERN_NEW_SCHEME = "3b60";
 	*/

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/authentication/LDAPAuthenticationSchemeImpl.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/authentication/LDAPAuthenticationSchemeImpl.java
@@ -43,22 +43,21 @@ package com.pivotal.gemfirexd.internal.impl.jdbc.authentication;
 
 
 import com.gemstone.gnu.trove.THashSet;
-import com.pivotal.gemfirexd.Constants;
-import com.pivotal.gemfirexd.Property;
+import com.pivotal.gemfirexd.*;
 import com.pivotal.gemfirexd.auth.callback.CredentialInitializer;
+import com.pivotal.gemfirexd.callbacks.AsyncEventHelper;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.SecurityUtils;
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
-import com.pivotal.gemfirexd.internal.iapi.jdbc.AuthenticationService;
 import com.pivotal.gemfirexd.internal.iapi.reference.MessageId;
-import com.pivotal.gemfirexd.internal.iapi.services.i18n.MessageService;
 import com.pivotal.gemfirexd.internal.iapi.services.monitor.Monitor;
 import com.pivotal.gemfirexd.internal.iapi.services.sanity.SanityManager;
 import com.pivotal.gemfirexd.internal.iapi.util.StringUtil;
 
 import javax.naming.*;
 import javax.naming.directory.*;
+import javax.naming.directory.Attribute;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 
@@ -138,9 +137,9 @@ implements CredentialInitializer
 	private static final String[] attrDN = {"dn"};								;
 	*/
 // GemStone changes END
+	private String auth_ldap_search_pw_attr = "AUTH_LDAP_SEARCH_PW";
 
 	public LDAPAuthenticationSchemeImpl(JNDIAuthenticationService as, Properties dbProperties) {
-
 		super(as, dbProperties);
 // GemStone changes BEGIN
 		this.traceOut = (FileOutputStream)this.initDirContextEnv.get(
@@ -166,6 +165,15 @@ implements CredentialInitializer
 								)
 								throws java.sql.SQLException
 	{
+		String encryptedPwd = getEncrypted(userPassword);
+		if (encryptedPwd != null) {
+			try {
+				userPassword = decryptPassword(userName, encryptedPwd, null, -1);
+			} catch (Exception e) {
+				throw getLoginSQLException(e);
+			}
+		}
+
 		if ( ((userName == null) || (userName.length() == 0)) ||
 			 ((userPassword == null) || (userPassword.length() == 0)) )
 		{
@@ -204,7 +212,11 @@ implements CredentialInitializer
 			}
 
 			if (userDN == (String) null) {
-				userDN = getDNFromUID(userName);
+				try {
+					userDN = getDNFromUID(userName);
+				} catch (Exception ex) {
+					throw getLoginSQLException(ex);
+				}
 			}
 		
 // GemStone changes BEGIN
@@ -281,6 +293,14 @@ implements CredentialInitializer
 // GemStone changes END
 
 		throw getLoginSQLException(e);
+	}
+
+	private String decryptPassword(String user, String secret, String transformation, int keySize) throws Exception {
+		if (GemFireXDUtils.TraceAuthentication) {
+			SanityManager.DEBUG_PRINT(AuthenticationServiceBase
+					.AuthenticationTrace, "Decrypting password for user " + user);
+		}
+		return AsyncEventHelper.decryptPassword(user, secret, null, -1);
 	}
 
 	
@@ -576,7 +596,7 @@ implements CredentialInitializer
 	 * @exception NamingException if could not retrieve the user DN.
 	 **/
 	private String getDNFromUID(String uid)
-		throws javax.naming.NamingException
+		throws Exception
 	{
 		//
 		// We bind to the LDAP server here
@@ -588,7 +608,7 @@ implements CredentialInitializer
 		if (this.searchAuthDN != (String) null) {
 			env = (Properties) initDirContextEnv.clone();
 			env.put(Context.SECURITY_PRINCIPAL, this.searchAuthDN);
-			env.put(Context.SECURITY_CREDENTIALS, this.searchAuthPW);
+			env.put(Context.SECURITY_CREDENTIALS, getSearchAuthPwd());
 		}
 		else
 			env = initDirContextEnv;
@@ -681,6 +701,24 @@ implements CredentialInitializer
 		
 		// Return the full user's DN
 		return userDN.toString();
+	}
+
+	private String getEncrypted(String pwd) {
+		if (pwd != null &&
+				pwd.startsWith(AuthenticationServiceBase.ID_PATTERN_LDAP_SCHEME_V1)) {
+			return pwd.substring(AuthenticationServiceBase.ID_PATTERN_LDAP_SCHEME_V1.length());
+		} else {
+			return null;
+		}
+	}
+
+	private String getSearchAuthPwd() throws Exception {
+		String entrypedPwd = getEncrypted(this.searchAuthPW);
+		if (entrypedPwd != null) {
+       return decryptPassword(auth_ldap_search_pw_attr,
+					 entrypedPwd, null, -1);
+		}
+		return this.searchAuthPW;
 	}
 // GemStone changes BEGIN
 
@@ -835,7 +873,7 @@ implements CredentialInitializer
          *              on failure to retrieve the LDAP group's base DN
          */
         public Set<String> getLDAPGroupMembers(String ldapGroup)
-            throws NamingException {
+            throws Exception {
 
           // We bind to the LDAP server here
           // Note that this bind might be anonymous (if anonymous searches
@@ -845,7 +883,7 @@ implements CredentialInitializer
           if (this.searchAuthDN != (String)null) {
             env = (Properties)initDirContextEnv.clone();
             env.put(Context.SECURITY_PRINCIPAL, this.searchAuthDN);
-            env.put(Context.SECURITY_CREDENTIALS, this.searchAuthPW);
+            env.put(Context.SECURITY_CREDENTIALS, getSearchAuthPwd());
           } else {
             env = initDirContextEnv;
           }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -1267,6 +1267,26 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
     }
 
     {
+      // out ResultSet ENCRYPT_PASSWORD()
+
+      // procedure argument names
+      String[] arg_names = { "USER_ID", "PASSWORD", "TRANSFORMATION", "KEYSIZE" };
+
+      // procedure argument types
+      TypeDescriptor[] arg_types = {
+          CATALOG_TYPE_SYSTEM_IDENTIFIER,
+          DataTypeDescriptor.getCatalogType(Types.VARCHAR,
+              Limits.DB2_VARCHAR_MAXWIDTH),
+          DataTypeDescriptor.getCatalogType(Types.VARCHAR,
+              Limits.DB2_VARCHAR_MAXWIDTH),
+          DataTypeDescriptor.getCatalogType(Types.INTEGER)};
+
+      super.createSystemProcedureOrFunction("ENCRYPT_PASSWORD", sysUUID, arg_names, arg_types,
+          0, 1, RoutineAliasInfo.NO_SQL, null, newlyCreatedRoutines, tc,
+          GFXD_SYS_PROC_CLASSNAME, false);
+    }
+
+    {
       // CHECK_TABLE_EX
 
       // procedure argument names

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/GranteeIterator.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/GranteeIterator.java
@@ -117,7 +117,7 @@ public final class GranteeIterator implements Iterator<String> {
             }
             currentGroupIter = ldapAuth.getLDAPGroupMembers(currentLdapGroup)
                 .iterator();
-          } catch (javax.naming.NamingException ne) {
+          } catch (Exception ne) {
             throw StandardException.newException(
                 SQLState.AUTH_INVALID_LDAP_GROUP, ne, currentLdapGroup);
           }


### PR DESCRIPTION
## Changes proposed in this pull request
Changes for password encryption utility. Added a new procedure SYS.ENCRYPT_PASSWORD(String userID, String password, String transformation, int keySize) that will return encrypted password for a given plain text password. This password can be used in startup conf files, when ldap authentication is enabled. The encryption key is stored in the data dictionary.
Changes done along with Sumedh.

## Patch testing
Manual tests
Security dunit tests

## ReleaseNotes changes
Doc changes to be done 

## Other PRs 
Snappy side PR: https://github.com/SnappyDataInc/snappydata/pull/1132