### PR TITLE
Checking if the entry causing constraint violation is destroyed or re…

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/AbstractRegionEntry.java
@@ -308,6 +308,10 @@ public abstract class AbstractRegionEntry extends ExclusiveSharedSynchronizer
   public final boolean isRemovedPhase2() {
     return getValueAsToken() == Token.REMOVED_PHASE2;
   }
+
+  public final boolean isRemovedPhase1() {
+    return getValueAsToken() == Token.REMOVED_PHASE1;
+  }
   
   public boolean fillInValue(LocalRegion region,
                              @Retained(ABSTRACT_REGION_ENTRY_FILL_IN_VALUE) InitialImageOperation.Entry dst,

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
@@ -64,7 +64,6 @@ import com.gemstone.gemfire.cache.CacheClosedException;
 import com.gemstone.gemfire.cache.DiskAccessException;
 import com.gemstone.gemfire.cache.DiskStore;
 import com.gemstone.gemfire.cache.DiskStoreFactory;
-import com.gemstone.gemfire.cache.LowMemoryException;
 import com.gemstone.gemfire.cache.RegionDestroyedException;
 import com.gemstone.gemfire.cache.persistence.PersistentID;
 import com.gemstone.gemfire.cache.query.IndexMaintenanceException;
@@ -2214,13 +2213,8 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
       IndexRecoveryTask task = new IndexRecoveryTask(allOplogs, recreateIndexes);
       // other disk store threads wait for this task, so use a different
       // thread pool for execution if possible (not in loner VM)
-      ThreadPoolExecutor executor;
-      if (getCache().getDistributionManager().isLoner()) {
-        executor = getCache().getDiskDelayedWritePool();
-      } else {
-        executor = (ThreadPoolExecutor)getCache().getDistributionManager()
-            .getWaitingThreadPool();
-      }
+      ThreadPoolExecutor executor = getCache()
+          .getWaitingThreadPoolOrDiskWritePool();
       executeDiskStoreTask(task, executor, true);
     }
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -6387,6 +6387,21 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
     return this.dm;
   }
 
+  /**
+   * Get a thread-pool for background execution. On normal DMs it will be the
+   * waiting thread pool which can have any size, or else in loner DMs (that
+   * don't have most execution thread pools) it will be the disk write pool
+   * that is a proper background thread pool even in loner DMs.
+   */
+  public final ThreadPoolExecutor getWaitingThreadPoolOrDiskWritePool() {
+    if (getDistributionManager().isLoner()) {
+      return getDiskDelayedWritePool();
+    } else {
+      return (ThreadPoolExecutor)getDistributionManager()
+          .getWaitingThreadPool();
+    }
+  }
+
   public GatewaySenderFactory createGatewaySenderFactory(){
     return new GatewaySenderFactoryImpl(this);
   }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/operations/SortedMap2IndexInsertOperation.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/operations/SortedMap2IndexInsertOperation.java
@@ -19,7 +19,8 @@ package com.pivotal.gemfirexd.internal.engine.access.operations;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
-import java.util.concurrent.FutureTask;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import com.gemstone.gemfire.LogWriter;
@@ -319,10 +320,10 @@ public final class SortedMap2IndexInsertOperation extends MemIndexOperation {
 
             };
 
