### PR TITLE
Disable load-balance by default on servers

### DIFF
--- a/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientConnection.java
+++ b/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientConnection.java
@@ -110,6 +110,10 @@ public final class ClientConnection extends ReentrantLock implements Connection 
     return this.clientService;
   }
 
+  public final Map<String, String> getConnectionProperties() {
+    return this.clientService.connectionProps;
+  }
+
   final ClientPooledConnection getOwnerPooledConnection() {
     return this.clientServiceOwner;
   }

--- a/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientService.java
+++ b/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientService.java
@@ -75,6 +75,7 @@ public final class ClientService extends ReentrantLock implements LobService {
   private HostAddress currentHostAddress;
   private String currentDefaultSchema;
   final OpenConnectionArgs connArgs;
+  final Map<String, String> connectionProps;
   final List<HostAddress> connHosts;
   private final boolean explicitLoadBalance;
   private boolean loadBalance;
@@ -328,6 +329,8 @@ public final class ClientService extends ReentrantLock implements LobService {
     this.connArgs = connArgs;
 
     Map<String, String> props = connArgs.getProperties();
+    this.connectionProps = props != null ? new HashMap<>(props) : new HashMap<>();
+
     String propValue;
     boolean hasLoadBalance = props != null &&
         props.containsKey(ClientAttribute.LOAD_BALANCE);
@@ -472,6 +475,8 @@ public final class ClientService extends ReentrantLock implements LobService {
                 failedServers, this.serverGroups, false, failure);
           }
         }
+        this.connectionProps.put(ClientAttribute.LOAD_BALANCE,
+            Boolean.toString(this.loadBalance));
 
         final TTransport currentTransport;
         int readTimeout;

--- a/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
+++ b/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
@@ -16304,7 +16304,7 @@ dropSchemaStatement() throws StandardException :
 }
 {
 	// GemStone changes BEGIN
-	<SCHEMA>
+	( <SCHEMA> | <DATABASE> )
 	{
 		CompilerContext cc = getCompilerContext();
 		cc.markAsDDLForSnappyUse(true);

--- a/gemfirexd/tools/src/test/java/org/apache/derbyTesting/junit/TestConfiguration.java
+++ b/gemfirexd/tools/src/test/java/org/apache/derbyTesting/junit/TestConfiguration.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.Properties;
 
+import com.gemstone.gemfire.internal.shared.ClientSharedUtils;
 import com.pivotal.gemfirexd.TestUtil;
 import com.pivotal.gemfirexd.internal.drda.NetworkServerControl;
 import junit.extensions.TestSetup;
@@ -1174,6 +1175,7 @@ public class TestConfiguration {
         .getBoolean(USE_ODBC_BRIDGE_PROP);
 
     private static final String netProtocol = "jdbc:gemfirexd://";
+    private static final String thriftProtocol = "jdbc:snappydata://";
 
     // assumes ODBC datasource named gemfirexd
     private static final String odbcProtocol = "jdbc:odbc:gemfirexd";
@@ -1202,11 +1204,12 @@ public class TestConfiguration {
         return odbcProtocol;
       }
       else {
-        return netProtocol + hostName + '[' + port + "]/";
+        return (ClientSharedUtils.isThriftDefault()
+            ? thriftProtocol : netProtocol) + hostName + '[' + port + "]/";
       }
     }
 // GemStone changes END
-    
+
     /**
      * Initialize the connection factory.
      * Defaults to the DriverManager implementation


### PR DESCRIPTION
## Changes proposed in this pull request

- Check the ControlConnection and if it on a server then disable load-balance by default (and close
  the ControlConnection)
- route "DROP DATABASE" DDL

## Patch testing

precheckin -Pstore

## Is precheckin with -Pstore clean?

Yes

## ReleaseNotes changes

Document that load-balance is false by default when connecting to servers

## Other PRs 

NA