### PR TITLE
Change the default auto reconnect to false

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionConfig.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/DistributionConfig.java
@@ -2328,7 +2328,7 @@ public interface DistributionConfig extends Config, ManagerLogWriter.LogConfig {
   public static final String DISABLE_AUTO_RECONNECT_NAME = "disable-auto-reconnect";
 
   /** The default value of the corresponding property */
-  public static final boolean DEFAULT_DISABLE_AUTO_RECONNECT = false;
+  public static final boolean DEFAULT_DISABLE_AUTO_RECONNECT = true;
   
   /**
    * Gets the value of <a href="../DistributedSystem.html#disable-auto-reconnect">"disable-auto-reconnect"</a>

--- a/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/GfxdDistributionLocator.java
+++ b/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/GfxdDistributionLocator.java
@@ -249,8 +249,9 @@ public class GfxdDistributionLocator extends GfxdServerLauncher {
     }
 
     Properties prop = (Properties) options.get(PROPERTIES);
-    if (prop.get(DistributionConfig.DISABLE_AUTO_RECONNECT_NAME) == null &&
-            prop.get(DistributionConfig.GEMFIRE_PREFIX + DistributionConfig.DISABLE_AUTO_RECONNECT_NAME) == null) {
+    if (prop.getProperty(DistributionConfig.DISABLE_AUTO_RECONNECT_NAME) == null &&
+            prop.getProperty(DistributionConfig.GEMFIRE_PREFIX
+                    + DistributionConfig.DISABLE_AUTO_RECONNECT_NAME) == null) {
       prop.put(DistributionConfig.DISABLE_AUTO_RECONNECT_NAME, "false");
     }
 

--- a/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/GfxdDistributionLocator.java
+++ b/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/GfxdDistributionLocator.java
@@ -247,6 +247,12 @@ public class GfxdDistributionLocator extends GfxdServerLauncher {
     if (this.bindAddress == null) {
       this.bindAddress = FabricLocator.LOCATOR_DEFAULT_BIND_ADDRESS;
     }
+
+    if (options.get(DistributionConfig.DISABLE_AUTO_RECONNECT_NAME) == null) {
+      Properties prop = (Properties) options.get(PROPERTIES);
+      prop.put(DistributionConfig.DISABLE_AUTO_RECONNECT_NAME, "false");
+    }
+
     final String locPort = (String)options.get(LOC_PORT_ARG);
     if (locPort != null) {
       this.port = Integer.parseInt(locPort);

--- a/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/GfxdDistributionLocator.java
+++ b/gemfirexd/tools/src/main/java/com/pivotal/gemfirexd/tools/GfxdDistributionLocator.java
@@ -248,8 +248,9 @@ public class GfxdDistributionLocator extends GfxdServerLauncher {
       this.bindAddress = FabricLocator.LOCATOR_DEFAULT_BIND_ADDRESS;
     }
 
-    if (options.get(DistributionConfig.DISABLE_AUTO_RECONNECT_NAME) == null) {
-      Properties prop = (Properties) options.get(PROPERTIES);
+    Properties prop = (Properties) options.get(PROPERTIES);
+    if (prop.get(DistributionConfig.DISABLE_AUTO_RECONNECT_NAME) == null &&
+            prop.get(DistributionConfig.GEMFIRE_PREFIX + DistributionConfig.DISABLE_AUTO_RECONNECT_NAME) == null) {
       prop.put(DistributionConfig.DISABLE_AUTO_RECONNECT_NAME, "false");
     }
 


### PR DESCRIPTION
  For locator it is still set to true

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
