### PR TITLE
REPAIR_METASTORE_INDEXES() sys proc

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -1499,6 +1499,13 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
     }
 
     {
+      // REPAIR_METASTORE_INDEXES
+      super.createSystemProcedureOrFunction("REPAIR_METASTORE_INDEXES", sysUUID, null,
+          null, 0, 0, RoutineAliasInfo.NO_SQL, null, newlyCreatedRoutines,
+          tc, GFXD_SYS_PROC_CLASSNAME, true);
+    }
+
+    {
       // out ResultSet EXPORT_DDLS(Boolean exportAll)
       String[] argNames = new String[] { "EXPORT_ALL" };
       TypeDescriptor[] argTypes = new TypeDescriptor[] {


### PR DESCRIPTION
## Changes proposed in this pull request
A system procedure SYS.REPAIR_METASTORE_INDEXES() to drop and recreate indexes in SNAPPY_HIVE_METASTORE schema.  To be used in cases such as index corruption.  This can be invoked by the super user to recreated the indexes.

## Patch testing
Basic testing done. Will do more manual tests before merge.

## Is precheckin with -Pstore clean?
New proc should not affect precheckin. But will run it anyway.

## ReleaseNotes changes
Will provide doc changes.

## Other PRs 
NA
