### PR TITLE
Remove the code for clearing the map under lock

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -841,41 +841,6 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
     public void run() {
       try {
         if (!oldEntryMap.isEmpty()) {
-          // Can't do map.clear as have to account for memory for each oldEntry
-          if (getTxManager().getHostedTransactionsInProgress().size() == 0) {
-            acquireWriteLockOnSnapshotRvv();
-            try {
-              if (getTxManager().getHostedTransactionsInProgress().size() == 0) {
-                if (getLoggerI18n().fineEnabled()) {
-                  getLoggerI18n().info(LocalizedStrings.DEBUG, "Clearing the Map");
-                }
-                for (Entry<String, Map<Object, BlockingQueue<RegionEntry>>> entry : oldEntryMap.entrySet()) {
-                  Map<Object, BlockingQueue<RegionEntry>> regionEntryMap = entry.getValue();
-                  LocalRegion region = (LocalRegion)getRegion(entry.getKey());
-                  for (Entry<Object, BlockingQueue<RegionEntry>> oldEntry : regionEntryMap.entrySet()) {
-                    for (RegionEntry re : oldEntry.getValue()) {
-                      if (GemFireCacheImpl.hasNewOffHeap()) {
-                        // also remove reference to region buffer, if any
-                        Object value = re._getValue();
-                        if (value instanceof SerializedDiskBuffer) {
-                          ((SerializedDiskBuffer)value).release();
-                        }
-                      }
-                      // free the allocated memory
-                      if (!region.reservedTable() && region.needAccounting()) {
-                        NonLocalRegionEntry nre = (NonLocalRegionEntry)re;
-                        region.freePoolMemory(nre.getValueSize(), nre.isForDelete());
-                      }
-                    }
-                  }
-                }
-                return;
-              }
-            } finally {
-              releaseWriteLockOnSnapshotRvv();
-            }
-          }
-
           for (Entry<String,Map<Object, BlockingQueue<RegionEntry>>> entry : oldEntryMap.entrySet()) {
             Map<Object, BlockingQueue<RegionEntry>> regionEntryMap = entry.getValue();
             LocalRegion region = (LocalRegion)getRegion(entry.getKey());

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapShotTxDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/transactions/SnapShotTxDUnit.java
@@ -960,7 +960,7 @@ public class SnapShotTxDUnit extends DistributedSQLTestBase {
         oldEntries = cache.getOldEntriesForRegion("/__PR/_B__T1_0");
         System.out.println("Oldentries"+oldEntries);
         //Should be null as no transaction is active and we have executed System.gc
-        assertTrue(oldEntries == null);
+        assertTrue(oldEntries.get(1) == null);
         assertEquals(cache.getCacheTransactionManager().getHostedTransactionsInProgress().size(), 0);
         assertNull(cache.getCacheTransactionManager().getCurrentTXState());
 


### PR DESCRIPTION
  If no tx is running, we used to take a lock and iterate over
  map to remove each entry.
  There was a bug introduced where entry was not removed from queue
  but the memory was being released for it.
  No need of this block, as anyway we are iterating over the map which
  next block of code does.

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
