### PR TITLE
[SNAP-2789] use updated package for StoreHiveCatalog

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/HiveTablesVTI.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/diag/HiveTablesVTI.java
@@ -115,9 +115,7 @@ public class HiveTablesVTI extends GfxdVTITemplate
       case 5: // SOURCEPATH
         // only show for ordinal 0 and avoid repetition
         if (this.currentTableColumns.nextIndex() == 1) {
-          return provider != null && (provider.startsWith("jdbc")
-              || provider.endsWith("JdbcRelationProvider"))
-              ? currentTableMeta.driverClass : currentTableMeta.dataSourcePath;
+          return currentTableMeta.dataSourcePath;
         } else return "";
       case 6: // COMPRESSION
         String compression = this.currentTableMeta.compressionCodec;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -1545,7 +1545,8 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
       // set then that can be used for overflow/gateway
 
       String serverGroup = this.getBootProperty("server-groups");
-      Boolean isLeadMember = serverGroup != null ? serverGroup.contains("IMPLICIT_LEADER_SERVERGROUP") : false;
+      boolean isLeadMember = serverGroup != null &&
+          serverGroup.contains(ServerGroupUtils.LEADER_SERVERGROUP);
 
       if (this.persistingDD || this.persistenceDir != null || isLeadMember) {
         try {
@@ -2431,7 +2432,7 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
           // Instantiate using reflection
           try {
             this.externalCatalog = (ExternalCatalog)ClassPathLoader
-                .getLatest().forName("io.snappydata.impl.StoreHiveCatalog")
+                .getLatest().forName("io.snappydata.sql.catalog.StoreHiveCatalog")
                 .newInstance();
           } catch (InstantiationException | IllegalAccessException
               | ClassNotFoundException e) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireStore.java
@@ -2432,7 +2432,7 @@ public final class GemFireStore implements AccessFactory, ModuleControl,
           // Instantiate using reflection
           try {
             this.externalCatalog = (ExternalCatalog)ClassPathLoader
-                .getLatest().forName("io.snappydata.sql.catalog.StoreHiveCatalog")
+                .getLatest().forName("io.snappydata.sql.catalog.impl.StoreHiveCatalog")
                 .newInstance();
           } catch (InstantiationException | IllegalAccessException
               | ClassNotFoundException e) {


### PR DESCRIPTION
## Changes proposed in this pull request

- updated package path of StoreHiveCatalog as per changes on snappydata
- use dataSourcePath for SOURCEPATH in SYS.HIVETABLES which contains either the path
  for file-based tables or URL for JDBC

## Patch testing

precheckin

## Is precheckin with -Pstore clean?

Not required separately since the changes are only to the SnappyData interface layer

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/1223