### PR TITLE
[SNAP-2985] Fixes for multiple inconsistency issue in snapshot

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -580,7 +580,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
    * Time interval after which oldentries cleaner thread run
    */
   public static long OLD_ENTRIES_CLEANER_TIME_INTERVAL = Long.getLong("gemfire" +
-      ".snapshot-oldentries-cleaner-time-interval", 200);
+      ".snapshot-oldentries-cleaner-time-interval", 2000);
 
   /**
    * Test only method

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -581,7 +581,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
    * Time interval after which oldentries cleaner thread run
    */
   public static long OLD_ENTRIES_CLEANER_TIME_INTERVAL = Long.getLong("gemfire" +
-      ".snapshot-oldentries-cleaner-time-interval", 200);
+      ".snapshot-oldentries-cleaner-time-interval", 2000);
 
   /**
    * Test only method
@@ -630,6 +630,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
     return OLD_ENTRIES_CLEANER_TIME_INTERVAL;
   }
   // For each entry this should be in sync
+
 
   public void addOldEntry(NonLocalRegionEntry oldRe, RegionEntry newEntry,
       LocalRegion region, EntryEventImpl event) {
@@ -942,8 +943,6 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
                 if (((BlockingQueue) entry.getValue()).isEmpty()) {
                   ((CustomEntryConcurrentHashMap)regionEntryMap).remove(entry.getKey(),
                       entry.getValue(), queueRemover , null, null);
-
-                  regionEntryMap.remove(entry.getKey());
                 }
                 if (getLoggerI18n().fineEnabled()) {
                   getLoggerI18n().fine(
@@ -1123,7 +1122,11 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
     public Object removeValue(Object key, Object value, Object existingValue,
         Object context, Object removeParams) {
       if (value != null
-          && (value == NO_OBJECT_TOKEN || ((BlockingQueue)existingValue).size() == 0)) {
+          && (value == NO_OBJECT_TOKEN || ((existingValue == value)
+          && ((BlockingQueue)existingValue).size() == 0))) {
+        if (getInstance().getLoggerI18n().fineEnabled()) {
+          getInstance().getLoggerI18n().info(LocalizedStrings.DEBUG, "Removing queue for key " + key);
+        }
         return null;
       }
       else {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
@@ -93,12 +93,16 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
           if (GemFireCacheImpl.hasNewOffHeap()) {
             ((SerializedDiskBuffer)v).retain();
           } else {
+            // Setting diskEntry to null as we don't do reference count for on-heap objects
+            // In ColumnFormatValue, if reference count is 0, we read from DiskEntry.
             ((SerializedDiskBuffer)v).setDiskEntry(null, br);
           }
         }
       } else {
         v = re.getValueInVMOrDiskWithoutFaultIn(br);
         if (v instanceof SerializedDiskBuffer && !GemFireCacheImpl.hasNewOffHeap()) {
+          // Setting diskEntry to null as we don't do reference count for on-heap objects
+          // In ColumnFormatValue, if reference count is 0, we read from DiskEntry.
           ((SerializedDiskBuffer)v).setDiskEntry(null, br);
         }
       }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
@@ -89,12 +89,17 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
         v = re.getValue(br);
         // do an additional retain to match the behaviour of
         // getValueInVMOrDiskWithoutFaultIn
-        if (GemFireCacheImpl.hasNewOffHeap() &&
-            (v instanceof SerializedDiskBuffer)) {
-          ((SerializedDiskBuffer)v).retain();
+        if (v instanceof SerializedDiskBuffer) {
+          ((SerializedDiskBuffer)v).setDiskEntry(null, br);
+          if (GemFireCacheImpl.hasNewOffHeap()) {
+            ((SerializedDiskBuffer)v).retain();
+          }
         }
       } else {
         v = re.getValueInVMOrDiskWithoutFaultIn(br);
+        if (v instanceof SerializedDiskBuffer ) {
+          ((SerializedDiskBuffer)v).setDiskEntry(null, br);
+        }
       }
       try {
         this.value = OffHeapHelper.getHeapForm(v);  // OFFHEAP: copy into heap cd
@@ -167,7 +172,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
 
   @Override
   public String toString() {
-    return "NonLocalRegionEntry("+this.key + "; value="  + this.value + "; version=" + this.versionTag;
+    return "NonLocalRegionEntry(Key="+this.key + "; value="  + this.value + "; version=" + this.versionTag;
   }
 
   public static NonLocalRegionEntry newEntry() {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
@@ -90,14 +90,15 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
         // do an additional retain to match the behaviour of
         // getValueInVMOrDiskWithoutFaultIn
         if (v instanceof SerializedDiskBuffer) {
-          ((SerializedDiskBuffer)v).setDiskEntry(null, br);
           if (GemFireCacheImpl.hasNewOffHeap()) {
             ((SerializedDiskBuffer)v).retain();
+          } else {
+            ((SerializedDiskBuffer)v).setDiskEntry(null, br);
           }
         }
       } else {
         v = re.getValueInVMOrDiskWithoutFaultIn(br);
-        if (v instanceof SerializedDiskBuffer ) {
+        if (v instanceof SerializedDiskBuffer && !GemFireCacheImpl.hasNewOffHeap()) {
           ((SerializedDiskBuffer)v).setDiskEntry(null, br);
         }
       }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
@@ -3923,9 +3923,11 @@ public final class TXState implements TXStateInterface {
     final boolean checkTX = getLockingPolicy().lockedForWrite(re, null, null);
     if (TXStateProxy.LOG_FINE) {
       final LogWriterI18n logger = region.getLogWriterI18n();
-      logger.info(LocalizedStrings.DEBUG, "getLocalEntry: for region "
-          + region.getFullPath() + " RegionEntry(" + re + ") checkTX="
-          + checkTX);
+      if (re.getVersionStamp() != null) {
+        logger.info(LocalizedStrings.DEBUG, "getLocalEntry: for region "
+            + region.getFullPath() + " RegionEntry(" + re + ") checkTX="
+            + checkTX + "version " + re.getVersionStamp().asVersionTag());
+      }
     }
     if (checkTX) {
       final Object key = re.getKey();
@@ -3978,6 +3980,16 @@ public final class TXState implements TXStateInterface {
           return getOldVersionedEntry(this, dataRegion, key, re);
         }
       }
+    }
+
+    if (shouldGetOldEntry(dataRegion)) {
+      synchronized (re) {
+        if (checkEntryInSnapshot(this, dataRegion, re)) {
+          NonLocalRegionEntry nl = NonLocalRegionEntry.newEntryWithoutFaultIn(re, dataRegion, true);
+          return nl;
+        }
+      }
+      return getOldVersionedEntry(this, dataRegion, re.getKey(), re);
     }
     return re;
   }
@@ -4045,18 +4057,20 @@ public final class TXState implements TXStateInterface {
    * It should also include any changes done by this tx.
    * @return true if this vector has seen the given version
    */
