### PR TITLE
Fix tests for having upper case column names for columns in select query.

### DIFF
--- a/tests/sql/src/main/java/sql/ddlStatements/IndexDDLStmt.java
+++ b/tests/sql/src/main/java/sql/ddlStatements/IndexDDLStmt.java
@@ -342,7 +342,8 @@ public class IndexDDLStmt implements DDLStmtIF {
     
     String type = " ";
     long count = SQLBB.getBB().getSharedCounters().incrementAndRead(SQLBB.indexCount);
-    String indexName = "trade.index" /*+ RemoteTestModule.getCurrentThread().getThreadId() */ + "_" + count;
+    String indexName = "index" /*+ RemoteTestModule.getCurrentThread().getThreadId() */ + "_" + count;
+    if(SQLPrms.isSnappyMode()) indexName = "trade."  + indexName;
     int createTypeIndex = 10; //1 in 10 chances
     if (rand.nextInt(createTypeIndex) == 0) {
       type = types[rand.nextInt(types.length)];
@@ -414,7 +415,9 @@ public class IndexDDLStmt implements DDLStmtIF {
     String indexName;
     synchronized (indexList) {
       if (indexList.size() == 0) return; //no indexes available to drop
-      indexName = "trade." + (String) indexList.remove(rand.nextInt(indexList.size())); //remove on of index name of the list
+      indexName = (String) indexList.remove(rand.nextInt(indexList.size()));
+      if (!indexName.startsWith("trade."))
+        indexName = "trade." + indexName; //remove on of index name of the list
     }
     String dropIndexStmt = "drop index " + indexName;
     try {

--- a/tests/sql/src/main/java/sql/ddlStatements/IndexDDLStmt.java
+++ b/tests/sql/src/main/java/sql/ddlStatements/IndexDDLStmt.java
@@ -342,7 +342,7 @@ public class IndexDDLStmt implements DDLStmtIF {
     
     String type = " ";
     long count = SQLBB.getBB().getSharedCounters().incrementAndRead(SQLBB.indexCount);
-    String indexName = "index" /*+ RemoteTestModule.getCurrentThread().getThreadId()*/ + "_" + count;
+    String indexName = "trade.index" /*+ RemoteTestModule.getCurrentThread().getThreadId() */ + "_" + count;
     int createTypeIndex = 10; //1 in 10 chances
     if (rand.nextInt(createTypeIndex) == 0) {
       type = types[rand.nextInt(types.length)];
@@ -359,7 +359,6 @@ public class IndexDDLStmt implements DDLStmtIF {
     
     try {
       Statement stmt = conn.createStatement();
-      stmt.execute("set schema trade");
       Log.getLogWriter().info("creating index statement is " + createIndexStmt);
       stmt.executeUpdate(createIndexStmt);
       SQLWarning warning = stmt.getWarnings(); //test to see there is a warning

--- a/tests/sql/src/main/java/sql/ddlStatements/IndexDDLStmt.java
+++ b/tests/sql/src/main/java/sql/ddlStatements/IndexDDLStmt.java
@@ -359,6 +359,7 @@ public class IndexDDLStmt implements DDLStmtIF {
     
     try {
       Statement stmt = conn.createStatement();
+      stmt.execute("set schema trade");
       Log.getLogWriter().info("creating index statement is " + createIndexStmt);
       stmt.executeUpdate(createIndexStmt);
       SQLWarning warning = stmt.getWarnings(); //test to see there is a warning

--- a/tests/sql/src/main/java/sql/dmlStatements/AbstractDMLStmt.java
+++ b/tests/sql/src/main/java/sql/dmlStatements/AbstractDMLStmt.java
@@ -153,6 +153,7 @@ public abstract class AbstractDMLStmt implements DMLStmtIF {
   public static ThreadLocal<Calendar> myCal; 
   public static boolean testworkaroundFor51519 = TestConfig.tab().booleanAt(sql.SQLPrms.testworkaroundFor51519,
       true) && !SQLTest.hasDerbyServer;
+  public static String str_sec_id = SQLPrms.isSnappyMode()?"SEC_ID".toLowerCase():"SEC_ID";
 
   static {
     if (SQLTest.isSnappyTest || SQLPrms.isSnappyMode()) {
@@ -790,14 +791,11 @@ public abstract class AbstractDMLStmt implements DMLStmtIF {
         rs = conn.createStatement().executeQuery(s);
         Log.getLogWriter().info("executed " + s + " from " + database);
         int temp=0;
-        String str_sec_id = "SEC_ID";
-        if(SQLPrms.isSnappyMode())
-          str_sec_id = str_sec_id.toLowerCase();
+
         while (rs.next()) {
           if (temp == 0 && rand.nextInt(1000) != 1) sid = rs.getInt(str_sec_id);
-          
           if (n==temp) {
-            sid = rs.getInt("SEC_ID");
+            sid = rs.getInt(str_sec_id);
             Log.getLogWriter().info("sec_id to be returned is " + sid);
             break;
           }

--- a/tests/sql/src/main/java/sql/dmlStatements/AbstractDMLStmt.java
+++ b/tests/sql/src/main/java/sql/dmlStatements/AbstractDMLStmt.java
@@ -790,8 +790,11 @@ public abstract class AbstractDMLStmt implements DMLStmtIF {
         rs = conn.createStatement().executeQuery(s);
         Log.getLogWriter().info("executed " + s + " from " + database);
         int temp=0;
+        String str_sec_id = "SEC_ID";
+        if(SQLPrms.isSnappyMode())
+          str_sec_id = str_sec_id.toLowerCase();
         while (rs.next()) {
-          if (temp == 0 && rand.nextInt(1000) != 1) sid = rs.getInt("SEC_ID"); 
+          if (temp == 0 && rand.nextInt(1000) != 1) sid = rs.getInt(str_sec_id);
           
           if (n==temp) {
             sid = rs.getInt("SEC_ID");

--- a/tests/sql/src/main/java/sql/dmlStatements/TradeBuyOrdersDMLStmt.java
+++ b/tests/sql/src/main/java/sql/dmlStatements/TradeBuyOrdersDMLStmt.java
@@ -94,7 +94,7 @@ public class TradeBuyOrdersDMLStmt extends AbstractDMLStmt {
     //no uniqkey queries
     "select * from trade.buyorders",
     "select cid, bid, cid, sid from trade.buyorders where cid >?  and sid <? and qty >? and orderTime<?  ",
-    "select sid, count(*) as COUNT from trade.buyorders  where status =? GROUP BY sid HAVING count(*) >=1",
+    "select sid, CAST(count(*) as integer) as COUNT from trade.buyorders  where status =? GROUP BY sid HAVING count(*) >=1",
     "select cid, CAST(count(distinct sid) as integer) as DIST_SID from trade.buyorders  where status =? GROUP BY cid",
     "select cid, cast (avg(qty*bid) as decimal (30, 20)) as amount from trade.buyorders  where status =? GROUP BY cid ORDER BY amount",
     "select cid, max(qty*bid) as largest_order from trade.buyorders  where status =? GROUP BY cid HAVING max(qty*bid) > 20000 ORDER BY largest_order, cid DESC ",

--- a/tests/sql/src/main/java/sql/dmlStatements/TradeBuyOrdersDMLStmt.java
+++ b/tests/sql/src/main/java/sql/dmlStatements/TradeBuyOrdersDMLStmt.java
@@ -1183,13 +1183,19 @@ public class TradeBuyOrdersDMLStmt extends AbstractDMLStmt {
       
       int i=0;
       int temp = 0;
+      String str_sid = "SID";
+      String str_cid = "CID";
+      if(SQLPrms.isSnappyMode()) {
+        str_cid = str_cid.toLowerCase();
+        str_sid = str_sid.toLowerCase();
+      }
       while (rs.next() && i<size) {
         if (temp ==0 ) {
-          cid[i] = rs.getInt("CID");
-          sid[i] = rs.getInt("SID");
+          cid[i] = rs.getInt(str_cid);
+          sid[i] = rs.getInt(str_sid);
         } else if (n>=temp) {
-          cid[i] = rs.getInt("CID");
-          sid[i] = rs.getInt("SID");
+          cid[i] = rs.getInt(str_cid);
+          sid[i] = rs.getInt(str_sid);
           i++;
         }
         temp++;                         

--- a/tests/sql/src/main/java/sql/dmlStatements/TradeBuyOrdersDMLStmt.java
+++ b/tests/sql/src/main/java/sql/dmlStatements/TradeBuyOrdersDMLStmt.java
@@ -62,6 +62,9 @@ public class TradeBuyOrdersDMLStmt extends AbstractDMLStmt {
    *   int tid; //for update or delete unique records to the thread
    */
 
+  public static String str_sid = SQLPrms.isSnappyMode()?"SID".toLowerCase():"SID";
+  public static String str_cid = SQLPrms.isSnappyMode()?"CID".toLowerCase():"CID";
+
   protected static String insert = "insert into trade.buyorders values (?,?,?,?,?,?,?,?)";
   protected static String put = "put into trade.buyorders values (?,?,?,?,?,?,?,?)";
   protected static String[] update = { 
@@ -1183,12 +1186,7 @@ public class TradeBuyOrdersDMLStmt extends AbstractDMLStmt {
       
       int i=0;
       int temp = 0;
-      String str_sid = "SID";
-      String str_cid = "CID";
-      if(SQLPrms.isSnappyMode()) {
-        str_cid = str_cid.toLowerCase();
-        str_sid = str_sid.toLowerCase();
-      }
+
       while (rs.next() && i<size) {
         if (temp ==0 ) {
           cid[i] = rs.getInt(str_cid);

--- a/tests/sql/src/main/java/sql/dmlStatements/TradeSellOrdersDMLStmt.java
+++ b/tests/sql/src/main/java/sql/dmlStatements/TradeSellOrdersDMLStmt.java
@@ -83,7 +83,9 @@ public class TradeSellOrdersDMLStmt extends AbstractDMLStmt {
   protected static String putWithGeneratedDefaultId = "put into trade.sellorders values (default,?,?,?,?,?,?,?)";
   protected static String putWithGeneratedDefaultIdAndDefaultValue = "put into trade.sellorders (default, cid, sid, qty, ask, order_time, tid)" +
   " values (?,?,?,?,?,?,?)";
-  
+  public static String str_sid = SQLPrms.isSnappyMode()?"SID".toLowerCase():"SID";
+  public static String str_cid = SQLPrms.isSnappyMode()?"CID".toLowerCase():"CID";
+
   protected static String[] update = { 
     //uniq
     "update trade.sellorders set status = 'filled'  where sid = ? and ask<? and status = 'open' and tid = ? ",  //for trigger test it could be a batch update
@@ -1061,12 +1063,7 @@ public class TradeSellOrdersDMLStmt extends AbstractDMLStmt {
       if (rs == null) {
           return false; //already did retry in getQuery
       }
-      String str_sid = "SID";
-      String str_cid = "CID";
-      if(SQLPrms.isSnappyMode()) {
-        str_cid = str_cid.toLowerCase();
-        str_sid = str_sid.toLowerCase();
-      }
+
       int i=0;
       int temp = 0;
       while (rs.next() && i<size) {

--- a/tests/sql/src/main/java/sql/dmlStatements/TradeSellOrdersDMLStmt.java
+++ b/tests/sql/src/main/java/sql/dmlStatements/TradeSellOrdersDMLStmt.java
@@ -1061,16 +1061,21 @@ public class TradeSellOrdersDMLStmt extends AbstractDMLStmt {
       if (rs == null) {
           return false; //already did retry in getQuery
       }
-      
+      String str_sid = "SID";
+      String str_cid = "CID";
+      if(SQLPrms.isSnappyMode()) {
+        str_cid = str_cid.toLowerCase();
+        str_sid = str_sid.toLowerCase();
+      }
       int i=0;
       int temp = 0;
       while (rs.next() && i<size) {
         if (temp ==0 ) {
-          cid[i] = rs.getInt("CID");
-          sid[i] = rs.getInt("SID");
+          cid[i] = rs.getInt(str_cid);
+          sid[i] = rs.getInt(str_sid);
         } else if (n<=temp) {
-          cid[i] = rs.getInt("CID");
-          sid[i] = rs.getInt("SID");
+          cid[i] = rs.getInt(str_cid);
+          sid[i] = rs.getInt(str_sid);
           i++;
         }
         temp++;             

--- a/tests/sql/src/main/java/sql/sqlutil/ResultSetHelper.java
+++ b/tests/sql/src/main/java/sql/sqlutil/ResultSetHelper.java
@@ -137,7 +137,7 @@ public class ResultSetHelper {
         }
         
         oTypes[i] = new ObjectTypeImpl(clazz); //resultSet column starts from 1
-        fieldNames[i] = rsmd.getColumnName(i+1); //resultSet column starts from 1
+        fieldNames[i] = rsmd.getColumnName(i+1).toUpperCase();//resultSet column starts from 1
       }
     } catch (SQLException se) {
       throw new TestException ("could not getStruct from resultSet\n" + TestHelper.getStackTrace(se));


### PR DESCRIPTION
## Changes proposed in this pull request
- Fix for column name mistmatch against derby by converting column names to upper case.
- A workaround in tests for SNAP-2885.

## Patch testing
Ran snappy-rowstore regression and few snappy bts that were affected. 

## Is precheckin with -Pstore clean?
N/A

## ReleaseNotes changes
N/A

## Other PRs 
N/A
