### PR TITLE
[SNAP-2657] fix performance problems with statistics SampleCollector

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/StatisticsImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/StatisticsImpl.java
@@ -379,7 +379,7 @@ public abstract class StatisticsImpl implements Statistics {
 
   @Override
   public int hashCode() {
-    return (int)this.uniqueId;
+    return Long.hashCode(this.uniqueId);
   }
   @Override
   public boolean equals(Object o) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -14666,6 +14666,10 @@ public class LocalRegion extends AbstractRegion
     }
   }
 
+  public boolean isRowBuffer() {
+    return false;
+  }
+
   @Override
   public boolean isInternalColumnTable() {
     return isInternalColumnTable;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
@@ -219,7 +219,6 @@ import com.gemstone.gemfire.internal.offheap.SimpleMemoryAllocatorImpl.Chunk;
 import com.gemstone.gemfire.internal.offheap.annotations.Unretained;
 import com.gemstone.gemfire.internal.sequencelog.RegionLogger;
 import com.gemstone.gemfire.internal.shared.SystemProperties;
-import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
 import com.gemstone.gemfire.internal.util.TransformUtils;
 import com.gemstone.gemfire.internal.util.concurrent.FutureResult;
 import com.gemstone.gemfire.internal.util.concurrent.StoppableCountDownLatch;
@@ -2523,33 +2522,35 @@ public class PartitionedRegion extends LocalRegion implements
   }
 
 
