### PR TITLE
Changes to wrap non-fatal OOME from Spark layer in LowMemoryException

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/cache/LowMemoryException.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/cache/LowMemoryException.java
@@ -59,6 +59,16 @@ public class LowMemoryException extends ResourceException {
   }
 
   /**
+   * Constructs an instance of <code>LowMemoryException</code> with the specified cause.
+   * @param cause
+   */
+  public LowMemoryException(Throwable cause) {
+    super(cause);
+    this.critMems = Collections.emptySet();
+    CallbackFactoryProvider.getStoreCallbacks().logMemoryStats();
+  }
+
+  /**
    * Get a read-only set of members in a critical state at the time this
    * exception was constructed.
    * @return the critical members


### PR DESCRIPTION
## Changes proposed in this pull request
Added a constructor with cause

Refer to the other PRs -
https://github.com/SnappyDataInc/spark/pull/146
https://github.com/SnappyDataInc/snappydata/pull/1277

## Patch testing
Added a unit test
running precheckin

## Is precheckin with -Pstore clean?

## ReleaseNotes changes
NA

## Other PRs 
https://github.com/SnappyDataInc/spark/pull/146
https://github.com/SnappyDataInc/snappydata/pull/1277


(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
