### PR TITLE
[SNAP-2582] allow for server-auth-provider to be NONE

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/Misc.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/Misc.java
@@ -171,10 +171,11 @@ public abstract class Misc {
   }
 
   public static void waitForSamplerInitialization() {
-    final GemFireStatSampler sampler = getDistributedSystem().getStatSampler();
+    InternalDistributedSystem system = getDistributedSystem();
+    final GemFireStatSampler sampler = system.getStatSampler();
     if (sampler != null) {
       try {
-        sampler.waitForInitialization();
+        sampler.waitForInitialization(system.getConfig().getAckWaitThreshold() * 1000L);
       } catch (InterruptedException ie) {
         checkIfCacheClosing(ie);
         Thread.currentThread().interrupt();

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/Misc.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/Misc.java
@@ -53,6 +53,7 @@ import com.gemstone.gemfire.distributed.DistributedMember;
 import com.gemstone.gemfire.distributed.internal.InternalDistributedSystem;
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
 import com.gemstone.gemfire.i18n.LogWriterI18n;
+import com.gemstone.gemfire.internal.GemFireStatSampler;
 import com.gemstone.gemfire.internal.InsufficientDiskSpaceException;
 import com.gemstone.gemfire.internal.LocalLogWriter;
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
@@ -79,6 +80,7 @@ import com.pivotal.gemfirexd.internal.engine.sql.conn.GfxdHeapThresholdListener;
 import com.pivotal.gemfirexd.internal.engine.store.GemFireStore;
 import com.pivotal.gemfirexd.internal.iapi.error.DerbySQLException;
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
+import com.pivotal.gemfirexd.internal.iapi.jdbc.AuthenticationService;
 import com.pivotal.gemfirexd.internal.iapi.reference.SQLState;
 import com.pivotal.gemfirexd.internal.iapi.services.context.ContextService;
 import com.pivotal.gemfirexd.internal.iapi.sql.conn.LanguageConnectionContext;
@@ -88,7 +90,6 @@ import com.pivotal.gemfirexd.internal.iapi.types.DataValueDescriptor;
 import com.pivotal.gemfirexd.internal.impl.jdbc.Util;
 import com.pivotal.gemfirexd.internal.impl.jdbc.authentication.AuthenticationServiceBase;
 import com.pivotal.gemfirexd.internal.impl.jdbc.authentication.LDAPAuthenticationSchemeImpl;
-import com.pivotal.gemfirexd.internal.impl.jdbc.authentication.NoneAuthenticationServiceImpl;
 import com.pivotal.gemfirexd.internal.impl.sql.execute.PlanUtils;
 import com.pivotal.gemfirexd.internal.shared.common.sanity.SanityManager;
 import com.pivotal.gemfirexd.tools.planexporter.CreateXML;
@@ -167,6 +168,18 @@ public abstract class Misc {
   
   public final static GemFireStore getMemStoreBootingNoThrow() {
     return GemFireStore.getBootingInstance();
+  }
+
+  public static void waitForSamplerInitialization() {
+    final GemFireStatSampler sampler = getDistributedSystem().getStatSampler();
+    if (sampler != null) {
+      try {
+        sampler.waitForInitialization();
+      } catch (InterruptedException ie) {
+        checkIfCacheClosing(ie);
+        Thread.currentThread().interrupt();
+      }
+    }
   }
 
   /**
@@ -742,10 +755,25 @@ public abstract class Misc {
     }
   }
 
+  /**
+   * Returns true if security is enabled for SnappyData.
+   * Only LDAP scheme is supported currently.
+   */
   public static boolean isSecurityEnabled() {
-    AuthenticationServiceBase authService = AuthenticationServiceBase.getPeerAuthenticationService();
-    return authService != null && !(authService instanceof NoneAuthenticationServiceImpl) &&
-        checkAuthProvider(getMemStore().getBootProperties());
+    AuthenticationService authService = Misc.getMemStoreBooting()
+        .getDatabase().getAuthenticationService();
+    if (authService != null) {
+      UserAuthenticator auth = ((AuthenticationServiceBase)authService)
+          .getAuthenticationScheme();
+      return auth instanceof LDAPAuthenticationSchemeImpl;
+    }
+    return false;
+  }
+
+  /* Returns true if LDAP Security is Enabled */
+  public static boolean checkLDAPAuthProvider(Map<Object, Object> map) {
+    return Constants.AUTHENTICATION_PROVIDER_LDAP.equalsIgnoreCase(
+        String.valueOf(map.get(Attribute.AUTH_PROVIDER)));
   }
 
   /**
@@ -779,12 +807,6 @@ public abstract class Misc {
       }
     }
     return false;
-  }
-
-  /* Returns true if LDAP Security is Enabled */
-  public static boolean checkAuthProvider(Map map) {
-    return "LDAP".equalsIgnoreCase(map.getOrDefault(Attribute.AUTH_PROVIDER, "").toString()) ||
-        "LDAP".equalsIgnoreCase(map.getOrDefault(Attribute.SERVER_AUTH_PROVIDER, "").toString());
   }
 
   // added by jing for processing the exception

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -174,9 +174,9 @@ public final class FabricDatabase implements ModuleControl,
   private volatile boolean active;
 
   /** DOCUMENT ME! */
-  private AuthenticationService authenticationService;
+  private AuthenticationServiceBase authenticationService;
 
-  private AuthenticationService peerAuthenticationService;
+  private AuthenticationServiceBase peerAuthenticationService;
 
   /** The {@link GemFireStore} of booted database. */
   protected GemFireStore memStore;
@@ -2018,7 +2018,7 @@ public final class FabricDatabase implements ModuleControl,
     new DatabaseContextImpl(cm, this);
   }
 
-  public final AuthenticationService getAuthenticationService() {
+  public final AuthenticationServiceBase getAuthenticationService() {
 
     // Expected to find one - Sanity check being done at
     // DB boot-up.
@@ -2034,17 +2034,7 @@ public final class FabricDatabase implements ModuleControl,
     return this.authenticationService;
   }
 
-  /**
-   * @throws com.gemstone.gemfire.cache.CacheClosedException if store is null
-   * @return
-   */
-  public static AuthenticationServiceBase getAuthenticationServiceBase() {
-    return (AuthenticationServiceBase)Monitor.findServiceModule(
-        Misc.getMemStoreBooting().getDatabase(), AuthenticationService.MODULE,
-        GfxdConstants.AUTHENTICATION_SERVICE);
-  }
-
-  public final AuthenticationService getPeerAuthenticationService() {
+  public final AuthenticationServiceBase getPeerAuthenticationService() {
 
     // Expected to find one - Sanity check being done at
     // DB boot-up.
@@ -2502,18 +2492,16 @@ public final class FabricDatabase implements ModuleControl,
    *
    * @throws  StandardException  DOCUMENT ME!
    */
-  protected AuthenticationService bootAuthenticationService(boolean create,
-                                                            Properties props)
+  protected AuthenticationServiceBase bootAuthenticationService(boolean create,
+                                                                Properties props)
   throws StandardException {
 
-    peerAuthenticationService = (AuthenticationService)Monitor.bootServiceModule(create, this, AuthenticationService.MODULE,
+    peerAuthenticationService = (AuthenticationServiceBase)Monitor.bootServiceModule(create, this, AuthenticationService.MODULE,
         GfxdConstants.PEER_AUTHENTICATION_SERVICE, props);
 
-    assert peerAuthenticationService instanceof AuthenticationServiceBase;
+    AuthenticationServiceBase.setPeerAuthenticationService(peerAuthenticationService);
 
-    AuthenticationServiceBase.setPeerAuthenticationService((AuthenticationServiceBase)peerAuthenticationService);
-
-    return (AuthenticationService)Monitor.bootServiceModule(create, this,
+    return (AuthenticationServiceBase)Monitor.bootServiceModule(create, this,
         AuthenticationService.MODULE, GfxdConstants.AUTHENTICATION_SERVICE, props);
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/DDLConflatable.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/DDLConflatable.java
@@ -33,7 +33,6 @@ import com.gemstone.gemfire.internal.shared.Version;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
 import com.pivotal.gemfirexd.internal.engine.GfxdDataSerializable;
 import com.pivotal.gemfirexd.internal.engine.GfxdSerializable;
-import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
 import com.pivotal.gemfirexd.internal.engine.store.GemFireStore;
 import com.pivotal.gemfirexd.internal.iapi.services.sanity.SanityManager;
@@ -587,7 +586,8 @@ public final class DDLConflatable extends GfxdDataSerializable implements
   @Override
   public void appendFields(StringBuilder sb) {
     sb.append(" [").append(this.ddlId).append(']');
-    sb.append(" SQLText [").append(this.sqlText);
+    sb.append(" SQLText [");
+    sb.append(GemFireXDUtils.maskGenericPasswordFromSQLString(this.sqlText));
     sb.append("] fullTableName=").append(this.fullTableName);
     sb.append(";defaultSchema=").append(this.defaultSchema);
     sb.append(";objectName=").append(this.objectName);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/StatementExecutorMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/StatementExecutorMessage.java
@@ -146,7 +146,10 @@ public class StatementExecutorMessage<T> extends RegionExecutorMessage<T> {
       long timeOutMillis, boolean abortOnLowMemory) {
     super(collector, region, routingObjects, getCurrentTXState(lcc),
         getTimeStatsSettings(lcc), abortOnLowMemory);
-    if (source != null && !Property.DEFAULT_USER_NAME.equals(defaultSchema)) {
+    // skip setting defaultSchema when it is for APP system user
+    if (source != null && !(Property.DEFAULT_USER_NAME.equals(defaultSchema) &&
+        Property.DEFAULT_USER_NAME.equals(lcc.getDataDictionary()
+            .getAuthorizationDatabaseOwner()))) {
       this.defaultSchema = defaultSchema;
       this.queryFlags = GemFireXDUtils.set(this.queryFlags, HASAUTHID);
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/GemFireXDUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/GemFireXDUtils.java
@@ -906,11 +906,10 @@ public final class GemFireXDUtils {
       boolean remoteConnection) throws StandardException {
     try {
       final Properties props = new Properties();
-      props.putAll(AuthenticationServiceBase.getPeerAuthenticationService()
-          .getBootCredentials());
-      boolean isSnappy = Misc.getMemStore().isSnappyStore();
-      String protocol = isSnappy ? Attribute.SNAPPY_PROTOCOL : Attribute.PROTOCOL;
-      final EmbedConnection conn = (EmbedConnection)InternalDriver
+      GemFireStore memStore = Misc.getMemStoreBooting();
+      props.putAll(memStore.getDatabase().getAuthenticationService().getBootCredentials());
+      String protocol = memStore.isSnappyStore() ? Attribute.SNAPPY_PROTOCOL : Attribute.PROTOCOL;
+      final EmbedConnection conn = InternalDriver
           .activeDriver().connect(protocol, props,
               EmbedConnection.CHILD_NOT_CACHEABLE,
               EmbedConnection.CHILD_NOT_CACHEABLE, remoteConnection, Connection.TRANSACTION_NONE);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/GemFireXDUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/GemFireXDUtils.java
@@ -1666,6 +1666,11 @@ public final class GemFireXDUtils {
       "\\b(CREATE_USER\\s*\\([^,]*,([^\\)]*)\\)|ENCRYPT_PASSWORD\\s*\\([^,]*,([^,]*),.*\\))",
       Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
+  private static final String delimiters = ")\\]},;";
+  private static final Pattern GENERIC_PASSWORD_PATTERN = Pattern.compile(
+      "\\b(PASSWORD|PWD)\\w*[^" + delimiters + "]*(?=[" + delimiters + "])",
+      Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
   /**
    * Encrypt a given message for storage in file or memory.
    * 
@@ -1918,6 +1923,14 @@ public final class GemFireXDUtils {
     else {
       return sql;
     }
+  }
+
+  /**
+   * Returns SQL string after masking any password provided in a SQL string.
+   * Currently "password=..." and "pwd=..." patterns are masked.
+   */
+  public static String maskGenericPasswordFromSQLString(String sql) {
+    return GENERIC_PASSWORD_PATTERN.matcher(sql).replaceAll("password ***");
   }
 
   public static void throwAssert(String msg) throws AssertFailure {
@@ -2904,8 +2917,8 @@ public final class GemFireXDUtils {
    * to complete.
    * 
    * @param timeout
-   *          the maximum timeout to wait for node initialization; a negative
-   *          value indicates infinite wait
+   *          the maximum timeout to wait for node initialization in milliseconds;
+   *          a negative value indicates infinite wait
    * @param waitForRegionInitializations
    *          also wait for region initializations to be complete (e.g. in case
    *          of persistent regions it can wait for other nodes to startup),

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/SecurityUtils.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/utils/SecurityUtils.java
@@ -195,7 +195,7 @@ public class SecurityUtils {
         }
         else {
           String val = inProperties.getProperty(key);
-          outProperties.put(key, val);
+          if (val != null) outProperties.put(key, val);
         }
       }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
@@ -525,10 +525,10 @@ public abstract class FabricServiceImpl implements FabricService {
       SanityManager.THROWASSERT("boot indicator cannot be user supplied.");
     }
 
-    GemFireStore memStore = Misc.getMemStoreBooting();
-    AuthenticationService authService = memStore.getDatabase()
-        .getAuthenticationService();
-    if (authService == null) {
+    GemFireStore memStore = Misc.getMemStoreBootingNoThrow();
+    AuthenticationService authService;
+    if (memStore == null || (authService = memStore.getDatabase()
+        .getAuthenticationService()) != null) {
       return;
     }
     // doing authentication before n/w server shutdown.

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/fabricservice/FabricServiceImpl.java
@@ -525,18 +525,17 @@ public abstract class FabricServiceImpl implements FabricService {
       SanityManager.THROWASSERT("boot indicator cannot be user supplied.");
     }
 
-    AuthenticationService authService = (AuthenticationService)Monitor
-        .findServiceModule(Misc.getMemStore().getDatabase(),
-            AuthenticationService.MODULE,
-            GfxdConstants.PEER_AUTHENTICATION_SERVICE);
-
+    GemFireStore memStore = Misc.getMemStoreBooting();
+    AuthenticationService authService = memStore.getDatabase()
+        .getAuthenticationService();
     if (authService == null) {
       return;
     }
     // doing authentication before n/w server shutdown.
     // taken from InternalDriver#connect...
     String failure;
-    if ((failure = authService.authenticate(null, shutdownCredentials)) != null) {
+    if ((failure = authService.authenticate(memStore.getDatabaseName(),
+        shutdownCredentials)) != null) {
       throw Util.generateCsSQLException(SQLState.NET_CONNECT_AUTH_FAILED,
           MessageService.getTextMessage(MessageId.AUTH_INVALID, failure));
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/procedure/DistributedProcedureCallFunction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/procedure/DistributedProcedureCallFunction.java
@@ -52,7 +52,6 @@ import com.pivotal.gemfirexd.internal.engine.distributed.GfxdConnectionWrapper;
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
 import com.pivotal.gemfirexd.internal.engine.procedure.cohort.ProcedureSender;
 import com.pivotal.gemfirexd.internal.iapi.reference.JDBC30Translation;
-import com.pivotal.gemfirexd.internal.iapi.reference.Property;
 import com.pivotal.gemfirexd.internal.iapi.services.sanity.SanityManager;
 import com.pivotal.gemfirexd.internal.iapi.sql.Activation;
 import com.pivotal.gemfirexd.internal.iapi.types.DataType;
@@ -365,9 +364,7 @@ public class DistributedProcedureCallFunction implements Function, Declarable {
       this.sqlText = sqlText;
       this.whereClause = whereClause;
       this.tableName = tableName;
-      if (!Property.DEFAULT_USER_NAME.equals(defaultSchema)) {
-        this.defaultSchema = defaultSchema;
-      }
+      this.defaultSchema = defaultSchema;
       // pre-initialize any fields into final shape else things may go awry due
       // to concurrent serialization and local execution (which happens in a
       // separate function execution thread) -- see #46480

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/procedure/coordinate/ProcedureProxy.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/procedure/coordinate/ProcedureProxy.java
@@ -125,19 +125,17 @@ public final class ProcedureProxy implements
   */
   private static Pattern pattern = Pattern
       .compile("\\s*(?i)(table)\\s+(\\S+)(\\s+(?i)(where)\\s+(\\S+.*))?");
+
   /**
-   * @param activation  
-   * @param probeValues        //if the where clause contains a IN operator
-   * @param startKeyGetter       
+   * @param activation
+   * @param probeValues         if the where clause contains a IN operator
+   * @param startKeyGetter
    * @param startSearchOperator
    * @param stopKeyGetter
    * @param stopSearchOperator
-   * @param conglomId          //the base table id 
-   * @param all                //execute the procedure in all nodes
-   * @param serverGroups       //execute the procedure in a set of groups. 
-   * @param long globalIndexId  //the id of the global hash index. This happens while a 
-   *                             where clause contains  the global hash index columns but 
-   *                             does not have the partition columns. 
+   * @param tableIdIndex        the base table index in activation
+   * @param all                 execute the procedure in all nodes
+   * @param serverGroupIdx      execute the procedure in a set of groups.
    */
   public ProcedureProxy(Activation activation, int tableIdIndex, long indexId, int numColumns,
       GeneratedMethod startKeyGetter, int startSearchOperator,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedStatement.java
@@ -2417,8 +2417,8 @@ public class EmbedStatement extends ConnectionChild
                   processor = GfxdDDLMessage.getReplyProcessor(sys, memberThatPersistOnHDFS,
                       true);
                   SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_DDLREPLAY,
-                      "EmbedStatement: Sending DDL statement " + this.SQLText
-                          + '[' + ddlId.longValue() + "] to other VMs in the "
+                      "EmbedStatement: Sending DDL statement " + ddl
+                          + " [" + ddlId + "] to other VMs in the "
                           + "distributed system for execution: " + selectedmember + ". This VM " +
                           		"is responsible for persisting the statement on HDFS. ");
                   GfxdDDLMessage.send(sys, processor, memberThatPersistOnHDFS, ddl,
@@ -2440,8 +2440,8 @@ public class EmbedStatement extends ConnectionChild
                 processor = GfxdDDLMessage.getReplyProcessor(sys, otherMembers,
                     true);
                 SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_DDLREPLAY,
-                    "EmbedStatement: Sending DDL statement " + this.SQLText
-                        + '[' + ddlId.longValue() + "] to other VMs in the "
+                    "EmbedStatement: Sending DDL statement " + ddl
+                        + " [" + ddlId + "] to other VMs in the "
                         + "distributed system for execution: " + otherMembers);
                 GfxdDDLMessage.send(sys, processor, otherMembers, ddl,
                     localConn.getConnectionID(), ddlId.longValue(), this.lcc);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedStatement.java
@@ -2064,6 +2064,10 @@ public class EmbedStatement extends ConnectionChild
           connForRemote = false;
           tran = null;
         }
+        if (act != null) {
+          // wait for stats sampler initialization
+          Misc.waitForSamplerInitialization();
+        }
         // set autocommit to true temporarily for DDLs in the nested transaction
         if (act != null && act instanceof DDLConstantAction) {
           if (!connForRemote) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/authentication/LDAPAuthenticationSchemeImpl.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/authentication/LDAPAuthenticationSchemeImpl.java
@@ -434,17 +434,19 @@ implements CredentialInitializer
 		//
 		String searchFilterProp =
 					authenticationService.getProperty(Property.AUTH_LDAP_SEARCH_FILTER);
-		
-		if (searchFilterProp == (String) null)
+
+		String defaultLeftSearchFilter = "(&(|(objectclass=user)(objectclass=person)" +
+				"(objectclass=inetOrgPerson)(objectclass=organizationalPerson))(uid=";
+		if (searchFilterProp == null)
 		{
 			// use our default search filter
-			this.leftSearchFilter = "(&(objectClass=inetOrgPerson)(uid=";
+			this.leftSearchFilter = defaultLeftSearchFilter;
 			this.rightSearchFilter = "))";
 
 		} else if (StringUtil.SQLEqualsIgnoreCase(searchFilterProp,Constants.LDAP_LOCAL_USER_DN)) {
 
 			// use local user DN in gemfirexd.user.<uid>
-			this.leftSearchFilter = "(&(objectClass=inetOrgPerson)(uid=";
+			this.leftSearchFilter = defaultLeftSearchFilter;
 			this.rightSearchFilter = "))";
 			this.useUserPropertyAsDN = true;
 
@@ -880,7 +882,7 @@ implements CredentialInitializer
           // are allowed in the LDAP server, or authenticated if we were
           // told/configured to.
           Properties env = null;
-          if (this.searchAuthDN != (String)null) {
+          if (this.searchAuthDN != null) {
             env = (Properties)initDirContextEnv.clone();
             env.put(Context.SECURITY_PRINCIPAL, this.searchAuthDN);
             env.put(Context.SECURITY_CREDENTIALS, getSearchAuthPwd());

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/security/SecurityTestUtils.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/security/SecurityTestUtils.java
@@ -267,7 +267,7 @@ public class SecurityTestUtils extends DistributedSQLTestBase {
 
         try {
           setLdapServerBootProperties(LdapTestServer.getInstance(), -1, -1,
-              sysUser, props);
+              sysUser, props, PartitionedRegion.rand.nextBoolean());
         } catch (Exception e) {
           fail("failed to get LDAP server instance", e);
         }
@@ -1254,6 +1254,13 @@ public class SecurityTestUtils extends DistributedSQLTestBase {
   public static Properties startLdapServerAndGetBootProperties(
       int locatorPort, int mcastPort, String sysUser,
       String ldifFilePath) throws Exception {
+    return startLdapServerAndGetBootProperties(locatorPort, mcastPort,
+        sysUser, null, false);
+  }
+
+  public static Properties startLdapServerAndGetBootProperties(
+      int locatorPort, int mcastPort, String sysUser,
+      String ldifFilePath, boolean disableServerAuth) throws Exception {
     final LdapTestServer server;
     if (ldifFilePath != null) {
       server = LdapTestServer.getInstance(ldifFilePath);
@@ -1266,12 +1273,13 @@ public class SecurityTestUtils extends DistributedSQLTestBase {
     }
     Properties bootProps = new Properties();
     setLdapServerBootProperties(server, locatorPort, mcastPort,
-        sysUser, bootProps);
+        sysUser, bootProps, disableServerAuth);
     return bootProps;
   }
 
   public static void setLdapServerBootProperties(LdapTestServer server,
-      int locatorPort, int mcastPort, String sysUser, Properties bootProps) {
+      int locatorPort, int mcastPort, String sysUser, Properties bootProps,
+      boolean disableServerAuth) {
     int serverPort = server.getServerPort();
     if (locatorPort > 0) {
       bootProps.setProperty(DistributionConfig.LOCATORS_NAME,
@@ -1287,6 +1295,9 @@ public class SecurityTestUtils extends DistributedSQLTestBase {
             + GfxdConstants.TRACE_FABRIC_SERVICE_BOOT);
     bootProps.setProperty(Attribute.AUTH_PROVIDER,
         com.pivotal.gemfirexd.Constants.AUTHENTICATION_PROVIDER_LDAP);
+    if (disableServerAuth) {
+      bootProps.setProperty(Attribute.SERVER_AUTH_PROVIDER, "NONE");
+    }
     bootProps.setProperty(
         com.pivotal.gemfirexd.Property.AUTH_LDAP_SEARCH_BASE,
         "ou=ldapTesting,dc=pune,dc=gemstone,dc=com");

--- a/lgpl/gemfire-jgroups/src/main/java/com/gemstone/org/jgroups/protocols/AUTH.java
+++ b/lgpl/gemfire-jgroups/src/main/java/com/gemstone/org/jgroups/protocols/AUTH.java
@@ -88,6 +88,18 @@ public class AUTH extends Protocol {
   /** current view ID, guarded by viewLock */
   private ViewId vid;
 
+  public static String getAuthInit() {
+    return System
+        .getProperty("gemfire.sys." // DistributionConfigImpl.SECURITY_SYSTEM_PREFIX
+            + "security-peer-auth-init"); // DistributionConfig.SECURITY_PEER_AUTH_INIT_NAME);
+  }
+
+  public static String getAuthenticator() {
+    return System
+        .getProperty("gemfire.sys." // DistributionConfigImpl.SECURITY_SYSTEM_PREFIX
+            + "security-peer-authenticator"); //DistributionConfig.SECURITY_PEER_AUTHENTICATOR_NAME);
+  }
+
   /**
    * Checks the auth header. When the header authenticated successfully, it just
    * passes up the join request and pbcast.GMS will accept the join and sends
@@ -100,9 +112,7 @@ public class AUTH extends Protocol {
   @Override
   public void up(Event evt) {
 
-    String authenticator = System
-        .getProperty("gemfire.sys." // DistributionConfigImpl.SECURITY_SYSTEM_PREFIX
-            +  "security-peer-authenticator"); //DistributionConfig.SECURITY_PEER_AUTHENTICATOR_NAME);
+    String authenticator = getAuthenticator();
     boolean isSecure = (authenticator != null && authenticator.length() != 0);
     if (isSecure) {
       String failMsg = null;
@@ -195,9 +205,7 @@ public class AUTH extends Protocol {
   @Override
   public void down(Event evt) {
 
-    String authInit = System
-        .getProperty("gemfire.sys." // DistributionConfigImpl.SECURITY_SYSTEM_PREFIX
-            +  "security-peer-auth-init"); // DistributionConfig.SECURITY_PEER_AUTH_INIT_NAME);
+    String authInit = getAuthInit();
     boolean isSecure = (authInit != null && authInit.length() != 0);
     if (isSecure) {
       int hdrType = getHeaderType(evt);


### PR DESCRIPTION
## Changes proposed in this pull request

- fixing issues with setting server-auth-provider to NONE while having auth-provider=LDAP
  - remove dependence of Misc.isSecurityEnabled and similar methods on peer authentication service
    rather use the regular auth service; also cleaned up reading/handling of auth service properties
  - internal connections (including GfxdConnectionWrapper) should use the properties from the
    regular authentication service rather than the peer auth service
  - update handling of boot properties in AuthenticationServiceBase so that the relevant security
    properties are extracted for both regular and peer auth services (so that changes listed above
        can use the regular auth service and obtain the security properties)
  - corrected other issues like setup of default schema in GfxdConnectionWrapper
- corrected auth error in shutdown by using the boot properties from the auth service for shutdown
- updated the default LDAP user search filter to match against many more LDAP implementations
- switched security tests to randomly set server-auth-provider to NONE to test for above changes
- added full wait for stats layer before firing any DDL/system procedure to fix occasional
  failures in stats tests

## Patch testing

precheckin, new tests and manual testing

## Is precheckin with -Pstore clean?

store side is now clean; there is a failure due to lock timeout on snappydata side which happens without these changes and will be tracked separately

## ReleaseNotes changes

Document the possibility of setting "-server-auth-provider=NONE" to disable peer-to-peer authentication

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/1167