-  private volatile Boolean columnBatching;
-  public boolean needsBatching() {
-    final Boolean columnBatching = this.columnBatching;
+  private volatile Boolean isRowBuffer;
+
+  @Override
+  public boolean isRowBuffer() {
+    final Boolean columnBatching = this.isRowBuffer;
     if (columnBatching != null) {
       return columnBatching;
     }
     // Find all the child region and see if they anyone of them has name ending
     // with _SHADOW_
     if (isInternalColumnTable()) {
-      this.columnBatching = false;
+      this.isRowBuffer = false;
       return false;
     } else {
-      boolean needsBatching = false;
+      boolean isRowBuffer = false;
       List<PartitionedRegion> childRegions = ColocationHelper.getColocatedChildRegions(this);
       for (PartitionedRegion pr : childRegions) {
         if (pr.isInternalColumnTable()) {
-          needsBatching = true;
+          isRowBuffer = true;
           break;
         }
       }
-      this.columnBatching = needsBatching;
-      return needsBatching;
+      this.isRowBuffer = isRowBuffer;
+      return isRowBuffer;
     }
   }
 
-  public void clearNeedsBatching() {
-    this.columnBatching = null;
+  public void clearIsRowBuffer() {
+    this.isRowBuffer = null;
   }
 
   private void handleSendOrWaitException(Exception ex,

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
@@ -2545,6 +2545,10 @@ public class PartitionedRegion extends LocalRegion implements
     }
   }
 
+  public void clearNeedsBatching() {
+    this.columnBatching = null;
+  }
+
   private void handleSendOrWaitException(Exception ex,
       DistributedPutAllOperation putallO, PutAllPartialResult partialKeys,
       PutAllPRMessage prMsg, TXStateProxy txProxy) {
@@ -5607,6 +5611,13 @@ public class PartitionedRegion extends LocalRegion implements
       o = prIdToPR.getRegion(Integer.valueOf(prid));
     }
     return (PartitionedRegion)o;
+  }
+
+  @SuppressWarnings("unchecked")
+  public static List<PartitionedRegion> getAllPartitionedRegions() {
+    synchronized (prIdToPR) {
+      return new ArrayList<PartitionedRegion>(prIdToPR.values());
+    }
   }
 
   /**

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionedRegion.java
@@ -2531,14 +2531,17 @@ public class PartitionedRegion extends LocalRegion implements
     }
     // Find all the child region and see if they anyone of them has name ending
     // with _SHADOW_
-    if (this.getName().toUpperCase().endsWith(StoreCallbacks.SHADOW_TABLE_SUFFIX)) {
+    if (isInternalColumnTable()) {
       this.columnBatching = false;
       return false;
     } else {
       boolean needsBatching = false;
       List<PartitionedRegion> childRegions = ColocationHelper.getColocatedChildRegions(this);
       for (PartitionedRegion pr : childRegions) {
-        needsBatching |= pr.getName().toUpperCase().endsWith(StoreCallbacks.SHADOW_TABLE_SUFFIX);
+        if (pr.isInternalColumnTable()) {
+          needsBatching = true;
+          break;
+        }
       }
       this.columnBatching = needsBatching;
       return needsBatching;
@@ -5613,10 +5616,15 @@ public class PartitionedRegion extends LocalRegion implements
     return (PartitionedRegion)o;
   }
 
-  @SuppressWarnings("unchecked")
   public static List<PartitionedRegion> getAllPartitionedRegions() {
     synchronized (prIdToPR) {
-      return new ArrayList<PartitionedRegion>(prIdToPR.values());
+      ArrayList<PartitionedRegion> allPRs = new ArrayList<>(prIdToPR.size());
+      for (Object pr : prIdToPR.values()) {
+        if (pr instanceof PartitionedRegion) {
+          allPRs.add((PartitionedRegion)pr);
+        }
+      }
+      return allPRs;
     }
   }
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/statistics/SampleCollector.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/statistics/SampleCollector.java
@@ -226,7 +226,7 @@ public class SampleCollector {
     List<ResourceInstance> updatedResources = new ArrayList<ResourceInstance>();
     for (ResourceInstance ri : this.resourceInstMap.values()) {
       StatisticDescriptor[] stats = ri.getResourceType().getStatisticDescriptors();
-      if (ri.getStatistics().isClosed()) {
+      if (ri.getStatistics().isClosed() || stats.length == 0) {
         continue;
       }
       
@@ -253,6 +253,7 @@ public class SampleCollector {
           }
         }
         // resize updatedStats to only contain the the stats which were updated
+        if (updatedStatsIdx == 0) continue;
         updatedStats = Arrays.copyOf(updatedStats, updatedStatsIdx);
       }
       

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/management/internal/beans/PartitionedRegionBridge.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/management/internal/beans/PartitionedRegionBridge.java
@@ -27,7 +27,6 @@ import com.gemstone.gemfire.internal.cache.lru.Sizeable;
 import com.gemstone.gemfire.internal.cache.BucketRegion;
 import com.gemstone.gemfire.internal.cache.PartitionedRegion;
 import com.gemstone.gemfire.internal.cache.PartitionedRegionStats;
-import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
 import com.gemstone.gemfire.management.FixedPartitionAttributesData;
 import com.gemstone.gemfire.management.PartitionAttributesData;
 import com.gemstone.gemfire.management.internal.ManagementConstants;
@@ -78,8 +77,6 @@ public class PartitionedRegionBridge<K, V>  extends RegionMBeanBridge<K, V> {
 
   private StatsAverageLatency remotePutAvgLatency;
 
-  private boolean isColumnTable = false;
-
   public static final String PAR_REGION_MONITOR = "PartitionedRegionMonitor";
   
   public static <K, V> PartitionedRegionBridge<K, V> getInstance(Region<K, V> region) {
@@ -100,9 +97,7 @@ public class PartitionedRegionBridge<K, V>  extends RegionMBeanBridge<K, V> {
     this.parRegion = (PartitionedRegion)region;
     this.prStats = parRegion.getPrStats();
 
-    this.isColumnTable = parRegion.getName().toUpperCase().endsWith(StoreCallbacks.SHADOW_TABLE_SUFFIX);
-    
-    PartitionAttributes<K, V>  partAttrs = parRegion.getPartitionAttributes();    
+    PartitionAttributes<K, V>  partAttrs = parRegion.getPartitionAttributes();
     
     this.parRegionMonitor = new MBeanStatsMonitor(PAR_REGION_MONITOR);
     
@@ -328,7 +323,7 @@ public class PartitionedRegionBridge<K, V>  extends RegionMBeanBridge<K, V> {
 
   @Override
   public boolean isColumnTable() {
-    return isColumnTable;
+    return parRegion.isInternalColumnTable();
   }
 
   @Override

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/catalog/ExternalCatalog.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/catalog/ExternalCatalog.java
@@ -47,12 +47,24 @@ public interface ExternalCatalog {
   boolean isColumnTable(String schema, String tableName, boolean skipLocks);
 
   /**
-   * Will be used by the execution engine to execute query in gemfirexd
-   * if tablename is of a row table.
+   * Will be used by the execution engine to route to JobServer
+   * when it finds out that this table is a column table.
+   * <p>
+   * This variant expects table meta-data as returned by {@link #getTable}.
    *
    * @return true if the table is column table, false if row/ref table
    */
