### PR TITLE
Set spark/snappydata connection properties into session

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/jdbc/InternalDriver.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/jdbc/InternalDriver.java
@@ -357,7 +357,25 @@ public abstract class InternalDriver implements ModuleControl {
 			if (conn.isClosed()) {
 				return null;
 			}
-			
+
+			// set defaults for Spark/SnappyData properties on the session
+			if (Boolean.parseBoolean(finfo.getProperty(Attribute.ROUTE_QUERY))) {
+				java.sql.Statement stmt = null;
+				for (String p : finfo.stringPropertyNames()) {
+					if (p.startsWith("spark.") || p.startsWith("snappydata.")) {
+						String v = finfo.getProperty(p);
+						if (v != null) {
+							if (stmt == null) {
+								stmt = conn.createStatement();
+							}
+							stmt.executeUpdate("set " + p + " = " + v);
+						}
+					}
+				}
+				if (stmt != null) {
+					stmt.close();
+				}
+			}
 			{
                           if (isolationLevel == Connection.TRANSACTION_NONE) {
                             conn.setAutoCommit(false, false);

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/recovery/PersistenceRecoveryOrderDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/recovery/PersistenceRecoveryOrderDUnit.java
@@ -154,10 +154,11 @@ public class PersistenceRecoveryOrderDUnit extends DistributedSQLTestBase {
       assertEquals(2, count);
     }*/
 
+    restartVMNums(-2);
     for (int i = 8; i >= 1; i--) {
       st1.execute("DROP TABLE T" + i);
     }
-    stopVMNums(-1,-2);
+    stopVMNums(-2);
   }
 
   public void testParallelInitializationColocatedTable2() throws Exception {


### PR DESCRIPTION
## Changes proposed in this pull request

Set all spark/snappydata connection properties into session using explicit "set ..." commands on
a temporary Statement.

This will send separate message for each setter and overall not very efficient but performance here
does not matter.

## Patch testing

manual

## ReleaseNotes changes

Add docs about this behaviour.

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/1136