### PR TITLE
add enable-rls flag to enable/disable Row-level security globally

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -1127,7 +1127,7 @@ public final class FabricDatabase implements ModuleControl,
             String schemaForTable = conflatable.getSchemaForTableNoThrow();
             if (this.memStore.restrictedDDLStmtQueue() &&
                 !(!disallowMetastoreOnLocator &&
-                        schemaForTable != null && Misc.isSnappyHiveMetaTable(schemaForTable))) {
+                    schemaForTable != null && Misc.isSnappyHiveMetaTable(schemaForTable))) {
               continue;
             }
             // check for any merged DDLs

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/GemFireXDUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/GemFireXDUtils.java
@@ -1819,7 +1819,7 @@ public final class GemFireXDUtils {
     // this is generated the first time a JVM forms a distributed system
     final String algo;
     if (transformation == null) {
-      transformation = algo = GfxdConstants.PASSWORD_PRIVATE_KEY_ALGO_DEFAULT;
+      algo = GfxdConstants.PASSWORD_PRIVATE_KEY_ALGO_DEFAULT;
     }
     else {
       algo = getPrivateKeyAlgorithm(transformation);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -3070,9 +3070,21 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
   }
 
   private boolean restrictTableCreation = Boolean.getBoolean(
-      "snappydata.RESTRICT_TABLE_CREATION");
+      Property.SNAPPY_RESTRICT_TABLE_CREATE);
+
+  private boolean rlsEnabled = Boolean.getBoolean(
+      Property.SNAPPY_ENABLE_RLS);
+
+  // TODO: this internal property is only for some unit tests and should be removed
+  // by updating the tests to use LDAP server (see PolictyTestBase in SnappyData)
+  public static boolean ALLOW_RLS_WITHOUT_SECURITY = false;
 
   public boolean tableCreationAllowed() {
     return !this.restrictTableCreation;
+  }
+
+  /** returns true if row-level security is enabled on the system */
+  public boolean isRLSEnabled() {
+    return rlsEnabled;
   }
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/Util.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/Util.java
@@ -240,7 +240,7 @@ public abstract class Util  {
 	}
 
 
-	static SQLException generateCsSQLException(
+	public static SQLException generateCsSQLException(
                     String error, Object arg1, Throwable t) {
 		return newEmbedSQLException(error,
 			new Object[] {arg1},

--- a/gemfirexd/core/src/main/java/io/snappydata/thrift/server/SnappyDataServiceImpl.java
+++ b/gemfirexd/core/src/main/java/io/snappydata/thrift/server/SnappyDataServiceImpl.java
@@ -270,9 +270,15 @@ public final class SnappyDataServiceImpl extends LocatorServiceImpl implements
 
       final String protocol;
       // default route-query to true on client connections
-      if (Misc.getMemStoreBooting().isSnappyStore()) {
-        if (!props.containsKey(Attribute.ROUTE_QUERY)) {
+      GemFireStore memStore = Misc.getMemStoreBooting();
+      if (memStore.isSnappyStore()) {
+        String routeQuery = props.getProperty(Attribute.ROUTE_QUERY);
+        if (routeQuery == null || routeQuery.isEmpty()) {
           props.setProperty(Attribute.ROUTE_QUERY, "true");
+        } else if (!Boolean.parseBoolean(routeQuery) && memStore.isRLSEnabled()) {
+          throw Util.generateCsSQLException(SQLState.SECURITY_EXCEPTION_ENCOUNTERED,
+              null, new IllegalStateException("Row level security (" + Property.SNAPPY_ENABLE_RLS +
+                  ") does not allow smart connector mode or with route-query=false"));
         }
         protocol = Attribute.SNAPPY_PROTOCOL;
       } else {

--- a/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/iapi/reference/Property.java
+++ b/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/iapi/reference/Property.java
@@ -697,7 +697,11 @@ public interface Property {
         public static final String SQLF_AUTH_PROVIDER = Attribute.SQLF_PREFIX
             + Attribute.AUTH_PROVIDER;
 
-  // GFXD HDFS PROPERTIES FOR EMBEDDED MODE - START 
+  String SNAPPY_ENABLE_RLS = "snappydata.enable-rls";
+
+  String SNAPPY_RESTRICT_TABLE_CREATE = "snappydata.RESTRICT_TABLE_CREATION";
+
+  // GFXD HDFS PROPERTIES FOR EMBEDDED MODE - START
         
   public static final String HADOOP_GFXD_LONER = 
       "hadoop.gemfirexd.loner.";


### PR DESCRIPTION
## Changes proposed in this pull request

- added enable-rls flag and disallow route-query=false (including smart connector) if it is enabled
- few cleanups

## Patch testing

RLS tests; full testing in progress

## ReleaseNotes changes

document that RLS with smart connectors or route-query=false is explicitly disabled

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/1139