-  boolean isRowTable(String schema, String tableName, boolean skipLocks);
+  boolean isColumnTable(Object hiveTable);
+
+  /**
+   * Will be used by the execution engine to execute query in gemfirexd
+   * if tablename is of a row table.
+   * <p>
+   * This variant expects table meta-data as returned by {@link #getTable}.
+   *
+   * @return true if the table is column table, false if row/ref table
+   */
+  boolean isRowTable(Object hiveTable);
 
   /**
    * Get the schema for a column table in Json format (as in Spark).
@@ -94,6 +106,8 @@ public interface ExternalCatalog {
    */
   public ExternalTableMetaData getHiveTableMetaData(String schema, String tableName,
       boolean skipLocks);
+
+  void clearCache(String schemaName, String tableName);
 
   void close();
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -1488,7 +1488,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
           bucketCount[0] = 0;
         }
         // get index columns
-        if (hiveCatalog.isRowTable(schema, table, true)) {
+        if (hiveCatalog.isRowTable(t)) {
           getIndexColumns(indexColumns, region);
           getPKColumns(pkColumns, region);
         }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -5628,18 +5628,9 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
         if (senderIds != null) {
           senderIdsStr = SharedUtils.toCSV(senderIds);
         }
-
-        final DataValueDescriptor tType = dvds[SYSTABLESRowFactory.SYSTABLES_TABLETYPE - 1];
-        if (tType != null && "T".equalsIgnoreCase(tType.toString()) &&
-            !LocalRegion.isMetaTable(region.getFullPath())) {
-          ExternalCatalog ec = Misc.getMemStore().getExternalCatalog();
-          LanguageConnectionContext lcc = Misc.getLanguageConnectionContext();
-          if (ec != null && lcc != null && (lcc.isQueryRoutingFlagTrue() ||
-              lcc.isSnappyInternalConnection()) && Misc.initialDDLReplayDone()) {
-            if (ec.isColumnTable(schemaName, table.toString(), true)) {
-              dvds[SYSTABLESRowFactory.SYSTABLES_TABLETYPE - 1] = new SQLChar("C");
-            }
-          }
+        if (region instanceof PartitionedRegion &&
+            ((PartitionedRegion)region).needsBatching()) {
+          dvds[SYSTABLESRowFactory.SYSTABLES_TABLETYPE - 1] = new SQLChar("C");
         }
 
         dvds[SYSTABLESRowFactory.SYSTABLES_DATAPOLICY - 1] = new SQLVarchar(

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -731,6 +731,7 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
         HAS_AUTO_GENERATED_COLUMNS,
         (isByteArrayStore() && !isPrimaryKeyBased())
             || (cdl != null ? cdl.hasAutoIncrementAlways() : false));
+    clearRowBufferFlag();
   }
 
   private long getDDLId(final LanguageConnectionContext lcc,
@@ -775,6 +776,7 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
           uuidAdvisor.handshake();
         }
       }
