### PR TITLE
Fixing reference count when creating NonLocalRegionEntry

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/NonLocalRegionEntry.java
@@ -386,7 +386,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
   }
 
   @Override
-  public Object _getValue() {
+  public final Object _getValue() {
     return value;
     //throw new UnsupportedOperationException(LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY.toLocalizedString());
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXState.java
@@ -3985,8 +3985,12 @@ public final class TXState implements TXStateInterface {
     if (shouldGetOldEntry(dataRegion)) {
       synchronized (re) {
         if (checkEntryInSnapshot(this, dataRegion, re)) {
-          NonLocalRegionEntry nl = NonLocalRegionEntry.newEntryWithoutFaultIn(re, dataRegion, true);
-          return nl;
+          // TODO: SW: this is a major performance problem because it will always read value
+          // from disk in essentially random order and then do a faultin; higher level
+          // DiskBlockSorter etc will be completely ineffective
+          // Proper solution is to create a snapshot of the original RegionEntry with diskId
+          // if value has been evicted, and create NLRE only for in-memory entries.
+          return NonLocalRegionEntry.newEntry(re, dataRegion, true);
         }
       }
       return getOldVersionedEntry(this, dataRegion, re.getKey(), re);


### PR DESCRIPTION
Problem with using newEntryWithoutFaultin when creating NonLocalRegionEntry is that it leads to an extra reference count. But higher layer cannot do extra release in all cases because when entry is read from oldEntriesMap then the extra release will be incorrect. Also the extra reference count cannot be released immediately after this call because if the value has been read from disk without fault-in then it will have only one refCount so will get released immediately before even being read by iterator.

The change to create NLRE in all cases leads to a performance problem when data is partially on disk since it will be read in essentially random order. This will be fixed in a subsequent PR.

## Changes proposed in this pull request

Use NLRE.newEntry instead of newEntryWithoutFaultin to create a snapshot of entry

## Patch testing

precheckin -Pstore

## Is precheckin with -Pstore clean?

Yes

## ReleaseNotes changes

NA

## Other PRs 

NA