-  private boolean isVersionInSnapshot(Region region, VersionSource id, long version) {
+  private boolean isVersionInSnapshot(Region region, VersionSource id, long version, boolean includeOwnChange) {
     // For snapshot we don't  need to check from the current version
     final LogWriterI18n logger = ((LocalRegion)region).getLogWriterI18n();
 
-    for (VersionInformation obj : this.queue) {
-      if (id == obj.member && (version == obj.version) &&
-          region == obj.region)
+    if (includeOwnChange) {
+      for (VersionInformation obj : this.queue) {
+        if (id == obj.member && (version == obj.version) &&
+            region == obj.region)
 
-        if (TXStateProxy.LOG_FINE) {
-          logger.info(LocalizedStrings.DEBUG, " The version found in the current tx : " + this);
-        }
+          if (TXStateProxy.LOG_FINE) {
+            logger.info(LocalizedStrings.DEBUG, " The version found in the current tx : " + this);
+          }
         return true;
+      }
     }
 
     Map<VersionSource, RegionVersionHolder> regionSnapshot;
@@ -4096,7 +4110,47 @@ public final class TXState implements TXStateInterface {
       // if rvv is not present then
       TXState state = tx.getLocalTXState();
       if (state.getCurrentRvvSnapShot() != null) {
-        if (state.isVersionInSnapshot(region, id, stamp.getRegionVersion())) {
+        if (state.isVersionInSnapshot(region, id, stamp.getRegionVersion(), true)) {
+          if (TXStateProxy.LOG_FINEST) {
+            logger.info(LocalizedStrings.DEBUG, "getLocalEntry: for region "
+                + region.getFullPath() + " RegionEntry(" + entry + ") with version " + stamp
+                .getRegionVersion() + " id: " + id + " , returning true.");
+          }
+          return true;
+        }
+      }
+      if (TXStateProxy.LOG_FINE) {
+        logger.info(LocalizedStrings.DEBUG, "getLocalEntry: for region "
+            + region.getFullPath() + " RegionEntry(" + entry + ") with version " + stamp
+            .getRegionVersion() + " id: " + id + " , returning false.");
+      }
+      return false;
+    }
+    return true;
+  }
+
+  public static boolean checkEntryInSnapshotWithoutMyChange(TXStateInterface tx, Region region, RegionEntry entry) {
+    if (tx.isSnapshot() && ((LocalRegion)region).concurrencyChecksEnabled) {
+      VersionStamp stamp = entry.getVersionStamp();
+      VersionSource id = stamp.getMemberID();
+      final LogWriterI18n logger = ((LocalRegion)region).getLogWriterI18n();
+
+      if (id == null) {
+        if (((LocalRegion)region).getVersionVector().isDiskVersionVector()) {
+          id = ((LocalRegion)region).getDiskStore().getDiskStoreID();
+        } else {
+          id = InternalDistributedSystem.getAnyInstance().getDistributedMember();
+        }
+        if (TXStateProxy.LOG_FINEST) {
+          logger.info(LocalizedStrings.DEBUG, "checkEntryInSnapshot: for region "
+              + region.getFullPath() + " RegionEntry(" + entry + ")" + " id not set in Entry, setting id to: " +
+              id);
+        }
+      }
+      // if rvv is not present then
+      TXState state = tx.getLocalTXState();
+      if (state.getCurrentRvvSnapShot() != null) {
+        if (state.isVersionInSnapshot(region, id, stamp.getRegionVersion(), false)) {
           if (TXStateProxy.LOG_FINEST) {
             logger.info(LocalizedStrings.DEBUG, "getLocalEntry: for region "
                 + region.getFullPath() + " RegionEntry(" + entry + ") with version " + stamp

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
@@ -4129,7 +4129,7 @@ public final class TXState implements TXStateInterface {
     return true;
   }
 
-  public static boolean checkEntryInSnapshotWithoutMyChange(TXStateInterface tx, Region region, RegionEntry entry) {
+  public static boolean checkEntryInSnapshotWithoutOwnChange(TXStateInterface tx, Region region, RegionEntry entry) {
     if (tx.isSnapshot() && ((LocalRegion)region).concurrencyChecksEnabled) {
       VersionStamp stamp = entry.getVersionStamp();
       VersionSource id = stamp.getMemberID();

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/locks/LockingPolicy.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/locks/LockingPolicy.java
@@ -501,7 +501,7 @@ public enum LockingPolicy {
         LockTimeoutException {
       // TODO: Suranjan Ideally no request should come in this mode.
       // put an assert here!
-      acquireLockFailFast(lockObj, mode, flags, lockOwner, context, msg);
+      // acquireLockFailFast(lockObj, mode, flags, lockOwner, context, msg);
     }
 
     @Override
@@ -527,6 +527,12 @@ public enum LockingPolicy {
         boolean allowTombstones, ReadEntryUnderLock reader) {
       // TODO: Suranjan try to see if we can add versioning information here and read
       return reader.readEntry(lockObj, context, iContext, allowTombstones);
+    }
+
+    @Override
+    public void releaseLock(ExclusiveSharedLockObject lockObj,
+        LockMode mode, Object lockOwner, boolean releaseAll, Object context) {
+      // no-op
     }
   },
   ;
@@ -665,7 +671,7 @@ public enum LockingPolicy {
    *          {@link ExclusiveSharedLockObject#releaseLock} method that can be
    *          used by the particular locking implementation
    */
-  public final void releaseLock(ExclusiveSharedLockObject lockObj,
+  public void releaseLock(ExclusiveSharedLockObject lockObj,
       LockMode mode, Object lockOwner, boolean releaseAll, Object context)
       throws IllegalMonitorStateException {
     if (mode != null) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/CustomEntryConcurrentHashMap.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/concurrent/CustomEntryConcurrentHashMap.java
@@ -1838,6 +1838,17 @@ RETRYLOOP:
         condition, context, removeParams, this.longSize);
   }
 
+
+  public final <C, P> V remove(final Object key, final Object value,
+      final MapCallback<K, V, C, P> condition, final C context,
+      final P removeParams) {
+    // throws NullPointerException if key null
+    final int hash = this.entryCreator.keyHashCode(key, this.compareValues);
+    return segmentFor(hash).remove(key, hash, value,
+        condition, context, removeParams, this.longSize);
+  }
+
+
 // End GemStone addition
 
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -2521,7 +2521,7 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
       try {
         final RowLocation rl = (RowLocation)itr.next();
         Assert.assertTrue(rl != null, "unexpected null encountered");
-        if (rl.isUpdateInProgress()) {
+        if (rl.isUpdateInProgress() || (rl.getValueWithoutFaultIn(this) instanceof Token)) {
           continue;
         }
         // #43228

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -2521,7 +2521,7 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
       try {
         final RowLocation rl = (RowLocation)itr.next();
         Assert.assertTrue(rl != null, "unexpected null encountered");
-        if (rl.isUpdateInProgress() || (rl.getValueWithoutFaultIn(this) instanceof Token)) {
+        if (rl.isUpdateInProgress() || rl.isDestroyedOrRemoved()) {
           continue;
         }
         // #43228

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/NonLocalRowLocationRegionEntry.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/NonLocalRowLocationRegionEntry.java
@@ -120,7 +120,7 @@ public final class NonLocalRowLocationRegionEntry extends NonLocalRegionEntry
   @Override
   public ExecRow getRow(GemFireContainer baseContainer)
       throws StandardException {
-    return baseContainer.newExecRow(this.value);
+    return baseContainer.newExecRow(this.key, this.value);
   }
 
   /**
@@ -129,7 +129,7 @@ public final class NonLocalRowLocationRegionEntry extends NonLocalRegionEntry
   @Override
   public ExecRow getRowWithoutFaultIn(GemFireContainer baseContainer)
       throws StandardException {
-    return baseContainer.newExecRow(this.value);
+    return baseContainer.newExecRow(this.key, this.value);
   }
 
   /**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/NonLocalRowLocationRegionEntryWithStats.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/NonLocalRowLocationRegionEntryWithStats.java
@@ -116,7 +116,7 @@ public final class NonLocalRowLocationRegionEntryWithStats extends
   @Override
   public ExecRow getRow(GemFireContainer baseContainer)
       throws StandardException {
-    return baseContainer.newExecRow(this.value);
+    return baseContainer.newExecRow(this.key, this.value);
   }
 
   /**
@@ -125,7 +125,7 @@ public final class NonLocalRowLocationRegionEntryWithStats extends
   @Override
   public ExecRow getRowWithoutFaultIn(GemFireContainer baseContainer)
       throws StandardException {
-    return baseContainer.newExecRow(this.value);
+    return baseContainer.newExecRow(this.key, this.value);
   }
 
   /**

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
@@ -313,6 +313,7 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
     attr.setPartitionAttributes(prAttr);
     final Region r = GemFireCacheImpl.getInstance().createRegion("t1", attr.create());
 
+    final int NUMITR = 100;
 
     Map map = new HashMap();
     for (int i = 0; i < 500; i++) {
@@ -324,12 +325,12 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
 
 
     Object lock = new Object();
-    boolean[] signal = {true};
+    boolean[] signal = { true };
 
     Runnable run = new Runnable() {
       @Override
       public void run() {
-        for (int k = 0; k < 100; k++) {
+        for (int k = 0; k < NUMITR; k++) {
           Map map = new HashMap();
           for (int i = 0; i < 500; i++) {
             map.put(i, k);
@@ -367,7 +368,7 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
               Misc.getGemFireCache().getLoggerI18n().info(LocalizedStrings.DEBUG, "the tombstone is " + re);
             }
           }
-          //System.out.println("The num is " + num + " and s is " + s);
+          // System.out.println("The num is " + num + " and s is " + s);
           assert (num == 500);
           if (s.size() > 1) {
             fail("FAIL The s is " + s);

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
@@ -5,8 +5,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 
 import com.gemstone.gemfire.cache.*;
@@ -15,6 +17,7 @@ import com.gemstone.gemfire.internal.cache.persistence.DiskStoreID;
 import com.gemstone.gemfire.internal.cache.versions.DiskRegionVersionVector;
 import com.gemstone.gemfire.internal.cache.versions.RegionVersionHolder;
 import com.gemstone.gemfire.internal.cache.versions.VersionSource;
+import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import com.pivotal.gemfirexd.TestUtil;
 import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.iapi.types.SQLInteger;
@@ -297,6 +300,73 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
     rs.close();
     st.close();
     conn.close();
+  }
+
+  public void testSnapshotBulkInsertTableAtomicity() throws Exception {
+
+    Connection conn = getConnection();
+
+    PartitionAttributesFactory paf = new PartitionAttributesFactory();
+    PartitionAttributes prAttr = paf.setTotalNumBuckets(1).create();
+    AttributesFactory attr = new AttributesFactory();
+    attr.setConcurrencyChecksEnabled(true);
+    attr.setPartitionAttributes(prAttr);
+    final Region r = GemFireCacheImpl.getInstance().createRegion("t1", attr.create());
+
+
+    Map map = new HashMap();
+    for (int i = 0; i < 500; i++) {
+      map.put(i, 0);
+    }
+    r.getCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+    r.putAll(map);
+    r.getCache().getCacheTransactionManager().commit();
+
+
+    Runnable run = new Runnable() {
+      @Override
+      public void run() {
+        for (int k = 0; k < 100; k++) {
+          Map map = new HashMap();
+          for (int i = 0; i < 500; i++) {
+            map.put(i, k);
+          }
+          r.getCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+          r.putAll(map);
+          r.getCache().getCacheTransactionManager().commit();
+        }
+      }
+    };
+    Thread t = new Thread(run);
+    t.start();
+
+    for(int i=0; i< 250; i++) {
+      r.getCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
+      TXStateInterface txstate = TXManagerImpl.getCurrentTXState();
+      Iterator txitr = txstate.getLocalEntriesIterator(null,
+          false, false, true, (LocalRegion)r);
+
+      int num = 0;
+      Set s = new HashSet();
+      while (txitr.hasNext()) {
+        RegionEntry re = (RegionEntry)txitr.next();
+        if (!re.isTombstone()) {
+          //Thread.sleep(10);
+          s.add(re.getValueInVM(null));
+          num++;
+        } else{
+          Misc.getGemFireCache().getLoggerI18n().info(LocalizedStrings.DEBUG, "the tombstone is " + re);
+        }
+      }
+      System.out.println("The num is " + num + " and s is " + s);
+      assert(num == 500);
+      if (s.size() > 1) {
+        fail("FAIL The s is " + s);
+      }
+      r.getCache().getCacheTransactionManager().commit();
+    }
+
+    t.join();
   }
 
   public void testSnapshotInsertTableAPI() throws Exception {

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/jdbc/transactions/snapshot/SnapshotTransactionTest.java
@@ -324,7 +324,7 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
 
 
     Object lock = new Object();
-    boolean[] signal = {false};
+    boolean[] signal = {true};
 
     Runnable run = new Runnable() {
       @Override
@@ -339,7 +339,7 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
           r.getCache().getCacheTransactionManager().commit();
         }
         synchronized (lock) {
-          signal[0] = true;
+          signal[0] = false;
         }
       }
     };
@@ -347,9 +347,9 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
     t.start();
 
 
-    while (true) {
+    while (signal[0]) {
       synchronized (lock) {
-        if (!signal[0]) {
+        if (signal[0]) {
           r.getCache().getCacheTransactionManager().begin(IsolationLevel.SNAPSHOT, null);
           TXStateInterface txstate = TXManagerImpl.getCurrentTXState();
           Iterator txitr = txstate.getLocalEntriesIterator(null,
@@ -367,14 +367,12 @@ public class SnapshotTransactionTest  extends JdbcTestBase {
               Misc.getGemFireCache().getLoggerI18n().info(LocalizedStrings.DEBUG, "the tombstone is " + re);
             }
           }
-          System.out.println("The num is " + num + " and s is " + s);
+          //System.out.println("The num is " + num + " and s is " + s);
           assert (num == 500);
           if (s.size() > 1) {
             fail("FAIL The s is " + s);
           }
           r.getCache().getCacheTransactionManager().commit();
-        } else {
-          break;
         }
       }
       Thread.sleep(5);


### PR DESCRIPTION
  1. Were returning RegionEntry to iterator, which could have its value changed
  by different writer before iterator could consume it. Now returning a NonLocalRegionEntry if entry from region has to be returned.
  2. The NonLocalRegionEntry had oldDiskId and ColumFormatValue used to read from DiskEntry
  instead of the value in memory. Setting that to null now, which means the value in memory will
  be read for NonLocalRegionEntry
  3. Used CustomEntryConcurrentHashMap to make sure we remove entry only if the same entry is present in map
  4. Similarly, made sure that before a queue is removed, its size is 0 and anytime an entry is added to queue it is put again in map for atomicity
  5. While checking whehter an entry in region exists in the snapshot of a tx, avoided the entry that was being changed so that due to uncommitted entry a valid entry doesn't get removed from the oldEntryMap
  6. Added tests where bulk puts and bulk reads are checked for atomicity

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
