### PR TITLE
Modifying the function to return the owner of the schema

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/PrivilegeInfo.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/execute/PrivilegeInfo.java
@@ -80,10 +80,10 @@ public abstract class PrivilegeInfo
 	 * @param objectDescriptor		object being checked against
 	 * @param sd					SchemaDescriptor
 	 * @param dd					DataDictionary
-	 *
+	 * @return schema owner
 	 * @exception StandardException if user does not own the object
 	 */
-	public static void checkOwnership( String user,
+	public static String checkOwnership( String user,
 								   TupleDescriptor objectDescriptor,
 								   SchemaDescriptor sd,
 								   DataDictionary dd)
@@ -104,6 +104,7 @@ public abstract class PrivilegeInfo
 									  sd.getSchemaName(),
 									  objectDescriptor.getDescriptorName());
 		}
+		return schemaOwner;
 	}
 
 	/**


### PR DESCRIPTION
Returning the owner of the schema ( can be ldapgroup).
Need it to store/expand the owner/s while creating the policy & generating the filter plan.

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
