### PR TITLE
possible approach to fix AQP-295

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -444,7 +444,7 @@ public final class FabricDatabase implements ModuleControl,
     final LogWriter logger = cache.getLogger();
     final EmbedConnection embedConn = (EmbedConnection)conn;
 
-    List<GfxdSystemProcedureMessage> postMssgs = null;
+    List<GfxdSystemProcedureMessage> postMsgs = null;
     try {
       final LanguageConnectionContext lcc = embedConn.getLanguageConnection();
       final GemFireTransaction tc = (GemFireTransaction)lcc
@@ -489,7 +489,7 @@ public final class FabricDatabase implements ModuleControl,
         else {
           this.memStore.getDDLStmtQueue().initializeQueue(this.dd);
         }
-        postMssgs =  postCreateDDLReplay(embedConn, bootProps, lcc, tc, logger);
+        postMsgs =  postCreateDDLReplay(embedConn, bootProps, lcc, tc, logger);
       } finally {
         if (ddReadLockAcquired) {
           this.dd.unlockAfterReading(null);
@@ -542,7 +542,7 @@ public final class FabricDatabase implements ModuleControl,
     }
 
 
-    for (GfxdSystemProcedureMessage msg : postMssgs) {
+    for (GfxdSystemProcedureMessage msg : postMsgs) {
       if (msg.getSysProcMethod().isOffHeapMethod()
         && this.memStore.getGemFireCache().getOffHeapStore() == null) {
         if (logger.severeEnabled()) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -440,11 +440,12 @@ public final class FabricDatabase implements ModuleControl,
       notifyRunning();
       return;
     }
+    final GemFireCacheImpl cache = GemFireCacheImpl.getExisting();
+    final LogWriter logger = cache.getLogger();
+    final EmbedConnection embedConn = (EmbedConnection)conn;
 
+    List<GfxdSystemProcedureMessage> postMssgs = null;
     try {
-      final EmbedConnection embedConn = (EmbedConnection)conn;
-      final GemFireCacheImpl cache = GemFireCacheImpl.getExisting();
-      final LogWriter logger = cache.getLogger();
       final LanguageConnectionContext lcc = embedConn.getLanguageConnection();
       final GemFireTransaction tc = (GemFireTransaction)lcc
           .getTransactionExecute();
@@ -488,7 +489,7 @@ public final class FabricDatabase implements ModuleControl,
         else {
           this.memStore.getDDLStmtQueue().initializeQueue(this.dd);
         }
-        postCreateDDLReplay(embedConn, bootProps, lcc, tc, logger);
+        postMssgs =  postCreateDDLReplay(embedConn, bootProps, lcc, tc, logger);
       } finally {
         if (ddReadLockAcquired) {
           this.dd.unlockAfterReading(null);
@@ -508,7 +509,7 @@ public final class FabricDatabase implements ModuleControl,
       initializeCatalog();
     } catch (Throwable t) {
       try {
-        LogWriter logger = Misc.getCacheLogWriter();
+
         if (logger != null) {
           logger.warning("got throwable: " + t.getMessage() + " calling shut down", t);
         }
@@ -538,6 +539,30 @@ public final class FabricDatabase implements ModuleControl,
       }
       throw StandardException.newException(SQLState.BOOT_DATABASE_FAILED, t,
           Attribute.GFXD_DBNAME);
+    }
+
+
+    for(GfxdSystemProcedureMessage msg: postMssgs) {
+      if (msg.getSysProcMethod().isOffHeapMethod()
+        && this.memStore.getGemFireCache().getOffHeapStore() == null) {
+        if (logger.severeEnabled()) {
+          logger.severe("FabricDatabase: aborted initial replay "
+            + "for message " + msg + " method "
+            + msg.getSysProcMethod().name());
+        }
+        continue;
+      }
+      try {
+        msg.execute();
+      } catch (Exception ex) {
+        if (logger.severeEnabled()) {
+          logger.severe("FabricDatabase: failed initial replay "
+            + "for message " + msg + " due to exception", ex);
+        }
+        throw StandardException.newException(SQLState.BOOT_DATABASE_FAILED, ex,
+          Attribute.GFXD_DBNAME);
+        //continue;
+      }
     }
   }
 
@@ -889,7 +914,7 @@ public final class FabricDatabase implements ModuleControl,
    * Replays the initial DDL received by GII from other nodes or recovered from
    * disc.
    */
-  private void postCreateDDLReplay(final EmbedConnection embedConn,
+  private List<GfxdSystemProcedureMessage> postCreateDDLReplay(final EmbedConnection embedConn,
       final Properties bootProps, final LanguageConnectionContext lcc,
       final GemFireTransaction tc, final LogWriter logger) throws Exception {
 
@@ -970,7 +995,7 @@ public final class FabricDatabase implements ModuleControl,
     final LinkedHashSet<GemFireContainer> uninitializedTables =
         new LinkedHashSet<GemFireContainer>();
     final Statement stmt = embedConn.createStatement();
-
+    List<GfxdSystemProcedureMessage> postMessages = new ArrayList<>();
     try {
       // commenting out for snap-585
       /*
@@ -1067,6 +1092,7 @@ public final class FabricDatabase implements ModuleControl,
             .getPreprocessedDDLQueue(currentQueue, skipRegionInit,
                 lastCurrentSchema, pre11TableSchemaVer, traceConflation);
 
+
         for (GfxdDDLQueueEntry entry : preprocessedQueue) {
           qEntry = entry;
           Object qVal = qEntry.getValue();
@@ -1083,6 +1109,10 @@ public final class FabricDatabase implements ModuleControl,
           if (qVal instanceof GfxdSystemProcedureMessage) {
             final GfxdSystemProcedureMessage msg =
                 (GfxdSystemProcedureMessage)qVal;
+            if (msg.postprocess()) {
+              postMessages.add(msg);
+              continue;
+            }
             if (msg.getSysProcMethod().isOffHeapMethod()
                 && this.memStore.getGemFireCache().getOffHeapStore() == null) {
               if (logger.severeEnabled()) {
@@ -1448,6 +1478,8 @@ public final class FabricDatabase implements ModuleControl,
         }
       }
 
+
+
       if (!lastCurrentSchema.equals(currentSchema)) {
         // restore the default schema
         FabricDatabase.setupDefaultSchema(dd, lcc, tc, currentSchema, true);
@@ -1462,6 +1494,8 @@ public final class FabricDatabase implements ModuleControl,
       synchronized (sync) {
         this.memStore.setInitialDDLReplayInProgress(false);
         this.memStore.setInitialDDLReplayDone(true);
+
+
         // notify any waiters
         sync.notifyAll();
       }
@@ -1500,12 +1534,15 @@ public final class FabricDatabase implements ModuleControl,
       stmt.close();
       // Setting this to false so that the waiting compactor thread finishes
       this.memStore.setInitialDDLReplayInProgress(false);
-    }
+      // restore the original schema if required
+      if (!ArrayUtils.objectEquals(initSchema, lcc.getCurrentSchemaName())) {
+        FabricDatabase.setupDefaultSchema(dd, lcc, tc, initSchema, true);
+      }
 
-    // restore the original schema if required
-    if (!ArrayUtils.objectEquals(initSchema, lcc.getCurrentSchemaName())) {
-      FabricDatabase.setupDefaultSchema(dd, lcc, tc, initSchema, true);
     }
+    return  postMessages;
+
+
   }
 
   private void checkRecoveredIndex(ArrayList<GemFireContainer> uninitializedContainers,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/db/FabricDatabase.java
@@ -542,7 +542,7 @@ public final class FabricDatabase implements ModuleControl,
     }
 
 
-    for(GfxdSystemProcedureMessage msg: postMssgs) {
+    for (GfxdSystemProcedureMessage msg : postMssgs) {
       if (msg.getSysProcMethod().isOffHeapMethod()
         && this.memStore.getGemFireCache().getOffHeapStore() == null) {
         if (logger.severeEnabled()) {
@@ -561,9 +561,9 @@ public final class FabricDatabase implements ModuleControl,
         }
         throw StandardException.newException(SQLState.BOOT_DATABASE_FAILED, ex,
           Attribute.GFXD_DBNAME);
-        //continue;
       }
     }
+
   }
 
   private Region createSnappySpecificGlobalCmdRegion(boolean isLead) throws IOException, ClassNotFoundException {
@@ -1478,8 +1478,6 @@ public final class FabricDatabase implements ModuleControl,
         }
       }
 
-
-
       if (!lastCurrentSchema.equals(currentSchema)) {
         // restore the default schema
         FabricDatabase.setupDefaultSchema(dd, lcc, tc, currentSchema, true);
@@ -1494,8 +1492,6 @@ public final class FabricDatabase implements ModuleControl,
       synchronized (sync) {
         this.memStore.setInitialDDLReplayInProgress(false);
         this.memStore.setInitialDDLReplayDone(true);
-
-
         // notify any waiters
         sync.notifyAll();
       }
@@ -1541,8 +1537,6 @@ public final class FabricDatabase implements ModuleControl,
 
     }
     return  postMessages;
-
-
   }
 
   private void checkRecoveredIndex(ArrayList<GemFireContainer> uninitializedContainers,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/DDLConflatable.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/DDLConflatable.java
@@ -278,7 +278,7 @@ public final class DDLConflatable extends GfxdDataSerializable implements
     || (this.isDropStatement && constantAction.isDropIfExists())
     || (this.fullTableName != null) : "Expected "
         + "a non-null schema/table name when conflation is requested";
-    assert !(preprocess() && postprocess());
+    // assert !(preprocess() && postprocess());
   }
   
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/DDLConflatable.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/DDLConflatable.java
@@ -60,7 +60,7 @@ import com.pivotal.gemfirexd.internal.shared.common.ResolverUtils;
  * @author swale
  */
 public final class DDLConflatable extends GfxdDataSerializable implements
-    ReplayableConflatable, GfxdDDLPreprocess {
+    ReplayableConflatable, GfxdDDLPreprocessOrPostProcess {
 
   private static final long serialVersionUID = -7222789225768258894L;
 
@@ -385,7 +385,7 @@ public final class DDLConflatable extends GfxdDataSerializable implements
   public boolean merge(Conflatable existing) {
     if (GemFireXDUtils.TraceConflation | DistributionManager.VERBOSE) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_CONFLATION, 
-          "DDLConflatable#merge called this=" + this + 
+          "DDLConflatable#merge called this=" + this +
           " existing conflatable=" + existing );
     }
     assert ((DDLConflatable) existing).isAlterTableDropFKConstraint();
@@ -538,6 +538,11 @@ public final class DDLConflatable extends GfxdDataSerializable implements
   public boolean preprocess() {
     // only "CREATE SCHEMA" is pre-processed
     return isCreateSchemaText();
+  }
+
+  public boolean postprocess() {
+    // only "CREATE SCHEMA" is pre-processed
+    return false;
   }
 
   @Override

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/DDLConflatable.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/DDLConflatable.java
@@ -278,7 +278,6 @@ public final class DDLConflatable extends GfxdDataSerializable implements
     || (this.isDropStatement && constantAction.isDropIfExists())
     || (this.fullTableName != null) : "Expected "
         + "a non-null schema/table name when conflation is requested";
-
     assert !(preprocess() && postprocess());
   }
   

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/DDLConflatable.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/DDLConflatable.java
@@ -278,6 +278,8 @@ public final class DDLConflatable extends GfxdDataSerializable implements
     || (this.isDropStatement && constantAction.isDropIfExists())
     || (this.fullTableName != null) : "Expected "
         + "a non-null schema/table name when conflation is requested";
+
+    assert !(preprocess() && postprocess());
   }
   
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLPreprocessOrPostProcess.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLPreprocessOrPostProcess.java
@@ -25,13 +25,15 @@ package com.pivotal.gemfirexd.internal.engine.ddl;
  * @author swale
  * @since 7.5
  */
-public interface GfxdDDLPreprocess {
+public interface GfxdDDLPreprocessOrPostProcess {
 
   /**
    * @return if this message/object should be pre-processed in the DDL queue
    *         before any other messages/objects
    */
   public boolean preprocess();
+
+  public boolean postprocess();
 
   /** Get a string representation of this message/object */
   public void appendFields(StringBuilder sb);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLRegionQueue.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/GfxdDDLRegionQueue.java
@@ -796,7 +796,7 @@ public final class GfxdDDLRegionQueue implements RegionQueue {
     final ArrayList<GfxdDDLQueueEntry> preprocessedQueue =
         new ArrayList<GfxdDDLQueueEntry>();
     ListIterator<GfxdDDLQueueEntry> iter = currentQueue.listIterator();
-    GfxdDDLPreprocess preprocessMsg;
+    GfxdDDLPreprocessOrPostProcess preprocessMsg;
     if (currentSchema == null) {
       currentSchema = SchemaDescriptor.STD_DEFAULT_SCHEMA_NAME;
     }
@@ -812,8 +812,8 @@ public final class GfxdDDLRegionQueue implements RegionQueue {
         }
       }
       // system/jar procedures should be executed at the start
-      if (qVal instanceof GfxdDDLPreprocess
-          && (preprocessMsg = (GfxdDDLPreprocess)qVal).preprocess()) {
+      if (qVal instanceof GfxdDDLPreprocessOrPostProcess
+          && (preprocessMsg = (GfxdDDLPreprocessOrPostProcess)qVal).preprocess()) {
         if (pre11TableSchemaVer != null
             && preprocessMsg instanceof GfxdSystemProcedureMessage) {
           GfxdSystemProcedureMessage m = (GfxdSystemProcedureMessage)qVal;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
@@ -2057,7 +2057,7 @@ public final class GfxdSystemProcedureMessage extends
     this.procMethod = null;
     this.params = null;
     this.sender = null;
-    assert !(preprocess() && postprocess());
+    //assert !(preprocess() && postprocess());
   }
 
   public GfxdSystemProcedureMessage(SysProcMethod procMethod, Object[] params,
@@ -2070,7 +2070,7 @@ public final class GfxdSystemProcedureMessage extends
     this.params = params;
     this.sender = sender;
     this.initialDDLReplayInProgress = Misc.initialDDLReplayInProgress();
-    assert !(preprocess() && postprocess());
+    assert !(procMethod.preprocess() && procMethod.postprocess());
   }
 
   @Override

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
@@ -107,6 +107,7 @@ public final class GfxdSystemProcedureMessage extends
   protected static final short INITIAL_DDL_REPLAY_IN_PROGRESS =
       (HAS_SERVER_GROUPS << 1);
 
+
   public enum SysProcMethod {
 
     setDatabaseProperty {
@@ -2056,6 +2057,7 @@ public final class GfxdSystemProcedureMessage extends
     this.procMethod = null;
     this.params = null;
     this.sender = null;
+    assert !(preprocess() && postprocess());
   }
 
   public GfxdSystemProcedureMessage(SysProcMethod procMethod, Object[] params,
@@ -2068,6 +2070,7 @@ public final class GfxdSystemProcedureMessage extends
     this.params = params;
     this.sender = sender;
     this.initialDDLReplayInProgress = Misc.initialDDLReplayInProgress();
+    assert !(preprocess() && postprocess());
   }
 
   @Override

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/messages/GfxdSystemProcedureMessage.java
@@ -52,7 +52,7 @@ import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
 import com.pivotal.gemfirexd.internal.engine.GfxdSerializable;
 import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.access.index.GfxdIndexManager;
-import com.pivotal.gemfirexd.internal.engine.ddl.GfxdDDLPreprocess;
+import com.pivotal.gemfirexd.internal.engine.ddl.GfxdDDLPreprocessOrPostProcess;
 import com.pivotal.gemfirexd.internal.engine.ddl.callbacks.CallbackProcedures;
 import com.pivotal.gemfirexd.internal.engine.ddl.catalog.GfxdSystemProcedures;
 import com.pivotal.gemfirexd.internal.engine.ddl.wan.messages.AbstractGfxdReplayableMessage;
@@ -99,7 +99,7 @@ import org.apache.log4j.LogManager;
  * 
  */
 public final class GfxdSystemProcedureMessage extends
-    AbstractGfxdReplayableMessage implements GfxdDDLPreprocess {
+    AbstractGfxdReplayableMessage implements GfxdDDLPreprocessOrPostProcess {
 
   private static final long serialVersionUID = 2039841562674551814L;
 
@@ -1506,7 +1506,7 @@ public final class GfxdSystemProcedureMessage extends
         Boolean useNativeTimer = (Boolean)params[0];
         String nativeTimerType = (String)params[1];
         SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_SYS_PROCEDURES,
-            "GfxdSystemProcedureMessage:SET_NANOTIMER_TYPE native timer: " + useNativeTimer + 
+            "GfxdSystemProcedureMessage:SET_NANOTIMER_TYPE native timer: " + useNativeTimer +
             " NativeTimerType: " + nativeTimerType );
         NanoTimer.setNativeTimer(useNativeTimer, nativeTimerType);
       }
@@ -1565,6 +1565,15 @@ public final class GfxdSystemProcedureMessage extends
         out.writeUTF((String)params[0]);
         out.writeUTF((String)params[1]);
         out.writeBoolean((Boolean)params[2]);
+      }
+
+      @Override
+      boolean preprocess() {
+        return false;
+      }
+
+      boolean postprocess() {
+        return true;
       }
 
       @Override
@@ -2008,6 +2017,10 @@ public final class GfxdSystemProcedureMessage extends
       return true;
     }
 
+    boolean postprocess() {
+      return false;
+    }
+
     abstract String getSQLStatement(Object[] params) throws StandardException;
 
     void appendParams(Object[] params, StringBuilder sb) {
@@ -2286,6 +2299,10 @@ public final class GfxdSystemProcedureMessage extends
   @Override
   public boolean preprocess() {
     return this.procMethod.preprocess();
+  }
+
+  public boolean postprocess() {
+    return this.procMethod.postprocess();
   }
 
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/store/raw/data/GfxdJarMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/store/raw/data/GfxdJarMessage.java
@@ -94,6 +94,7 @@ public final class GfxdJarMessage extends AbstractGfxdReplayableMessage
     this.schemaName = ret[0];
     this.sqlName = ret[1];
     this.fullName = this.schemaName + '.' + this.sqlName;
+    assert !(preprocess() && postprocess());
   }
 
   public void setOldId(long oldId) {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/store/raw/data/GfxdJarMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/store/raw/data/GfxdJarMessage.java
@@ -37,7 +37,7 @@ import com.gemstone.gemfire.internal.shared.Version;
 import com.pivotal.gemfirexd.internal.catalog.SystemProcedures;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
 import com.pivotal.gemfirexd.internal.engine.GfxdSerializable;
-import com.pivotal.gemfirexd.internal.engine.ddl.GfxdDDLPreprocess;
+import com.pivotal.gemfirexd.internal.engine.ddl.GfxdDDLPreprocessOrPostProcess;
 import com.pivotal.gemfirexd.internal.engine.ddl.wan.messages.AbstractGfxdReplayableMessage;
 import com.pivotal.gemfirexd.internal.engine.distributed.FunctionExecutionException;
 import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
@@ -52,7 +52,7 @@ import com.pivotal.gemfirexd.internal.io.StorageRandomAccessFile;
 import com.pivotal.gemfirexd.internal.shared.common.reference.SQLState;
 
 public final class GfxdJarMessage extends AbstractGfxdReplayableMessage
-    implements StorageFile, GfxdDDLPreprocess {
+    implements StorageFile, GfxdDDLPreprocessOrPostProcess {
 
   private static final long serialVersionUID = 8648222850391801895L;
 
@@ -289,6 +289,10 @@ public final class GfxdJarMessage extends AbstractGfxdReplayableMessage
   @Override
   public boolean preprocess() {
     return true;
+  }
+
+  public boolean postprocess() {
+    return false;
   }
 
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/store/raw/data/GfxdJarResource.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/store/raw/data/GfxdJarResource.java
@@ -35,8 +35,6 @@ import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedM
 import com.gemstone.gemfire.internal.Assert;
 import com.gemstone.gemfire.internal.InternalDataSerializer;
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
-import com.gemstone.gemfire.internal.cache.NoDataStoreAvailableException;
-import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
 import com.pivotal.gemfirexd.internal.engine.ddl.GfxdDDLRegion.RegionValue;


### PR DESCRIPTION
Possible approach to fix AQP-295.
The changes still need to be cleaned but I will do it once the approach is vetted.
Following is the issue & the fix:
The issue is that the region corresponding to sample table's reservoir region is created as a part of system procedure ( that means no container etc). That system procedure message is added into DDL queue with the preprocess flag as true. That means it gets executed before any DDL statements are executed from the queue. Since this reservoir region is colocated withe sample table , the creation of reservoir region as part of preprocess fails, as no sample table has yet been created.

Even if we make preprocess flag as false, such that reervoir region creation statement gets executed as part of queue, the region creation still fails,as the colocated sample table has not yet been initialized & hence its entry in the meta region identity has not yet happened & the reservoir region creation code gets executed directly ( & not via container mechansim)

The way I have tried to fix it is by augmenting the marker interface GfxdDDLPreprocess to have another method boolean postprocess. 
If this returns true ( as in case of Reservoir region creation procedure), these messages are executed at the end of the boot process.
I am not sure if this is a clean solution, but this is one option which I have tried.



## Patch testing

(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