-            FutureTask<Boolean> outcome = new FutureTask<Boolean>(deadEntryRemover);
-            Thread cleaner = new Thread(outcome);
-            cleaner.start();
+            ThreadPoolExecutor executor = Misc.getGemFireCache()
+                .getWaitingThreadPoolOrDiskWritePool();
             try {
+              Future<Boolean> outcome = executor.submit(deadEntryRemover);
               if (outcome.get(2000, TimeUnit.MILLISECONDS)) {
                 // either the entry was token removed or token destroyed, try again
                 continue;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/operations/SortedMap2IndexInsertOperation.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/operations/SortedMap2IndexInsertOperation.java
@@ -18,6 +18,9 @@
 package com.pivotal.gemfirexd.internal.engine.access.operations;
 
 import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 
 import com.gemstone.gemfire.LogWriter;
 import com.gemstone.gemfire.cache.ConflictException;
@@ -287,18 +290,47 @@ public final class SortedMap2IndexInsertOperation extends MemIndexOperation {
 
         // TODO: identify the cause of Bug SNAP-2627
         // Till then this is the crude fix
-        if (oldValue instanceof AbstractRegionEntry &&
-            ((AbstractRegionEntry)oldValue).isDestroyedOrRemoved()) {
-          // create a dummy exception
-          Throwable th = GemFireXDUtils.newDuplicateKeyViolation("unique constraint",
-            container.getQualifiedTableName(), "key=" + key.toString()
-            + ", row=" + value, oldValue, null, null);
-          final GemFireCacheImpl cache = Misc.getGemFireCache();
-          final LogWriter logger = cache.getLogger();
-          logger.error("Unique index constraint violation caused due to " +
-            "removed/destroyed entry. The index is corrupted. Cleaning the index", th);
-          skipListMap.remove(key, oldValue);
-          continue;
+        if (oldValue instanceof AbstractRegionEntry) {
+          final AbstractRegionEntry existingRe = (AbstractRegionEntry)oldValue;
+          if (existingRe.isDestroyedOrRemoved()) {
+            Callable<Boolean> deadEntryRemover = new Callable<Boolean>() {
+              @Override
+              public Boolean call() {
+                synchronized (existingRe) {
+                  if (existingRe.isDestroyedOrRemoved()) {
+                    if (!existingRe.isRemovedPhase1()) {
+                      // create a dummy exception
+                      Throwable th = GemFireXDUtils.newDuplicateKeyViolation("unique constraint",
+                          container.getQualifiedTableName(), "key=" + key.toString()
+                              + ", row=" + value, oldValue, null, null);
+                      final GemFireCacheImpl cache = Misc.getGemFireCache();
+                      final LogWriter logger = cache.getLogger();
+                      logger.error("Unique index constraint violation caused due to " +
+                          "removed/destroyed entry. The index is corrupted. Cleaning the index", th);
+
+                      skipListMap.remove(key, oldValue);
+                    }
+                    return true;
+                  }
+
+                }
+                return false;
+              }
+
+            };
+
+            FutureTask<Boolean> outcome = new FutureTask<Boolean>(deadEntryRemover);
+            Thread cleaner = new Thread(outcome);
+            cleaner.start();
+            try {
+              if (outcome.get(2000, TimeUnit.MILLISECONDS)) {
+                // either the entry was token removed or token destroyed, try again
+                continue;
+              }
+            } catch (Exception e) {
+              // not much can be done? let this thread throw duplicate key exception
+            }
+          }
         }
 
         throw GemFireXDUtils.newDuplicateKeyViolation("unique constraint",

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/BugsTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/BugsTest.java
@@ -1724,6 +1724,7 @@ public class BugsTest extends JdbcTestBase {
             delete.setInt(1, i % numKeysToOperate);
             delete.executeUpdate();
           }
+          conn1.close();
         } catch (Exception sqle) {
           sqle.printStackTrace();
           fail("test failed due to exception = " + sqle);
@@ -1744,6 +1745,7 @@ public class BugsTest extends JdbcTestBase {
     for (Thread th : threads) {
       th.join();
     }
+    conn.close();
     assertFalse(anyFailure[0]);
   }
 }

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/BugsTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/BugsTest.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.StringTokenizer;
+import java.util.concurrent.CyclicBarrier;
 
 import com.gemstone.gemfire.cache.persistence.PartitionOfflineException;
 import com.gemstone.gemfire.distributed.internal.DistributionConfig;
@@ -1689,5 +1690,60 @@ public class BugsTest extends JdbcTestBase {
     CompactCompositeIndexKey ccik = new CompactCompositeIndexKey(row, uniqueIndex.getExtraIndexInfo());
     sm.put(ccik, are);
     st.execute("insert into t1 values (202, 'a0', 'lse')");
+  }
+
+  public void testBugSNAP2640ConcurrentCreateDelete() throws Exception {
+    final int numOps = 10000;
+    boolean[] anyFailure = new boolean[] { false };
+    final int numKeysToOperate = 10;
+    final int numThreads = 30;
+    final CyclicBarrier barrier = new CyclicBarrier(numThreads);
+    Connection conn = getConnection();
+    Statement st = conn.createStatement();
+    st.execute("create table t1 (col1 int, col2 int not null unique) replicate");
+    Runnable task = new Runnable() {
+      @Override
+      public void run() {
+        try {
+          Connection conn1 = getConnection();
+          PreparedStatement insert = conn1.prepareStatement("insert into t1 values(?,?)");
+          PreparedStatement delete = conn1.prepareStatement("delete from t1 where col1 = ?");
+          barrier.await();
+          for (int i = 0; i < numOps; ++i) {
+            try {
+              insert.setInt(1, i % numKeysToOperate);
+              insert.setInt(2, i % numKeysToOperate);
+              insert.executeUpdate();
+            } catch (SQLException sqle) {
+              if (sqle.toString().toLowerCase().indexOf("violation") != -1
+                  && sqle.toString().toLowerCase().indexOf("constraint") != -1) {
+                // ok
+              }
+            }
+
+            delete.setInt(1, i % numKeysToOperate);
+            delete.executeUpdate();
+          }
+        } catch (Exception sqle) {
+          sqle.printStackTrace();
+          fail("test failed due to exception = " + sqle);
+          anyFailure[0] = true;
+        }
+      }
+    };
+
+    Thread[] threads = new Thread[numThreads];
+    for (int i = 0; i < numThreads; ++i) {
+      threads[i] = new Thread(task);
+    }
+
+    for (Thread th : threads) {
+      th.start();
+    }
+
+    for (Thread th : threads) {
+      th.join();
+    }
+    assertFalse(anyFailure[0]);
   }
 }


### PR DESCRIPTION
…moved in a separate thread with synch taken on region entry to avoid dead lock

 The entry causing constraint violation is checked for if its destroyed or removed in a separate thread to avoid deadlock. The check is done by taking a synch lock on region entry , so that the thread actually destroying or creating entry has the time to finish its operation.

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
