### PR TITLE
added schema creation pattern for routing to lead node

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
@@ -148,7 +148,7 @@ public class GenericStatement
             "(STREAMING|DEPLOY|UNDEPLOY|CACHE|UNCACHE|REFRESH|RESET)";
         private static final String TABLE_DML_SELECT_PATTERN =
             "((((INSERT|PUT)\\s+INTO)|(DELETE\\s+FROM))\\s+(TABLE)?.*\\s+SELECT)";
-	      private static final String CREATE_OR_DROP_PATTERN = "(FUNCTION|POLICY)";
+	      private static final String CREATE_OR_DROP_PATTERN = "(FUNCTION|POLICY|SCHEMA)";
 	      private static final String ALTER_TABLE_PREFIX = "ALTER\\s+(TABLE)?\\s+.*\\s+";
 	      private static final String ALTER_TABLE_COMMANDS = "(ADD|DROP|ENABLE|DISABLE)";
 


### PR DESCRIPTION
The sql for creating schema is now routed to lead node.
Otherwise what happens is that if a schema is created via jdbc client & not table is yet created in schema, the hive catalog  does not have entry of that schema.
And so dropping of the schema  throws exception.



## Patch testing
added bug test
## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

[bug test](https://github.com/SnappyDataInc/snappydata/pull/1254)