### PR TITLE
Exposing a stored procedure to detect whether security is enabled on

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -3022,6 +3022,14 @@ public class GfxdSystemProcedures extends SystemProcedures {
   }
 
   /**
+   * Check whether security is enabled on the snappy cluster or not.
+   * @return true if security is enabled in snappy cluster and false otherwise
+   */
+  public static Boolean GET_IS_SECURITY_ENABLED(){
+    return Misc.isSecurityEnabled();
+  }
+
+  /**
    * Check SELECT authorization for given columns of a column or row table.
    * The parameter "authType" must be one of the Authorizer.*PRIV types while
    * "opType" must be one of the Authorizer.*OP types.

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -2016,6 +2016,13 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
           arg_names, arg_types, 0, 1, RoutineAliasInfo.READS_SQL_DATA, null,
           newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
     }
+    {
+      // GET_IS_SECURITY_ENABLED()
+      super.createSystemProcedureOrFunction("GET_IS_SECURITY_ENABLED", sysUUID, null,
+          null, 0, 0, RoutineAliasInfo.NO_SQL,
+          DataTypeDescriptor.getCatalogType(Types.BOOLEAN), newlyCreatedRoutines, tc,
+          GFXD_SYS_PROC_CLASSNAME, false);
+    }
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })


### PR DESCRIPTION
snappy cluster or not.

## Changes proposed in this pull request

- Exposing a stored procedure to detect whether security is enabled on snappy cluster or not. This needs to be done for the smart connector mode.
- Fixing kafka utils clean-up for DUnit tests.

## Patch testing

Manually tested using snappy-shell. Scalatests and DUnit tests for snappy streaming sink also covers this change.

## Is precheckin with -Pstore clean?

Yet to be checked.

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/1249