+      clearRowBufferFlag();
       this.iargs = null; // free the internal region arguments
     } catch (TimeoutException e) {
       throw StandardException.newException(
@@ -807,6 +809,20 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
     if (r.getConcurrencyChecksEnabled()) {
       SanityManager.DEBUG_PRINT("info:" + GfxdConstants.TRACE_CONGLOM,
           "Concurrency checks enabled for table " + getQualifiedTableName());
+    }
+  }
+
+  /**
+   * reset the isRowBuffer flag for parent row buffer region
+   */
+  private void clearRowBufferFlag() {
+    if (isColumnStore()) {
+      String rowBufferTable = getRowBufferTableName(this.qualifiedName);
+      PartitionedRegion rowBuffer = (PartitionedRegion)Misc.getRegionForTableByPath(
+          rowBufferTable, false);
+      if (rowBuffer != null) {
+        rowBuffer.clearIsRowBuffer();
+      }
     }
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -5099,7 +5099,7 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
   }
 
   public final boolean isRowBuffer() {
-    return isPartitioned() && ((PartitionedRegion)this.region).needsBatching();
+    return isPartitioned() && this.region.isRowBuffer();
   }
 
   public final boolean isColumnStore() {
@@ -5627,11 +5627,8 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
         if (senderIds != null) {
           senderIdsStr = SharedUtils.toCSV(senderIds);
         }
-        if (region instanceof PartitionedRegion) {
-          PartitionedRegion pr = (PartitionedRegion)region;
-          if (pr.needsBatching() || pr.isInternalColumnTable()) {
-            dvds[SYSTABLESRowFactory.SYSTABLES_TABLETYPE - 1] = new SQLChar("C");
-          }
+        if (region.isRowBuffer() || region.isInternalColumnTable()) {
+          dvds[SYSTABLESRowFactory.SYSTABLES_TABLETYPE - 1] = new SQLChar("C");
         }
 
         dvds[SYSTABLESRowFactory.SYSTABLES_DATAPOLICY - 1] = new SQLVarchar(

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -5106,8 +5106,7 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
     // latter check is not useful currently since only column tables use
     // object store, but still added the check for possible future use
     // (e.g. local index table on column store)
-    return isObjectStore() &&
-        this.tableName.endsWith(SystemProperties.SHADOW_TABLE_SUFFIX);
+    return isObjectStore() && this.region.isInternalColumnTable();
   }
 
   public final boolean isOffHeap() {
@@ -5628,9 +5627,11 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
         if (senderIds != null) {
           senderIdsStr = SharedUtils.toCSV(senderIds);
         }
-        if (region instanceof PartitionedRegion &&
-            ((PartitionedRegion)region).needsBatching()) {
-          dvds[SYSTABLESRowFactory.SYSTABLES_TABLETYPE - 1] = new SQLChar("C");
+        if (region instanceof PartitionedRegion) {
+          PartitionedRegion pr = (PartitionedRegion)region;
+          if (pr.needsBatching() || pr.isInternalColumnTable()) {
+            dvds[SYSTABLESRowFactory.SYSTABLES_TABLETYPE - 1] = new SQLChar("C");
+          }
         }
 
         dvds[SYSTABLESRowFactory.SYSTABLES_DATAPOLICY - 1] = new SQLVarchar(

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/tools/sizer/ObjectSizer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/tools/sizer/ObjectSizer.java
@@ -36,7 +36,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
-import java.util.regex.Pattern;
 
 import com.gemstone.gemfire.LogWriter;
 import com.gemstone.gemfire.cache.PartitionAttributesFactory;
@@ -66,7 +65,6 @@ import com.gemstone.gemfire.internal.offheap.SimpleMemoryAllocatorImpl;
 import com.gemstone.gemfire.internal.offheap.SimpleMemoryAllocatorImpl.Chunk;
 import com.gemstone.gemfire.internal.offheap.annotations.Released;
 import com.gemstone.gemfire.internal.offheap.annotations.Retained;
-import com.gemstone.gemfire.internal.shared.SystemProperties;
 import com.gemstone.gemfire.internal.size.ReflectionSingleObjectSizer;
 import com.pivotal.gemfirexd.Constants;
 import com.pivotal.gemfirexd.Constants.QueryHints.SizerHints;
@@ -639,7 +637,7 @@ public class ObjectSizer {
     long valInOffheapCount = 0;
     final boolean agentAttached = SIZE_OF_UTIL.isAgentAttached();
     boolean isValueTypeEvaluated = false;
-    final boolean isColumnTable = isColumnTable(c.getQualifiedTableName());
+    final boolean isColumnTable = c.isColumnStore();
     int numColumnsInColumnTable = -1;
     long dvdArraySize = 0;
     boolean gatewayEntries = false;
@@ -843,7 +841,7 @@ public class ObjectSizer {
           }
           else if (valClass == byte[][].class) {
 
-            if (isColumnTable(c.getQualifiedTableName())) {
+            if (c.isColumnStore()) {
               columnRowCount += getRowCountFromColumnTable(c, (byte[][])value);
             }
 
@@ -993,13 +991,6 @@ public class ObjectSizer {
       }
     }
 
-  }
-
-  private static final Pattern columnTableRegex =
-      Pattern.compile(".*" + SystemProperties.SHADOW_SCHEMA_NAME + "(.*)" +
-          SystemProperties.SHADOW_TABLE_SUFFIX);
-  private Boolean isColumnTable(String fullyQualifiedTable) {
-    return columnTableRegex.matcher(fullyQualifiedTable).matches();
   }
 
   private int getRowCountFromColumnTable(GemFireContainer c, byte[][] value) throws StandardException {

--- a/gemfirexd/tools/src/main/javacc/com/pivotal/gemfirexd/internal/impl/tools/ij/ij.jj
+++ b/gemfirexd/tools/src/main/javacc/com/pivotal/gemfirexd/internal/impl/tools/ij/ij.jj
@@ -1064,11 +1064,16 @@ class ij {
 	   Outputs the names of all fields of given table. Outputs field
 	   names and data type.
 	 */
-	public ijResult describeTable(String schema, String table) throws SQLException {
+	public ijResult describeTable(String schema, String table) throws SQLException, ParseException {
 		ResultSet rs = null;
 		try {
 			haveConnection();
-			verifyTableExists(schema,table);
+			try {
+				verifyTableExists(schema,table);
+			} catch (ijException ignored) {
+				// fallback to parser for statements like DESCRIBE EXTENDED
+				throw new ParseException();
+			}
 
 			DatabaseMetaData dbmd = theConnection.getMetaData();
 			rs = dbmd.getColumns(null,schema,table,null);

--- a/gemfirexd/tools/src/main/javacc/com/pivotal/gemfirexd/internal/impl/tools/ij/ij.jj
+++ b/gemfirexd/tools/src/main/javacc/com/pivotal/gemfirexd/internal/impl/tools/ij/ij.jj
@@ -1071,7 +1071,7 @@ class ij {
 			try {
 				verifyTableExists(schema,table);
 			} catch (ijException ignored) {
-				// fallback to parser for statements like DESCRIBE EXTENDED
+				// fallback to full parser with routing for statements like DESCRIBE EXTENDED
 				throw new ParseException();
 			}
 


### PR DESCRIPTION
For cases having large number of regions (like 200 or more), SampleCollector runs in a hot loop
trying to lookup every statistic in every monitor. Latter is created for every metric/gauge in every
statistic instance and thus runs into thousands (e.g. ~10K with 500 tables) so overall lookups
become like 5 million in every run.

While the design of having a monitor for every metric/gauge for every statistic instance, and looking
up against it in case of any updates itself is inefficient, the changes below bring the performance
within acceptable range with tables of the order of 1000 or so which is sufficient for practical purposes.

## Changes proposed in this pull request

- Skip including statistics for checking that have seen no updates. This reduces the number of changes
  from 500 to single digits and improve the performance by two orders or magnitude or more.
  Actual number of statistics with updates in a second are expected to be small on an average.
- avoid lookup in hive metastore for tableType column in SYSTABLES scan and instead use
  PartitionedRegion.needsBatching()
- avoid lookup of hive metastore for isRowTable() since calling points already have the HiveTable
- renamed "needsBatching()" to "isRowBuffer()" and cleaned up checks for column/row buffers to
  consistently use LocalRegion.isInternalColumnTable() and isRowBuffer()
- add methods to return all PartitionedRegions and clear PartitionedRegion.isRowBuffer since it may
  have been cached incorrectly when column store for a table was not yet created
- add routing for DESCRIBE EXTENDED

## Patch testing

precheckin -Pstore

## Is precheckin with -Pstore clean?

occasional failure in SnapshotTxGIIDUnit.testSnapshotGII_failedForOneServer that is present on
master for a while and needs to be looked into separately

## ReleaseNotes changes

NA

## Other PRs 

snappydata PR https://github.com/SnappyDataInc/snappydata/pull/1190