### PR TITLE
fix for 'text' data type coming as column datatype from spark. parsin…

### DIFF
--- a/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
+++ b/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
@@ -1132,6 +1132,7 @@ public class SQLParser
 		  case DOUBLE:
 		  case BLOB:
 		  case CLOB:
+		  case TEXT:
 		  case CLOB_STRING:
 		  case JSON:
 		  case NCLOB:
@@ -2822,6 +2823,7 @@ TOKEN [IGNORE_CASE] :
   |	<C: "c">
   | <CALLED: "called">
 |	<CLOB: "clob">
+|	<TEXT: "text">
   |	<COBOL: "cobol">
 |	<COMMITTED: "committed">
 |   <CONCAT: "concat">
@@ -5256,6 +5258,11 @@ LOBType() throws StandardException :
 			type = TypeId.CLOB_NAME;
 		}
 	|
+	  <TEXT> [ length = lengthAndModifier() ]
+  		{
+  			type = TypeId.CLOB_NAME;
+  		}
+  |
         <CLOB_STRING> [ length = lengthAndModifier() ]
         {
     	    type = TypeId.CLOB_NAME;
@@ -17989,7 +17996,8 @@ nonReservedKeyword()  :
 	|	tok = <CALLED>
 	|	tok = <CLASS>
 	|	tok = <CLOB>
-|	tok = <COALESCE>
+	|	tok = <TEXT>
+  |	tok = <COALESCE>
 	|	tok = <COBOL>
 	|	tok = <COMMITTED>
 	|	tok = <COMPRESS>
@@ -18004,7 +18012,7 @@ nonReservedKeyword()  :
 	|	tok = <DATA>
 	|	tok = <DATE>
 	|	tok = <DAY>
-        |	tok = <DIRTY>
+  |	tok = <DIRTY>
 	|	tok = <DYNAMIC>
     |   tok = <DATABASE>
 	|	tok = <DB2SQL>


### PR DESCRIPTION
…g 'text' data type & treating it as clob

## Changes proposed in this pull request
Parsing the "text" column data type as clob

## Patch testing

(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 
[snappydata-parser-change](https://github.com/SnappyDataInc/snappydata/pull/1260)

