### PR TITLE
bug fix

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/WrapperRowLocationForTxn.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/WrapperRowLocationForTxn.java
@@ -49,6 +49,29 @@ public final class WrapperRowLocationForTxn extends AbstractRowLocation {
     this.createdForUpdateOperation = forUpdateOp;
   }
 
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj ==  this) {
+      return true;
+    } else if (obj instanceof WrapperRowLocationForTxn && this.actualRowLocation != null
+        && ((WrapperRowLocationForTxn)obj).actualRowLocation != null) {
+      WrapperRowLocationForTxn that = (WrapperRowLocationForTxn) obj;
+      return  this.actualRowLocation.equals(that.actualRowLocation);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 17;
+   // h = h * 37 + this.indexContainer.hashCode();
+   // h = h * 37 + this.indexKey.hashCode();
+    h = h * 37 + (this.actualRowLocation != null ? this.actualRowLocation.hashCode() : super.hashCode());
+    return h;
+  }
+
   public boolean wasCreatedForUpdateOp() {
     return this.createdForUpdateOperation;
   }


### PR DESCRIPTION
As per my understanding of the problem, the issue is
1) A tx update comes on tab1 on col3. the unique index is on col1
This creates a TxEntry & it modifies the other indexes on tx replacing the RegionEntry in the indexes, with WraperrRLtxn. But since col1 is not modified, it leaves it untouched.
2) Now numerous other Ops in same trxn  come on other tables.
3) Now a delete on the same row ( for which update was made) comes on tab1 . This op is definitely in a separate batch. ( because of #2). Now the base entry of reference for this op is TxEntry ( & not RegionEntry). when it attempts to replace unique index with WrapperRLTxn for delete, it the entry passed for matching is TxEntry & not RegionEntry. As a result instead of replacing RegionEntry with WrapperRLtxn it ends up appending WrapperRLTxn . So now the unique index has both WraperTxn as well as RegionEntry.
4) The final commit then leaves the unique index with RegionEntry.

I also had to conflate two WrapperRLTxns in index if they were on same RegionEntry & having same TxID. I am not sure why multiple WrapperRLtxns ( for same TxEntry & same underlying RegionEntry with same TxIDs) is causing problem ( though I think ideally it should be conflated on the lines of what I have done, isn't it?). But the change was needed to completely fix the window. I have not touched the Set part , but I suppose that needs to be closed too. Though current set of ops apparently never exceed the RowLocation array threshold of 100 , but I suppose it needs to be handled for set too.



(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
