### PR TITLE
Fixed issue related to the ODBC Failover functionality

### DIFF
--- a/native/src/snappyclient/cpp/SQLState.cpp
+++ b/native/src/snappyclient/cpp/SQLState.cpp
@@ -131,6 +131,8 @@ const SQLState SQLState::DATA_CONTAINER_CLOSED("40XD0",
     ExceptionSeverity::TRANSACTION_SEVERITY);
 const SQLState SQLState::THRIFT_PROTOCOL_ERROR("58015",
     ExceptionSeverity::SESSION_SEVERITY);
+const SQLState SQLState::NODE_BUCKET_MOVED("X0Z18",
+    ExceptionSeverity::TRANSACTION_SEVERITY);
 
 void SQLState::staticInitialize() {
 }

--- a/native/src/snappyclient/cpp/impl/ClientService.cpp
+++ b/native/src/snappyclient/cpp/impl/ClientService.cpp
@@ -257,7 +257,6 @@ void ClientService::handleSnappyException(const char* op, bool tryFailover,
 
   if(createNewConnection){ //failover
     close();
-//    thrift::HostAddress hostAddr= m_connHosts.at(0);
     openConnection(m_currentHostAddr,failedServers,se);
   }
 }
@@ -1732,8 +1731,6 @@ void ClientService::close() {
 void ClientService::updateFailedServersForCurrent(
     std::set<thrift::HostAddress>& failedServers, bool checkAllFailed,
     const std::exception& failure) {
-
-  //TODO:: Need to discuss with sumedh about this method
   thrift::HostAddress host = this->m_currentHostAddr;
 
   auto ret = failedServers.insert(host);
@@ -1745,24 +1742,6 @@ void ClientService::updateFailedServersForCurrent(
   }
 }
 
-void ClientService::handleException(const std::exception& te,
-        std::set<thrift::HostAddress>& failedServers, bool tryFailover,
-        bool ignoreNodeFailure,bool createNewConnection,
-        const std::string& op){
-//  DEFAULT_OUTPUT_FN(std::string("ClientService received exception for").append(op)
-//      .append(". Failed Servers=").append(failedServers.))
-//  if( !m_isOpen && createNewConnection){
-//    newSnappyExceptionForConnectionClose(m_currentHostAddr, failedServers,
-//        createNewConnection, te);
-//  }
-//  if( ! m_loadBalance || m_isolationLevel != IsolationLevel::NONE){
-//    tryFailover = false;
-//  }
-//  if(dynamic_cast<thrift::SnappyException*>(te) != nullptr){
-//    auto snappyEx = dynamic_cast<thrift::SnappyException*>(te);
-//    handleSnappyException(op, tryFailover, &snappyEx,failedServers);
-//  }
-}
 void ClientService::newSnappyExceptionForConnectionClose(const thrift::HostAddress source,
         std::set<thrift::HostAddress>& failedServers, bool createNewConnection,
         const thrift::SnappyException& snappyEx){
@@ -1809,8 +1788,7 @@ void ClientService::tryCreateNewConnection(thrift::HostAddress source,
     if (this->m_loadBalance){
       std::set<thrift::HostAddress> failedServers;
       updateFailedServersForCurrent(failedServers,true,te);
-      thrift::HostAddress hostAddr= m_currentHostAddr;
-      openConnection(hostAddr,failedServers, te);
+      openConnection(m_currentHostAddr,failedServers, te);
     }
   }catch(...){
     throw te;
@@ -1829,7 +1807,6 @@ void ClientService::throwSnappyExceptionForNodeFailure(thrift::HostAddress sourc
   // create a new connection in any case for future operations
   if(createNewConnection && m_loadBalance){
     updateFailedServersForCurrent(failedServers,false,se);
-//    thrift::HostAddress hostAddr= m_connHosts.at(0);
     openConnection(source,failedServers,se);
   }
   throwSQLExceptionForNodeFailure(op,se);
@@ -1846,7 +1823,6 @@ void ClientService::throwSnappyExceptionForNodeFailure(thrift::HostAddress sourc
   // create a new connection in any case for future operations
   if(createNewConnection && m_loadBalance){
     updateFailedServersForCurrent(failedServers,false,se);
-//    thrift::HostAddress hostAddr= m_connHosts.at(0);
     openConnection(source,failedServers,se);
   }
   throwSQLExceptionForNodeFailure(op,se);

--- a/native/src/snappyclient/cpp/impl/ClientService.cpp
+++ b/native/src/snappyclient/cpp/impl/ClientService.cpp
@@ -373,7 +373,7 @@ void ClientService::setPendingTransactionAttrs(
 ClientService::ClientService(const std::string& host, const int port,
     thrift::OpenConnectionArgs& connArgs) :
             // default for load-balance is false
-          m_connArgs(initConnectionArgs(connArgs)), m_loadBalance(false),
+          m_connArgs(initConnectionArgs(connArgs)), m_loadBalance(true),
           m_reqdServerType(thrift::ServerType::THRIFT_SNAPPY_CP),
           m_useFramedTransport(false), m_serverGroups(),
           m_transport(), m_client(createDummyProtocol()),
@@ -391,7 +391,7 @@ ClientService::ClientService(const std::string& host, const int port,
   if (!props.empty()) {
     if ((propValue = props.find(ClientAttribute::LOAD_BALANCE))
         != props.end()) {
-      m_loadBalance = boost::iequals("true", propValue->second);
+      m_loadBalance = !(boost::iequals("false", propValue->second));
       props.erase(propValue);
     }
 

--- a/native/src/snappyclient/cpp/impl/ClientService.h
+++ b/native/src/snappyclient/cpp/impl/ClientService.h
@@ -63,7 +63,11 @@ namespace impl {
 
   class ClientTransport;
   class ControlConnection;
-
+  enum class FailoverStatus :unsigned char{
+                NONE,         /** no failover to be done */
+                NEW_SERVER,   /** failover to a new server */
+                RETRY         /** retry to the same server */
+              };
   class SnappyDataClient : public thrift::SnappyDataServiceClient {
   public:
     SnappyDataClient(protocol::TProtocol* prot) :
@@ -359,7 +363,14 @@ namespace impl {
         }
 
   };
+class NetConnection{
+private:
 
+  /** set of SQLState strings that denote failover should be done */
+    static std::set<std::string> failoverSQLStateSet;
+public:
+  static FailoverStatus getFailoverStatus(const std::string& sqlState,const int32_t& errorCode, const TException& snappyEx);
+  };
 } /* namespace impl */
 } /* namespace client */
 } /* namespace snappydata */

--- a/native/src/snappyclient/cpp/impl/ClientService.h
+++ b/native/src/snappyclient/cpp/impl/ClientService.h
@@ -46,345 +46,363 @@
 using namespace apache::thrift;
 
 namespace apache {
-namespace thrift {
-  namespace transport {
-    class TSocket;
+  namespace thrift {
+    namespace transport {
+      class TSocket;
+    }
+    namespace protocol {
+      class TProtocol;
+    }
   }
-  namespace protocol {
-    class TProtocol;
-  }
-}
 }
 
 namespace io {
-namespace snappydata {
-namespace client {
-namespace impl {
-
-  class ClientTransport;
-  class ControlConnection;
-
-  class SnappyDataClient : public thrift::SnappyDataServiceClient {
-  public:
-    SnappyDataClient(protocol::TProtocol* prot) :
-        thrift::SnappyDataServiceClient(
-            boost::shared_ptr < protocol::TProtocol > (prot)) {
-    }
-
-    inline protocol::TProtocol* getProtocol() const noexcept {
-      return iprot_;
-    }
-
-  private:
-    void resetProtocols(
-        const boost::shared_ptr<protocol::TProtocol>& iprot,
-        const boost::shared_ptr<protocol::TProtocol>& oprot) {
-      piprot_ = iprot;
-      poprot_ = oprot;
-      iprot_ = iprot.get();
-      oprot_ = oprot.get();
-    }
+  namespace snappydata {
+    namespace client {
+      namespace impl {
+
+        class ClientTransport;
+        class ControlConnection;
+
+        class SnappyDataClient : public thrift::SnappyDataServiceClient {
+        public:
+          SnappyDataClient(protocol::TProtocol* prot) :
+              thrift::SnappyDataServiceClient(
+                  boost::shared_ptr<protocol::TProtocol>(prot)) {
+          }
+
+          inline protocol::TProtocol* getProtocol() const noexcept {
+            return iprot_;
+          }
+
+        private:
+          void resetProtocols(
+              const boost::shared_ptr<protocol::TProtocol>& iprot,
+              const boost::shared_ptr<protocol::TProtocol>& oprot) {
+            piprot_ = iprot;
+            poprot_ = oprot;
+            iprot_ = iprot.get();
+            oprot_ = oprot.get();
+          }
+
+          friend class ClientService;
+        };
+
+        class ClientService {
+        private:
+          const thrift::OpenConnectionArgs m_connArgs;
+          bool m_loadBalance;
+          thrift::ServerType::type m_reqdServerType;
+          bool m_useFramedTransport;
+          std::set<std::string> m_serverGroups;
+
+          boost::shared_ptr<ClientTransport> m_transport;
+          SnappyDataClient m_client;
+
+          thrift::HostAddress m_currentHostAddr;
+          std::vector<thrift::HostAddress> m_connHosts;
+          int64_t m_connId;
+          std::string m_token;
+          bool m_isOpen;
+
+          std::map<thrift::TransactionAttribute::type, bool> m_pendingTXAttrs;
+          bool m_hasPendingTXAttrs;
+          IsolationLevel m_isolationLevel;
+          std::map<thrift::TransactionAttribute::type, bool> m_currentTXAttrs;
+
+          // using boost::mutex and not std::mutex due to superior implementation on
+          // Windows compared to that provided by VS (which always does kernel call)
+          boost::mutex m_lock;
+
+          // no copy constructor or assignment operator due to obvious issues
+          // with usage of same connection by multiple threads concurrently
+          ClientService(const ClientService&) = delete;
+          ClientService& operator=(const ClientService&) = delete;
+
+          void clearPendingTransactionAttrs();
+
+          static thrift::OpenConnectionArgs& initConnectionArgs(
+              thrift::OpenConnectionArgs& connArgs);
+
+          static protocol::TProtocol* createDummyProtocol();
+
+          static protocol::TProtocol* createProtocol(
+              thrift::HostAddress& hostAddr,
+              const thrift::ServerType::type serverType,
+              const bool useFramedTransport,
+              //const SSLSocketParameters& sslParams,
+              boost::shared_ptr<ClientTransport>& returnTransport);
+
+          void updateFailedServersForCurrent(
+              std::set<thrift::HostAddress>& failedServers,
+              bool checkAllFailed, const std::exception& failure);
+
+        protected:
+          virtual void checkConnection(const char* op);
+
+          virtual void handleSnappyException(const char* op, bool tryFailOver,
+              bool ignoreNodeFailure, bool createNewConnection,
+              std::set<thrift::HostAddress>& failedServers,
+              const thrift::SnappyException& se);
+
+          virtual void handleStdException(const char* op,
+              const std::exception& stde);
+
+          virtual void handleTTransportException(const char* op,
+              bool tryFailover, bool ignoreNodeFailure,
+              bool createNewConnection,
+              std::set<thrift::HostAddress>& failedServers,
+              const transport::TTransportException& tte);
+
+          virtual void handleTProtocolException(const char* op,
+              bool tryFailover, bool ignoreNodeFailure,
+              bool createNewConnection,
+              std::set<thrift::HostAddress>& failedServers,
+              const protocol::TProtocolException& tpe);
 
-    friend class ClientService;
-  };
-
-  class ClientService {
-  private:
-    const thrift::OpenConnectionArgs m_connArgs;
-    bool m_loadBalance;
-    thrift::ServerType::type m_reqdServerType;
-    bool m_useFramedTransport;
-    std::set<std::string> m_serverGroups;
-
-    boost::shared_ptr<ClientTransport> m_transport;
-    SnappyDataClient m_client;
-
-    thrift::HostAddress m_currentHostAddr;
-    std::vector<thrift::HostAddress> m_connHosts;
-    int64_t m_connId;
-    std::string m_token;
-    bool m_isOpen;
-
-    std::map<thrift::TransactionAttribute::type, bool> m_pendingTXAttrs;
-    bool m_hasPendingTXAttrs;
-    IsolationLevel m_isolationLevel;
-    std::map<thrift::TransactionAttribute::type, bool> m_currentTXAttrs;
-
-    // using boost::mutex and not std::mutex due to superior implementation on
-    // Windows compared to that provided by VS (which always does kernel call)
-    boost::mutex m_lock;
-
-    // no copy constructor or assignment operator due to obvious issues
-    // with usage of same connection by multiple threads concurrently
-    ClientService(const ClientService&) = delete;
-    ClientService& operator=(const ClientService&) = delete;
-
-    void clearPendingTransactionAttrs();
+          virtual void handleTException(const char* op, bool tryFailover,
+              bool ignoreNodeFailure, bool createNewConnection,
+              std::set<thrift::HostAddress>& failedServers,
+              const TException& te);
 
-    static thrift::OpenConnectionArgs& initConnectionArgs(
-        thrift::OpenConnectionArgs& connArgs);
+          virtual void handleUnknownException(const char* op);
 
-    static protocol::TProtocol* createDummyProtocol();
+          BOOST_NORETURN void throwSQLExceptionForNodeFailure(const char* op,
+              const std::exception& se);
 
-    static protocol::TProtocol* createProtocol(
-        thrift::HostAddress& hostAddr,
-        const thrift::ServerType::type serverType,
-        const bool useFramedTransport,
-        //const SSLSocketParameters& sslParams,
-        boost::shared_ptr<ClientTransport>& returnTransport);
+          void openConnection(thrift::HostAddress& hostAddr,
+              std::set<thrift::HostAddress>& failedServers,
+              const std::exception& te);
 
-    void updateFailedServersForCurrent(std::set<thrift::HostAddress>& failedServers,
-        bool checkAllFailed, const std::exception& failure);
-
-  protected:
-    virtual void checkConnection(const char* op);
-
-    virtual void handleSnappyException(const char* op,bool tryFailOver,
-        bool ignoreNodeFailure, bool createNewConnection,
-        std::set<thrift::HostAddress>& failedServers,
-        const thrift::SnappyException& se);
-
-    virtual void handleStdException(const char* op,
-        const std::exception& stde);
-
-    virtual void handleTTransportException(const char* op,bool tryFailover,
-        bool ignoreNodeFailure, bool createNewConnection,
-        std::set<thrift::HostAddress>& failedServers,
-        const transport::TTransportException& tte);
-
-    virtual void handleTProtocolException(const char* op,
-        const protocol::TProtocolException& tpe);
-
-    virtual void handleTException(const char* op, bool tryFailover,
-        bool ignoreNodeFailure, bool createNewConnection,
-        std::set<thrift::HostAddress>& failedServers,
-        const TException& te);
+          void flushPendingTransactionAttrs();
 
-    virtual void handleUnknownException(const char* op);
+          void setPendingTransactionAttrs(thrift::StatementAttrs& stmtAttrs);
 
-    BOOST_NORETURN void throwSQLExceptionForNodeFailure(const char* op,
-        const std::exception& se);
+          void getTransactionAttributesNoLock(
+              std::map<thrift::TransactionAttribute::type, bool>& result);
 
-    void openConnection(thrift::HostAddress& hostAddr,
-        std::set<thrift::HostAddress>& failedServers,
-        const std::exception& te);
+          void destroyTransport() noexcept;
 
-    void flushPendingTransactionAttrs();
+          void newSnappyExceptionForConnectionClose(
+              const thrift::HostAddress source,
+              std::set<thrift::HostAddress>& failedServers,
+              bool createNewConnection, const thrift::SnappyException& te);
 
-    void setPendingTransactionAttrs(thrift::StatementAttrs& stmtAttrs);
+          void newSnappyExceptionForConnectionClose(
+              const thrift::HostAddress& source);
 
-    void getTransactionAttributesNoLock(
-        std::map<thrift::TransactionAttribute::type, bool>& result);
+          void tryCreateNewConnection(thrift::HostAddress source,
+              std::set<thrift::HostAddress>& failedServers,
+              const thrift::SnappyException& te);
 
-    void destroyTransport() noexcept;
+          BOOST_NORETURN void throwSnappyExceptionForNodeFailure(
+              thrift::HostAddress source, const char* op,
+              std::set<thrift::HostAddress>& failedServers,
+              bool createNewConnection, const thrift::SnappyException& te);
 
-    void newSnappyExceptionForConnectionClose(const thrift::HostAddress source,
-        std::set<thrift::HostAddress>& failedServers, bool createNewConnection,
-        const thrift::SnappyException& te);
+          BOOST_NORETURN void throwSnappyExceptionForNodeFailure(
+              thrift::HostAddress source, const char* op,
+              std::set<thrift::HostAddress>& failedServers,
+              bool createNewConnection, const std::exception& se);
 
-    void newSnappyExceptionForConnectionClose(const thrift::HostAddress& source);
+          virtual bool handleException(const char* op, bool tryFailover,
+                        bool ignoreNodeFailure, bool createNewConnection,
+                        std::set<thrift::HostAddress>& failedServers,
+                        const TException& te);
 
-    void tryCreateNewConnection(thrift::HostAddress source,
-        std::set<thrift::HostAddress>& failedServers,
-        const thrift::SnappyException& te);
 
-    BOOST_NORETURN void throwSnappyExceptionForNodeFailure(thrift::HostAddress source,
-        const char* op, std::set<thrift::HostAddress>& failedServers,
-        bool createNewConnection, const thrift::SnappyException& te);
+        private:
+          // the static hostName and hostId used by all connections
+          static std::string s_hostName;
+          static std::string s_hostId;
+          static boost::mutex s_globalLock;
+          static bool s_initialized;
 
-    BOOST_NORETURN void throwSnappyExceptionForNodeFailure(thrift::HostAddress source,
-            const char* op, std::set<thrift::HostAddress>& failedServers,
-            bool createNewConnection, const std::exception& se);
+          /**
+           * Global initialization that is done only once.
+           * The s_globalLock must be held in the invocation.
+           */
+          static bool globalInitialize();
 
-  private:
-    // the static hostName and hostId used by all connections
-    static std::string s_hostName;
-    static std::string s_hostId;
-    static boost::mutex s_globalLock;
-    static bool s_initialized;
+        public:
+          ClientService(const std::string& host, const int port,
+              thrift::OpenConnectionArgs& arguments);
 
-    /**
-     * Global initialization that is done only once.
-     * The s_globalLock must be held in the invocation.
-     */
-    static bool globalInitialize();
+          virtual ~ClientService();
 
-  public:
-    ClientService(const std::string& host, const int port,
-        thrift::OpenConnectionArgs& arguments);
+          static void staticInitialize();
 
-    virtual ~ClientService();
+          static void staticInitialize(
+              std::map<std::string, std::string>& props);
 
-    static void staticInitialize();
+          static thrift::ServerType::type getServerType(bool isServer,
+              bool useBinaryProtocol, bool useSSL);
 
-    static void staticInitialize(
-        std::map<std::string, std::string>& props);
+          inline bool isOpen() const noexcept {
+            return m_isOpen;
+          }
 
-    static thrift::ServerType::type getServerType(bool isServer,
-        bool useBinaryProtocol, bool useSSL);
+          inline const boost::shared_ptr<ClientTransport>& getTransport() const
+              noexcept {
+            return m_transport;
+          }
 
-    inline bool isOpen() const noexcept {
-      return m_isOpen;
-    }
+          const char* getTokenStr() const noexcept {
+            return m_token.empty() ? NULL : m_token.c_str();
+          }
 
-    inline const boost::shared_ptr<ClientTransport>& getTransport()
-        const noexcept {
-      return m_transport;
-    }
+          const thrift::HostAddress& getCurrentHostAddress() const noexcept {
+            return m_currentHostAddr;
+          }
 
-    const char* getTokenStr() const noexcept {
-      return m_token.empty() ? NULL : m_token.c_str();
-    }
+          const thrift::OpenConnectionArgs& getConnectionArgs() const
+              noexcept {
+            return m_connArgs;
+          }
 
-    const thrift::HostAddress& getCurrentHostAddress() const noexcept {
-      return m_currentHostAddr;
-    }
+          IsolationLevel getCurrentIsolationLevel() const noexcept {
+            return m_isolationLevel;
+          }
 
-    const thrift::OpenConnectionArgs& getConnectionArgs() const noexcept {
-      return m_connArgs;
-    }
+          void execute(thrift::StatementResult& result,
+              const std::string& sql,
+              const std::map<int32_t, thrift::OutputParameter>& outputParams,
+              const thrift::StatementAttrs& attrs);
 
-    IsolationLevel getCurrentIsolationLevel() const noexcept {
-      return m_isolationLevel;
-    }
+          void executeUpdate(thrift::UpdateResult& result,
+              const std::vector<std::string>& sqls,
+              const thrift::StatementAttrs& attrs);
 
-    void execute(thrift::StatementResult& result,
-        const std::string& sql,
-        const std::map<int32_t, thrift::OutputParameter>& outputParams,
-        const thrift::StatementAttrs& attrs);
+          void executeQuery(thrift::RowSet& result, const std::string& sql,
+              const thrift::StatementAttrs& attrs);
 
-    void executeUpdate(thrift::UpdateResult& result,
-        const std::vector<std::string>& sqls,
-        const thrift::StatementAttrs& attrs);
+          void prepareStatement(thrift::PrepareResult& result,
+              const std::string& sql,
+              const std::map<int32_t, thrift::OutputParameter>& outputParams,
+              const thrift::StatementAttrs& attrs);
 
-    void executeQuery(thrift::RowSet& result, const std::string& sql,
-        const thrift::StatementAttrs& attrs);
+          void executePrepared(thrift::StatementResult& result,
+              thrift::PrepareResult& prepResult, const thrift::Row& params,
+              const std::map<int32_t, thrift::OutputParameter>& outputParams,
+              const thrift::StatementAttrs& attrs);
 
-    void prepareStatement(thrift::PrepareResult& result,
-        const std::string& sql,
-        const std::map<int32_t, thrift::OutputParameter>& outputParams,
-        const thrift::StatementAttrs& attrs);
+          void executePreparedUpdate(thrift::UpdateResult& result,
+              thrift::PrepareResult& prepResult, const thrift::Row& params,
+              const thrift::StatementAttrs& attrs);
 
-    void executePrepared(thrift::StatementResult& result,
-        thrift::PrepareResult& prepResult, const thrift::Row& params,
-        const std::map<int32_t, thrift::OutputParameter>& outputParams,
-        const thrift::StatementAttrs& attrs);
+          void executePreparedQuery(thrift::RowSet& result,
+              thrift::PrepareResult& prepResult, const thrift::Row& params,
+              const thrift::StatementAttrs& attrs);
 
-    void executePreparedUpdate(thrift::UpdateResult& result,
-        thrift::PrepareResult& prepResult, const thrift::Row& params,
-        const thrift::StatementAttrs& attrs);
+          void executePreparedBatch(thrift::UpdateResult& result,
+              thrift::PrepareResult& prepResult,
+              const std::vector<thrift::Row>& paramsBatch,
+              const thrift::StatementAttrs& attrs);
 
-    void executePreparedQuery(thrift::RowSet& result,
-        thrift::PrepareResult& prepResult, const thrift::Row& params,
-        const thrift::StatementAttrs& attrs);
+          void prepareAndExecute(thrift::StatementResult& result,
+              const std::string& sql,
+              const std::vector<thrift::Row>& paramsBatch,
+              const std::map<int32_t, thrift::OutputParameter>& outputParams,
+              const thrift::StatementAttrs& attrs);
 
-    void executePreparedBatch(thrift::UpdateResult& result,
-        thrift::PrepareResult& prepResult,
-        const std::vector<thrift::Row>& paramsBatch,
-        const thrift::StatementAttrs& attrs);
+          void getNextResultSet(thrift::RowSet& result,
+              const int64_t cursorId, const int8_t otherResultSetBehaviour);
 
-    void prepareAndExecute(thrift::StatementResult& result,
-        const std::string& sql,
-        const std::vector<thrift::Row>& paramsBatch,
-        const std::map<int32_t, thrift::OutputParameter>& outputParams,
-        const thrift::StatementAttrs& attrs);
+          void getBlobChunk(thrift::BlobChunk& result, const int32_t lobId,
+              const int64_t offset, const int32_t size,
+              const bool freeLobAtEnd);
 
-    void getNextResultSet(thrift::RowSet& result,
-        const int64_t cursorId, const int8_t otherResultSetBehaviour);
+          void getClobChunk(thrift::ClobChunk& result, const int32_t lobId,
+              const int64_t offset, const int32_t size,
+              const bool freeLobAtEnd);
 
-    void getBlobChunk(thrift::BlobChunk& result, const int32_t lobId,
-        const int64_t offset, const int32_t size,
-        const bool freeLobAtEnd);
+          int64_t sendBlobChunk(thrift::BlobChunk& chunk);
 
-    void getClobChunk(thrift::ClobChunk& result, const int32_t lobId,
-        const int64_t offset, const int32_t size,
-        const bool freeLobAtEnd);
+          int64_t sendClobChunk(thrift::ClobChunk& chunk);
 
-    int64_t sendBlobChunk(thrift::BlobChunk& chunk);
+          void freeLob(const int32_t lobId);
 
-    int64_t sendClobChunk(thrift::ClobChunk& chunk);
+          void scrollCursor(thrift::RowSet& result, const int64_t cursorId,
+              const int32_t offset, const bool offsetIsAbsolute,
+              const bool fetchReverse, const int32_t fetchSize);
 
-    void freeLob(const int32_t lobId);
+          void executeCursorUpdate(const int64_t cursorId,
+              const thrift::CursorUpdateOperation::type operation,
+              const thrift::Row& changedRow,
+              const std::vector<int32_t>& changedColumns,
+              const int32_t changedRowIndex);
 
-    void scrollCursor(thrift::RowSet& result, const int64_t cursorId,
-        const int32_t offset, const bool offsetIsAbsolute,
-        const bool fetchReverse, const int32_t fetchSize);
+          void executeBatchCursorUpdate(const int64_t cursorId,
+              const std::vector<thrift::CursorUpdateOperation::type>& operations,
+              const std::vector<thrift::Row>& changedRows,
+              const std::vector<std::vector<int32_t> >& changedColumnsList,
+              const std::vector<int32_t>& changedRowIndexes);
 
-    void executeCursorUpdate(const int64_t cursorId,
-        const thrift::CursorUpdateOperation::type operation,
-        const thrift::Row& changedRow,
-        const std::vector<int32_t>& changedColumns,
-        const int32_t changedRowIndex);
+          void beginTransaction(const IsolationLevel isolationLevel);
 
-    void executeBatchCursorUpdate(const int64_t cursorId,
-        const std::vector<thrift::CursorUpdateOperation::type>& operations,
-        const std::vector<thrift::Row>& changedRows,
-        const std::vector<std::vector<int32_t> >& changedColumnsList,
-        const std::vector<int32_t>& changedRowIndexes);
+          void setTransactionAttribute(const TransactionAttribute flag,
+              bool isTrue);
 
-    void beginTransaction(const IsolationLevel isolationLevel);
+          bool getTransactionAttribute(const TransactionAttribute flag);
 
-    void setTransactionAttribute(const TransactionAttribute flag, bool isTrue);
+          void getTransactionAttributes(
+              std::map<thrift::TransactionAttribute::type, bool>& result);
 
-    bool getTransactionAttribute(const TransactionAttribute flag);
+          void commitTransaction(const bool startNewTransaction);
 
-    void getTransactionAttributes(std::map<thrift::TransactionAttribute::type,
-        bool>& result);
+          void rollbackTransaction(const bool startNewTransaction);
 
-    void commitTransaction(const bool startNewTransaction);
+          void fetchActiveConnections(
+              std::vector<thrift::ConnectionProperties>& result);
 
-    void rollbackTransaction(const bool startNewTransaction);
+          void fetchActiveStatements(std::map<int64_t, std::string>& result);
 
-    void fetchActiveConnections(
-        std::vector<thrift::ConnectionProperties>& result);
+          void getServiceMetaData(thrift::ServiceMetaData& result);
 
-    void fetchActiveStatements(std::map<int64_t, std::string>& result);
+          void getSchemaMetaData(thrift::RowSet& result,
+              const thrift::ServiceMetaDataCall::type schemaCall,
+              thrift::ServiceMetaDataArgs& metadataArgs);
 
-    void getServiceMetaData(thrift::ServiceMetaData& result);
+          void getIndexInfo(thrift::RowSet& result,
+              thrift::ServiceMetaDataArgs& metadataArgs, const bool unique,
+              const bool approximate);
 
-    void getSchemaMetaData(thrift::RowSet& result,
-        const thrift::ServiceMetaDataCall::type schemaCall,
-        thrift::ServiceMetaDataArgs& metadataArgs);
+          void getUDTs(thrift::RowSet& result,
+              thrift::ServiceMetaDataArgs& metadataArgs,
+              const std::vector<thrift::SnappyType::type>& types);
 
-    void getIndexInfo(thrift::RowSet& result,
-        thrift::ServiceMetaDataArgs& metadataArgs, const bool unique,
-        const bool approximate);
+          void getBestRowIdentifier(thrift::RowSet& result,
+              thrift::ServiceMetaDataArgs& metadataArgs, const int32_t scope,
+              const bool nullable);
 
-    void getUDTs(thrift::RowSet& result,
-        thrift::ServiceMetaDataArgs& metadataArgs,
-        const std::vector<thrift::SnappyType::type>& types);
+          void closeResultSet(const int64_t cursorId);
 
-    void getBestRowIdentifier(thrift::RowSet& result,
-        thrift::ServiceMetaDataArgs& metadataArgs, const int32_t scope,
-        const bool nullable);
+          void cancelStatement(const int64_t stmtId);
 
-    void closeResultSet(const int64_t cursorId);
+          void closeStatement(const int64_t stmtId);
 
-    void cancelStatement(const int64_t stmtId);
+          void bulkClose(const std::vector<thrift::EntityId>& entities);
 
-    void closeStatement(const int64_t stmtId);
+          void close();
 
-    void bulkClose(const std::vector<thrift::EntityId>& entities);
+          const std::vector<thrift::HostAddress>& getLocators() const
+              noexcept {
+            return m_connHosts;
+          }
 
-    void close();
+          const std::set<std::string>& getServerGrps() const noexcept {
+            return m_serverGroups;
+          }
 
-    const std::vector<thrift::HostAddress>& getLocators() const noexcept{
-    	return m_connHosts;
-    }
+          inline bool isFrameTransport() const noexcept {
+            return m_useFramedTransport;
+          }
 
-    const std::set<std::string>& getServerGrps() const noexcept{
-        	return m_serverGroups;
-        }
+        };
 
-    inline bool isFrameTransport() const noexcept {
-          return m_useFramedTransport;
-        }
-
-  };
-
-} /* namespace impl */
-} /* namespace client */
-} /* namespace snappydata */
+      } /* namespace impl */
+    } /* namespace client */
+  } /* namespace snappydata */
 } /* namespace io */
 
 #endif /* CLIENTSERVICE_H_ */

--- a/native/src/snappyclient/cpp/impl/ClientService.h
+++ b/native/src/snappyclient/cpp/impl/ClientService.h
@@ -178,10 +178,6 @@ namespace impl {
 
     void destroyTransport() noexcept;
 
-    void handleException(const std::exception& te,
-        std::set<thrift::HostAddress>& failedServers, bool tryFailover,
-        bool ignoreNodeFailure, bool createNewConnection, const std::string& op);
-
     void newSnappyExceptionForConnectionClose(const thrift::HostAddress source,
         std::set<thrift::HostAddress>& failedServers, bool createNewConnection,
         const thrift::SnappyException& te);

--- a/native/src/snappyclient/cpp/impl/ControlConnection.cpp
+++ b/native/src/snappyclient/cpp/impl/ControlConnection.cpp
@@ -214,10 +214,7 @@ void ControlConnection::getPreferredServer(thrift::HostAddress& preferredServer,
         failedServers.insert(m_controlHost);
       }
       m_controlLocator->getOutputProtocol()->getTransport()->close();
-      failoverToAvailableHost(failedServers,true,failure);
-//      if(failure ==nullptr){
-//        failure = &(tex);
-//      }
+      failoverToAvailableHost(failedServers,true,tex);
     }catch(std::exception &ex){
       throw unexpectedError(ex, m_controlHost);
     }
@@ -309,7 +306,7 @@ void ControlConnection::failoverToAvailableHost(std::set<thrift::HostAddress>& f
         break;
       }
     }catch(TException &tExp){
-      //failure = &tExp;
+      tExp.what();
       failedServers.insert(controlAddr);
       if(outTransport != nullptr){
         outTransport->close();

--- a/native/src/snappyclient/cpp/impl/ControlConnection.cpp
+++ b/native/src/snappyclient/cpp/impl/ControlConnection.cpp
@@ -244,7 +244,7 @@ void ControlConnection::searchRandomServer(const std::set<thrift::HostAddress>& 
     }
   }
   if(findIt) return;
-  throw failoverExhausted(skipServers,failure);
+  failoverExhausted(skipServers,failure);
 }
 void ControlConnection::failoverToAvailableHost(std::set<thrift::HostAddress>& failedServers,
     bool checkFailedControlHosts, const std::exception& failure){
@@ -324,7 +324,7 @@ void ControlConnection::failoverToAvailableHost(std::set<thrift::HostAddress>& f
     m_controlLocator.reset (new thrift::LocatorServiceClient(inProtocol,outProtocol));
     return;
   }
-  throw failoverExhausted(failedServers,failure);
+  failoverExhausted(failedServers,failure);
 }
 
 const thrift::SnappyException* ControlConnection:: unexpectedError(const std::exception& ex, const thrift::HostAddress& host){
@@ -376,7 +376,7 @@ void  ControlConnection::refreshAllHosts(const std::vector<thrift::HostAddress>&
   m_controlHostSet.insert(allHosts.begin(),allHosts.end());
 }
 
-thrift::SnappyException* ControlConnection::failoverExhausted(const std::set<thrift::HostAddress>& failedServers,
+void ControlConnection::failoverExhausted(const std::set<thrift::HostAddress>& failedServers,
     const std::exception& failure) {
 
   std::string failedServerString;
@@ -392,6 +392,6 @@ thrift::SnappyException* ControlConnection::failoverExhausted(const std::set<thr
   snappyExData.__set_reason(reason.append(failedServerString));
   snappyEx->__set_exceptionData(snappyExData);
   snappyEx->__set_serverInfo(failedServerString);
-  return snappyEx;
+  throw snappyEx;
 }
 

--- a/native/src/snappyclient/cpp/impl/ControlConnection.cpp
+++ b/native/src/snappyclient/cpp/impl/ControlConnection.cpp
@@ -61,18 +61,22 @@ using namespace io::snappydata::thrift;
 std::vector<std::unique_ptr<ControlConnection> > ControlConnection::s_allConnections;
 boost::mutex ControlConnection::s_allConnsLock;
 
-ControlConnection::ControlConnection(ClientService *const &service) :m_serverGroups(service->getServerGrps()){
-  m_locators= service->getLocators();
+ControlConnection::ControlConnection(ClientService * const &service) :
+    m_serverGroups(service->getServerGrps()) {
+  m_locators = service->getLocators();
   m_framedTransport = service->isFrameTransport();
-  m_snappyServerType=service->getServerType(true,false,false);
-  m_controlHost= service->getCurrentHostAddress();
-  boost::assign::insert(m_snappyServerTypeSet)(service->getServerType(true,false,false));
-  std::copy(m_locators.begin(),m_locators.end(),std::inserter(m_controlHostSet,m_controlHostSet.end()));
+  m_snappyServerType = service->getServerType(true, false, false);
+  m_controlHost = service->getCurrentHostAddress();
+  boost::assign::insert(m_snappyServerTypeSet)(
+      service->getServerType(true, false, false));
+  std::copy(m_locators.begin(), m_locators.end(),
+      std::inserter(m_controlHostSet, m_controlHostSet.end()));
   m_controlLocator = nullptr;
 }
 
 const boost::optional<ControlConnection&> ControlConnection::getOrCreateControlConnection(
-    const std::vector<thrift::HostAddress>& hostAddrs, ClientService *const &service, const std::exception& failure){
+    const std::vector<thrift::HostAddress>& hostAddrs,
+    ClientService * const &service, const std::exception& failure) {
 
   // loop through all ControlConnections since size of this global list is
   // expected to be in single digit (total number of distributed systems)
@@ -82,105 +86,118 @@ const boost::optional<ControlConnection&> ControlConnection::getOrCreateControlC
   signed short index = static_cast<signed short>(s_allConnections.size());
   signed short allConnSize = index;
   while (--index >= 0) {
-    const std::unique_ptr<ControlConnection>& controlConn = s_allConnections.at(index);
+    const std::unique_ptr<ControlConnection>& controlConn =
+        s_allConnections.at(index);
 
     boost::lock_guard<boost::mutex> serviceGuard(controlConn->m_lock);
     std::vector<thrift::HostAddress> _locators = controlConn->m_locators;
-    for(thrift::HostAddress hostAddr : hostAddrs){
-      auto result = std::find(_locators.begin(),_locators.end(),hostAddr);
+    for (thrift::HostAddress hostAddr : hostAddrs) {
+      auto result = std::find(_locators.begin(), _locators.end(), hostAddr);
 
-      if(result ==  _locators.end()){
-          continue;
-        }else{
-            auto serviceServerType = service->getServerType(true,false,false); // TODO: need to discuss with sumedh about this getServerType method
-            auto contrConnServerType = controlConn->m_snappyServerType;
-            if(contrConnServerType == serviceServerType){
-              return *controlConn;
-            }else{
-              thrift::SnappyException *ex = new thrift::SnappyException();
-              std::string portStr;
-              Utils::convertIntToString(hostAddr.port,portStr);
-              std::string msg= hostAddr.hostName + ":" + portStr +
-                  " as registered but having different type " + Utils::getServerTypeString(contrConnServerType) +
-                  " than connection " + Utils::getServerTypeString( serviceServerType) ;
-              SnappyExceptionData snappyExData;
-              snappyExData.__set_sqlState("08006");
-              snappyExData.__set_reason(msg);
-              //snappyExData.__set_errorCode(17002); //TODO:: Need to confirm with sumedh
-              ex->__set_exceptionData(snappyExData);
-              ex->__set_serverInfo(hostAddr.hostName + ":" + portStr );
-              throw ex;
-            }
+      if (result == _locators.end()) {
+        continue;
+      } else {
+        auto serviceServerType = service->getServerType(true, false, false); // TODO: need to discuss with sumedh about this getServerType method
+        auto contrConnServerType = controlConn->m_snappyServerType;
+        if (contrConnServerType == serviceServerType) {
+          return *controlConn;
+        } else {
+          thrift::SnappyException *ex = new thrift::SnappyException();
+          std::string portStr;
+          Utils::convertIntToString(hostAddr.port, portStr);
+          std::string msg = hostAddr.hostName + ":" + portStr
+              + " as registered but having different type "
+              + Utils::getServerTypeString(contrConnServerType)
+              + " than connection "
+              + Utils::getServerTypeString(serviceServerType);
+          SnappyExceptionData snappyExData;
+          snappyExData.__set_sqlState("08006");
+          snappyExData.__set_reason(msg);
+          //snappyExData.__set_errorCode(17002); //TODO:: Need to confirm with sumedh
+          ex->__set_exceptionData(snappyExData);
+          ex->__set_serverInfo(hostAddr.hostName + ":" + portStr);
+          throw ex;
         }
+      }
     }
   }
 
-  if(allConnSize == 0){ // first attempt of creating connection
-  // if we reached here, then need to create a new ControlConnection
-  std::unique_ptr<ControlConnection> controlService ( new ControlConnection(service));
-  thrift::HostAddress preferredServer;
-  controlService->getPreferredServer(preferredServer,failure, true);
-  // check again if new control host already exist
-  index =  static_cast<signed short>(s_allConnections.size());
-  while (--index >= 0) {
-    const std::unique_ptr<ControlConnection>& controlConn = s_allConnections.at(index);
-    boost::lock_guard<boost::mutex> serviceGuard(controlConn->m_lock);
-    std::vector<thrift::HostAddress> _locators = controlConn->m_locators;
-    auto result = std::find(_locators.begin(),_locators.end(),preferredServer);
-    if(result == _locators.end()){
-      return *controlConn;
+  if (allConnSize == 0) { // first attempt of creating connection
+    // if we reached here, then need to create a new ControlConnection
+    std::unique_ptr<ControlConnection> controlService(
+        new ControlConnection(service));
+    thrift::HostAddress preferredServer;
+    controlService->getPreferredServer(preferredServer, failure, true);
+    // check again if new control host already exist
+    index = static_cast<signed short>(s_allConnections.size());
+    while (--index >= 0) {
+      const std::unique_ptr<ControlConnection>& controlConn =
+          s_allConnections.at(index);
+      boost::lock_guard<boost::mutex> serviceGuard(controlConn->m_lock);
+      std::vector<thrift::HostAddress> _locators = controlConn->m_locators;
+      auto result = std::find(_locators.begin(), _locators.end(),
+          preferredServer);
+      if (result == _locators.end()) {
+        return *controlConn;
+      }
     }
-  }
-  s_allConnections.push_back(std::move(controlService));
-  return *s_allConnections.back();
-  }else{
+    s_allConnections.push_back(std::move(controlService));
+    return *s_allConnections.back();
+  } else {
     thrift::SnappyException *ex = new thrift::SnappyException();
     SnappyExceptionData snappyExData;
-    snappyExData.__set_sqlState(std::string(SQLState::UNKNOWN_EXCEPTION.getSQLState())); //TODO: need to discuss suitable SQLSTATE with sumedh
+    snappyExData.__set_sqlState(
+        std::string(SQLState::UNKNOWN_EXCEPTION.getSQLState()));
     snappyExData.__set_reason("Failed to connect");
     ex->__set_exceptionData(snappyExData);
     throw ex;
   }
 }
-void ControlConnection::getLocatorPreferredServer(thrift::HostAddress& prefHostAddr,
+void ControlConnection::getLocatorPreferredServer(
+    thrift::HostAddress& prefHostAddr,
     std::set<thrift::HostAddress>& failedServers,
-    std::set<std::string>serverGroups){
-  m_controlLocator->getPreferredServer(prefHostAddr,m_snappyServerTypeSet,serverGroups,failedServers);
+    std::set<std::string> serverGroups) {
+  m_controlLocator->getPreferredServer(prefHostAddr, m_snappyServerTypeSet,
+      serverGroups, failedServers);
 }
-void ControlConnection::getPreferredServer(thrift::HostAddress& preferredServer,
-    const std::exception& failure,bool forFailover){
+void ControlConnection::getPreferredServer(
+    thrift::HostAddress& preferredServer, const std::exception& failure,
+    bool forFailover) {
   std::set<thrift::HostAddress> failedServers;
   std::set<std::string> serverGroups;
-  return getPreferredServer(preferredServer,failure,failedServers,serverGroups,forFailover);
+  return getPreferredServer(preferredServer, failure, failedServers,
+      serverGroups, forFailover);
 }
-void ControlConnection::getPreferredServer(thrift::HostAddress& preferredServer,
-    const std::exception& failure,
+
+void ControlConnection::getPreferredServer(
+    thrift::HostAddress& preferredServer, const std::exception& failure,
     std::set<thrift::HostAddress>& failedServers,
-    std::set<std::string>& serverGroups,bool forFailover){
-  if(m_controlLocator == nullptr)
-  {
-    failoverToAvailableHost(failedServers, false,failure);
+    std::set<std::string>& serverGroups, bool forFailover) {
+  if (m_controlLocator == nullptr) {
+    failoverToAvailableHost(failedServers, false, failure);
     forFailover = true;
   }
   boost::lock_guard<boost::mutex> localGuard(m_lock);
   bool firstCall = true;
-  while(true){
-
-    try{
-      if(forFailover){
+  while (true) {
+    try {
+      if (forFailover) {
         //refresh the full host list
         std::vector<HostAddress> prefServerAndAllHosts;
-        m_controlLocator->getAllServersWithPreferredServer(prefServerAndAllHosts,m_snappyServerTypeSet,serverGroups,failedServers);
-        if(! prefServerAndAllHosts.empty())
-        {
-        std::vector<HostAddress> allHosts(prefServerAndAllHosts.begin() +1,prefServerAndAllHosts.end());
-        refreshAllHosts(allHosts);
-        preferredServer = prefServerAndAllHosts.at(0);
+        m_controlLocator->getAllServersWithPreferredServer(
+            prefServerAndAllHosts, m_snappyServerTypeSet, serverGroups,
+            failedServers);
+        if (!prefServerAndAllHosts.empty()) {
+          std::vector<HostAddress> allHosts(prefServerAndAllHosts.begin() + 1,
+              prefServerAndAllHosts.end());
+          refreshAllHosts(allHosts);
+          preferredServer = prefServerAndAllHosts.at(0);
         }
-      }else{
-        getLocatorPreferredServer(preferredServer,failedServers,serverGroups);
+      } else {
+        getLocatorPreferredServer(preferredServer, failedServers,
+            serverGroups);
       }
-      if(preferredServer.port <=0){
+      if (preferredServer.port <= 0) {
         /*For this case we don't have a locator or locator unable to
          * determine a preferred server, so choose some server randomly
          * as the "preferredServer". In case all servers have failed then
@@ -189,176 +206,196 @@ void ControlConnection::getPreferredServer(thrift::HostAddress& preferredServer,
          * working at this point (e.g after a reconnect)
          * */
         std::set<thrift::HostAddress> skipServers = failedServers;
-        if( !failedServers.empty() && std::find(failedServers.begin(),failedServers.end(),m_controlHost)!= failedServers.end()){
+        if (!failedServers.empty()
+            && std::find(failedServers.begin(), failedServers.end(),
+                m_controlHost) != failedServers.end()) {
           //don't change the original failure list since that is proper
           // for the current operation but change for random server search
           skipServers.erase(m_controlHost);
         }
-        searchRandomServer(skipServers, failure,preferredServer);
+        searchRandomServer(skipServers, failure, preferredServer);
       }
       return;
-    }catch(thrift::SnappyException &snEx){
-      FailoverStatus status = NetConnection::getFailoverStatus(snEx.exceptionData.sqlState,snEx.exceptionData.errorCode,snEx);
-      if(status== FailoverStatus::NONE){
-       throw unexpectedError(snEx, m_controlHost);
-      }else if(status== FailoverStatus::RETRY){
+    } catch (thrift::SnappyException &snEx) {
+      FailoverStatus status = NetConnection::getFailoverStatus(
+          snEx.exceptionData.sqlState, snEx.exceptionData.errorCode, snEx);
+      if (status == FailoverStatus::NONE) {
+        throw unexpectedError(snEx, m_controlHost);
+      } else if (status == FailoverStatus::RETRY) {
         forFailover = true;
         continue;
       }
-    }catch(TException &tex){
+    } catch (const TException &tex) {
       //Search for a new host for locator query
       // for the first call do not mark controlhost as failed but retry(e.g. for a reconnect case)
-      if(firstCall){
+      if (firstCall) {
         firstCall = false;
-      }else{
+      } else {
         failedServers.insert(m_controlHost);
       }
       m_controlLocator->getOutputProtocol()->getTransport()->close();
-      failoverToAvailableHost(failedServers,true,tex);
-    }catch(std::exception &ex){
+      failoverToAvailableHost(failedServers, true, tex);
+    } catch (std::exception &ex) {
       throw unexpectedError(ex, m_controlHost);
     }
     forFailover = true;
   }
 }
 
-void ControlConnection::searchRandomServer(const std::set<thrift::HostAddress>& skipServers,
-    const std::exception& failure,thrift::HostAddress& hostAddress){
+void ControlConnection::searchRandomServer(
+    const std::set<thrift::HostAddress>& skipServers,
+    const std::exception& failure, thrift::HostAddress& hostAddress) {
   std::vector<thrift::HostAddress> searchServers;
   // Note: Do not use unordered_set -- reason is http://www.cplusplus.com/forum/general/198319/
-  std::copy(m_controlHostSet.begin(),m_controlHostSet.end(),std::inserter(searchServers,searchServers.end()));
-  if(searchServers.size() > 2){
-    std::random_shuffle(searchServers.begin(),searchServers.end());
+  std::copy(m_controlHostSet.begin(), m_controlHostSet.end(),
+      std::inserter(searchServers, searchServers.end()));
+  if (searchServers.size() > 2) {
+    std::random_shuffle(searchServers.begin(), searchServers.end());
   }
   bool findIt = false;
-  for(thrift::HostAddress host: searchServers){
-    if(host.serverType == m_snappyServerType &&
-        !(!skipServers.empty() &&
-            std::find(skipServers.begin(),skipServers.end(),host)!=skipServers.end())){
+  for (thrift::HostAddress host : searchServers) {
+    if (host.serverType == m_snappyServerType
+        && !(!skipServers.empty()
+            && std::find(skipServers.begin(), skipServers.end(), host)
+                != skipServers.end())) {
       hostAddress = host;
       findIt = true;
       break;
     }
   }
-  if(findIt) return;
-  failoverExhausted(skipServers,failure);
+  if (findIt) return;
+  failoverExhausted(skipServers, failure);
 }
-void ControlConnection::failoverToAvailableHost(std::set<thrift::HostAddress>& failedServers,
-    bool checkFailedControlHosts, const std::exception& failure){
+void ControlConnection::failoverToAvailableHost(
+    std::set<thrift::HostAddress>& failedServers,
+    bool checkFailedControlHosts, const std::exception& failure) {
   boost::lock_guard<boost::mutex> localGuard(m_lock);
-  for(auto iterator = m_controlHostSet.begin();iterator!= m_controlHostSet.end(); ++iterator ){
+  for (auto iterator = m_controlHostSet.begin();
+      iterator != m_controlHostSet.end(); ++iterator) {
     thrift::HostAddress controlAddr = *iterator;
-    if(checkFailedControlHosts && ! failedServers.empty() && (failedServers.find(controlAddr) != failedServers.end())){
+    if (checkFailedControlHosts && !failedServers.empty()
+        && (failedServers.find(controlAddr) != failedServers.end())) {
       continue;
     }
     m_controlLocator.reset(nullptr);
 
-    boost::shared_ptr<TTransport> inTransport =nullptr;
-    boost::shared_ptr<TTransport> outTransport =nullptr;
-    boost::shared_ptr<TProtocol>  inProtocol =nullptr;
-    boost::shared_ptr<TProtocol>  outProtocol =nullptr;
+    boost::shared_ptr<TTransport> inTransport = nullptr;
+    boost::shared_ptr<TTransport> outTransport = nullptr;
+    boost::shared_ptr<TProtocol> inProtocol = nullptr;
+    boost::shared_ptr<TProtocol> outProtocol = nullptr;
 
-    try{
-      while(true){
-        if(outTransport !=nullptr){
+    try {
+      while (true) {
+        if (outTransport != nullptr) {
           outTransport->close();
         }
         boost::shared_ptr<TTransport> tTransport = nullptr;
-        if(m_snappyServerType == thrift::ServerType::THRIFT_LOCATOR_BP_SSL ||
-            m_snappyServerType == thrift::ServerType::THRIFT_LOCATOR_CP_SSL ||
-            m_snappyServerType == thrift::ServerType::THRIFT_SNAPPY_BP_SSL ||
-            m_snappyServerType==thrift::ServerType::THRIFT_SNAPPY_CP_SSL){
+        if (m_snappyServerType == thrift::ServerType::THRIFT_LOCATOR_BP_SSL
+            || m_snappyServerType == thrift::ServerType::THRIFT_LOCATOR_CP_SSL
+            || m_snappyServerType == thrift::ServerType::THRIFT_SNAPPY_BP_SSL
+            || m_snappyServerType
+                == thrift::ServerType::THRIFT_SNAPPY_CP_SSL) {
           TSSLSocketFactory sslSocketFactory;
-          tTransport = sslSocketFactory.createSocket(controlAddr.hostName,controlAddr.port);
-        }else if(m_snappyServerType == thrift::ServerType::THRIFT_LOCATOR_BP ||
-            m_snappyServerType== thrift::ServerType::THRIFT_LOCATOR_CP ||
-            m_snappyServerType== thrift::ServerType::THRIFT_SNAPPY_BP ||
-            m_snappyServerType== thrift::ServerType::THRIFT_SNAPPY_CP){
-          tTransport = boost::make_shared<TSocket>(controlAddr.hostName,controlAddr.port);
+          tTransport = sslSocketFactory.createSocket(controlAddr.hostName,
+              controlAddr.port);
+        } else if (m_snappyServerType == thrift::ServerType::THRIFT_LOCATOR_BP
+            || m_snappyServerType == thrift::ServerType::THRIFT_LOCATOR_CP
+            || m_snappyServerType == thrift::ServerType::THRIFT_SNAPPY_BP
+            || m_snappyServerType == thrift::ServerType::THRIFT_SNAPPY_CP) {
+          tTransport = boost::make_shared<TSocket>(controlAddr.hostName,
+              controlAddr.port);
         }
         tTransport->open();
         TTransportFactory* transportFactory = nullptr;
-        if(m_framedTransport){
+        if (m_framedTransport) {
           transportFactory = new TFramedTransportFactory();
-        }else{
+        } else {
           transportFactory = new TTransportFactory();
         }
         inTransport = transportFactory->getTransport(tTransport);
         outTransport = transportFactory->getTransport(tTransport);
         delete transportFactory;
-        transportFactory= 0;
+        transportFactory = 0;
 
         TProtocolFactory* protocolFactory = nullptr;
-        if(m_snappyServerType == thrift::ServerType::THRIFT_LOCATOR_BP ||
-            m_snappyServerType==thrift::ServerType::THRIFT_LOCATOR_BP_SSL ||
-            m_snappyServerType == thrift::ServerType::THRIFT_SNAPPY_BP ||
-            m_snappyServerType == thrift::ServerType::THRIFT_SNAPPY_BP_SSL){
+        if (m_snappyServerType == thrift::ServerType::THRIFT_LOCATOR_BP
+            || m_snappyServerType == thrift::ServerType::THRIFT_LOCATOR_BP_SSL
+            || m_snappyServerType == thrift::ServerType::THRIFT_SNAPPY_BP
+            || m_snappyServerType
+                == thrift::ServerType::THRIFT_SNAPPY_BP_SSL) {
           protocolFactory = new TBinaryProtocolFactory();
 
-        }else{
+        } else {
           protocolFactory = new TCompactProtocolFactory();
         }
-        inProtocol=  protocolFactory->getProtocol(inTransport);
-        outProtocol= protocolFactory->getProtocol(outTransport);
+        inProtocol = protocolFactory->getProtocol(inTransport);
+        outProtocol = protocolFactory->getProtocol(outTransport);
 
         delete protocolFactory;
-        protocolFactory=0;
+        protocolFactory = 0;
         break;
       }
-    }catch(TException &tExp){
-      tExp.what();
+    } catch (const TException& te) {
       failedServers.insert(controlAddr);
-      if(outTransport != nullptr){
+      if (outTransport != nullptr) {
         outTransport->close();
       }
       continue;
-    }catch(std::exception &ex){
-      throw unexpectedError(ex,controlAddr);
+    } catch (std::exception &ex) {
+      throw unexpectedError(ex, controlAddr);
     }
-
     m_controlHost = controlAddr;
-
-    m_controlLocator.reset (new thrift::LocatorServiceClient(inProtocol,outProtocol));
+    m_controlLocator.reset(
+        new thrift::LocatorServiceClient(inProtocol, outProtocol));
     return;
   }
-  failoverExhausted(failedServers,failure);
+  failoverExhausted(failedServers, failure);
 }
 
-const thrift::SnappyException* ControlConnection:: unexpectedError(const std::exception& ex, const thrift::HostAddress& host){
+const thrift::SnappyException* ControlConnection::unexpectedError(
+    const std::exception& ex, const thrift::HostAddress& host) {
 
-  if(m_controlLocator != nullptr){
+  if (m_controlLocator != nullptr) {
     m_controlLocator->getOutputProtocol()->getTransport()->close();
     m_controlLocator.reset(nullptr);
   }
   thrift::SnappyException *snappyEx = new thrift::SnappyException();
   SnappyExceptionData snappyExData;
-  snappyExData.__set_sqlState(std::string(SQLState::UNKNOWN_EXCEPTION.getSQLState()));
+  snappyExData.__set_sqlState(
+      std::string(SQLState::UNKNOWN_EXCEPTION.getSQLState()));
   snappyExData.__set_reason(ex.what());
 
   snappyEx->__set_exceptionData(snappyExData);
 
   std::string portNum;
-  Utils::convertIntToString(host.port,portNum);
-  snappyEx->__set_serverInfo(host.hostName + host.ipAddress + portNum + Utils::getServerTypeString(host.serverType));
+  Utils::convertIntToString(host.port, portNum);
+  snappyEx->__set_serverInfo(
+      host.hostName + host.ipAddress + portNum
+          + Utils::getServerTypeString(host.serverType));
 
   return snappyEx;
 }
 
-void  ControlConnection::refreshAllHosts(const std::vector<thrift::HostAddress>& allHosts) {
+void ControlConnection::refreshAllHosts(
+    const std::vector<thrift::HostAddress>& allHosts) {
   //refresh the locator list first(keep old but push current to front)
   std::vector<thrift::HostAddress> locators = m_locators;
   std::vector<thrift::HostAddress> newLocators(locators.size());
 
-  for(HostAddress host: allHosts){
+  for (HostAddress host : allHosts) {
     thrift::ServerType::type sType = host.serverType;
-    if(sType == ServerType::THRIFT_LOCATOR_BP || sType == ServerType::THRIFT_LOCATOR_BP_SSL ||
-        sType == ServerType::THRIFT_LOCATOR_CP || sType == ServerType::THRIFT_LOCATOR_CP_SSL ||
-        (std::find(locators.begin(),locators.end(), host)!=locators.end())){
+    if (sType == ServerType::THRIFT_LOCATOR_BP
+        || sType == ServerType::THRIFT_LOCATOR_BP_SSL
+        || sType == ServerType::THRIFT_LOCATOR_CP
+        || sType == ServerType::THRIFT_LOCATOR_CP_SSL
+        || (std::find(locators.begin(), locators.end(), host)
+            != locators.end())) {
       newLocators.push_back(host);
     }
   }
-  for(HostAddress host: locators){
-    if(!(std::find(newLocators.begin(),newLocators.end(), host)!=newLocators.end())){
+  for (HostAddress host : locators) {
+    if (!(std::find(newLocators.begin(), newLocators.end(), host)
+        != newLocators.end())) {
       newLocators.push_back(host);
     }
   }
@@ -369,23 +406,28 @@ void  ControlConnection::refreshAllHosts(const std::vector<thrift::HostAddress>&
   // to prefer the ones coming as "allServers" with "isServer" flag
   // correctly set rather than the ones in "secondary-locators"
   m_controlHostSet.clear();
-  m_controlHostSet.insert(newLocators.begin(),newLocators.end());
-  m_controlHostSet.insert(allHosts.begin(),allHosts.end());
+  m_controlHostSet.insert(newLocators.begin(), newLocators.end());
+  m_controlHostSet.insert(allHosts.begin(), allHosts.end());
 }
 
-void ControlConnection::failoverExhausted(const std::set<thrift::HostAddress>& failedServers,
+void ControlConnection::failoverExhausted(
+    const std::set<thrift::HostAddress>& failedServers,
     const std::exception& failure) {
 
   std::string failedServerString;
-  for(thrift::HostAddress host : failedServers){
+  for (thrift::HostAddress host : failedServers) {
     std::string portStr;
-    Utils::convertIntToString(host.port,portStr);
-    failedServerString.append(host.hostName).append(":").append(portStr).append(",");
+    Utils::convertIntToString(host.port, portStr);
+    failedServerString.append(host.hostName).append(":").append(portStr).append(
+        ",");
   }
   thrift::SnappyException *snappyEx = new thrift::SnappyException();
   SnappyExceptionData snappyExData;
-  snappyExData.__set_sqlState(std::string(SQLState::DATA_CONTAINER_CLOSED.getSQLState()));
-  std::string reason ="{Failed afer trying all available servers:}" ;
+  snappyExData.__set_sqlState(
+      std::string(SQLState::DATA_CONTAINER_CLOSED.getSQLState()));
+  std::string reason = "{Failed afer trying all available servers:}";
+  if (std::string(failure.what()).compare("std::exception") == 0) // failure is not empty exception
+  reason.append(" and ").append(failure.what());
   snappyExData.__set_reason(reason.append(failedServerString));
   snappyEx->__set_exceptionData(snappyExData);
   snappyEx->__set_serverInfo(failedServerString);

--- a/native/src/snappyclient/cpp/impl/ControlConnection.h
+++ b/native/src/snappyclient/cpp/impl/ControlConnection.h
@@ -107,7 +107,7 @@ namespace io {
           const thrift::SnappyException* unexpectedError(const std::exception& e,
               const thrift::HostAddress& host);
 
-          thrift::SnappyException* failoverExhausted(const std::set<thrift::HostAddress>& failedServers,
+          void failoverExhausted(const std::set<thrift::HostAddress>& failedServers,
               const std::exception& failure);
 
           void getLocatorPreferredServer(thrift::HostAddress& prefHostAddr,

--- a/native/src/snappyclient/cpp/impl/ControlConnection.h
+++ b/native/src/snappyclient/cpp/impl/ControlConnection.h
@@ -100,32 +100,36 @@ namespace io {
           ControlConnection(ClientService *const &service);
 
           void failoverToAvailableHost(std::set<thrift::HostAddress>& failedServers,
-              bool checkFailedControlHosts,  std::exception* failure);
+              bool checkFailedControlHosts, const std::exception& failure);
 
           void refreshAllHosts(const std::vector<thrift::HostAddress>& allHosts);
 
-          const thrift::SnappyException* unexpectedError(const std::exception& e, const thrift::HostAddress& host);
+          const thrift::SnappyException* unexpectedError(const std::exception& e,
+              const thrift::HostAddress& host);
 
-          thrift::SnappyException* failoverExhausted(const std::set<thrift::HostAddress>& failedServers,std::exception* failure);
+          thrift::SnappyException* failoverExhausted(const std::set<thrift::HostAddress>& failedServers,
+              const std::exception& failure);
 
-          void getLocatorPreferredServer(thrift::HostAddress& prefHostAddr,std::set<thrift::HostAddress>& failedServers,
+          void getLocatorPreferredServer(thrift::HostAddress& prefHostAddr,
+              std::set<thrift::HostAddress>& failedServers,
               std::set<std::string>serverGroups);
 
-          void getPreferredServer(thrift::HostAddress& preferredServer,std::exception* failure,
-              bool forFailover = false);
+          void getPreferredServer(thrift::HostAddress& preferredServer,
+              const std::exception& failure, bool forFailover = false);
 
         public:
 
           static const boost::optional<ControlConnection&> getOrCreateControlConnection(
-              const std::vector<thrift::HostAddress>& hostAddrs, ClientService *const &service, std::exception* failure);
+              const std::vector<thrift::HostAddress>& hostAddrs, ClientService *const &service,
+              const std::exception& failure);
 
-          void getPreferredServer(thrift::HostAddress& preferredServer,std::exception* failure,
+          void getPreferredServer(thrift::HostAddress& preferredServer,const std::exception& failure,
               std::set<thrift::HostAddress>& failedServers,
               std::set<std::string>& serverGroups,bool forFailover = false);
 
 
           void searchRandomServer(const std::set<thrift::HostAddress>& skipServers,
-              std::exception* failure,thrift::HostAddress& hostAddress);
+             const std::exception& failure,thrift::HostAddress& hostAddress);
         };
 
       } /* namespace impl */

--- a/native/src/snappyclient/cpp/impl/ControlConnection.h
+++ b/native/src/snappyclient/cpp/impl/ControlConnection.h
@@ -67,7 +67,6 @@ namespace io {
   namespace snappydata {
     namespace client {
       namespace impl {
-
         /**
          * Holds locator, server information to use for failover. Also provides
          * convenience methods to actually search for an appropriate host for
@@ -96,7 +95,6 @@ namespace io {
           static std::vector<std::unique_ptr<ControlConnection> > s_allConnections;
           /** Global lock for {@link allConnections} */
           static boost::mutex s_allConnsLock;
-
           /*********Member functions**************/
           ControlConnection():m_serverGroups(std::set<std::string>()){};
           ControlConnection(ClientService *const &service);
@@ -115,6 +113,7 @@ namespace io {
 
           void getPreferredServer(thrift::HostAddress& preferredServer,std::exception* failure,
               bool forFailover = false);
+
         public:
 
           static const boost::optional<ControlConnection&> getOrCreateControlConnection(

--- a/native/src/snappyclient/cpp/impl/ControlConnection.h
+++ b/native/src/snappyclient/cpp/impl/ControlConnection.h
@@ -36,7 +36,6 @@
 #ifndef CONTROLCONNECTION_H_
 #define CONTROLCONNECTION_H_
 
-
 #include "ClientService.h"
 #include <boost/thread/mutex.hpp>
 #include <boost/optional.hpp>
@@ -96,23 +95,29 @@ namespace io {
           /** Global lock for {@link allConnections} */
           static boost::mutex s_allConnsLock;
           /*********Member functions**************/
-          ControlConnection():m_serverGroups(std::set<std::string>()){};
-          ControlConnection(ClientService *const &service);
+          ControlConnection() :
+              m_serverGroups(std::set<std::string>()) {
+          }
+          ;
+          ControlConnection(ClientService * const &service);
 
-          void failoverToAvailableHost(std::set<thrift::HostAddress>& failedServers,
+          void failoverToAvailableHost(
+              std::set<thrift::HostAddress>& failedServers,
               bool checkFailedControlHosts, const std::exception& failure);
 
-          void refreshAllHosts(const std::vector<thrift::HostAddress>& allHosts);
+          void refreshAllHosts(
+              const std::vector<thrift::HostAddress>& allHosts);
 
-          const thrift::SnappyException* unexpectedError(const std::exception& e,
-              const thrift::HostAddress& host);
+          const thrift::SnappyException* unexpectedError(
+              const std::exception& e, const thrift::HostAddress& host);
 
-          void failoverExhausted(const std::set<thrift::HostAddress>& failedServers,
+          void failoverExhausted(
+              const std::set<thrift::HostAddress>& failedServers,
               const std::exception& failure);
 
           void getLocatorPreferredServer(thrift::HostAddress& prefHostAddr,
               std::set<thrift::HostAddress>& failedServers,
-              std::set<std::string>serverGroups);
+              std::set<std::string> serverGroups);
 
           void getPreferredServer(thrift::HostAddress& preferredServer,
               const std::exception& failure, bool forFailover = false);
@@ -120,16 +125,18 @@ namespace io {
         public:
 
           static const boost::optional<ControlConnection&> getOrCreateControlConnection(
-              const std::vector<thrift::HostAddress>& hostAddrs, ClientService *const &service,
-              const std::exception& failure);
+              const std::vector<thrift::HostAddress>& hostAddrs,
+              ClientService * const &service, const std::exception& failure);
 
-          void getPreferredServer(thrift::HostAddress& preferredServer,const std::exception& failure,
+          void getPreferredServer(thrift::HostAddress& preferredServer,
+              const std::exception& failure,
               std::set<thrift::HostAddress>& failedServers,
-              std::set<std::string>& serverGroups,bool forFailover = false);
+              std::set<std::string>& serverGroups, bool forFailover = false);
 
-
-          void searchRandomServer(const std::set<thrift::HostAddress>& skipServers,
-             const std::exception& failure,thrift::HostAddress& hostAddress);
+          void searchRandomServer(
+              const std::set<thrift::HostAddress>& skipServers,
+              const std::exception& failure,
+              thrift::HostAddress& hostAddress);
         };
 
       } /* namespace impl */

--- a/native/src/snappyclient/cpp/impl/NetConnection.cpp
+++ b/native/src/snappyclient/cpp/impl/NetConnection.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2010-2015 Pivotal Software, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+/*
+ * Changes for SnappyData data platform.
+ *
+ * Portions Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+/*
+ * NetConnection.cpp
+ *
+ *  Created on: 15-Jul-2019
+ *      Author: pbisen
+ */
+#include "SQLState.h"
+#include "SQLException.h"
+#include "NetConnection.h"
+
+
+using namespace io::snappydata;
+using namespace io::snappydata::client;
+using namespace io::snappydata::client::impl;
+
+std::set<std::string> NetConnection::failoverSQLStateSet={ "08001",
+ "08003", "08004", "08006", "X0J15", "X0Z32", "XN001", "XN014", "XN016",
+ "58009", "58014", "58015", "58016", "58017", "57017", "58010", "30021",
+ "XJ040", "XJ041", "XSDA3", "XSDA4", "XSDAJ", "XJ217" };
+
+FailoverStatus NetConnection::getFailoverStatus(const std::string& sqlState,
+    const int32_t& errorCode, const TException& snappyEx){
+
+  if( ! sqlState.compare(SQLState::SNAPPY_NODE_SHUTDOWN.getSQLState())
+      || !sqlState.compare(SQLState::NODE_BUCKET_MOVED.getSQLState())){
+    return FailoverStatus::RETRY;
+  }
+  /* for 08001 we have to, unfortunately, resort to string search to
+  * determine if failover makes sense or it is due to some problem
+  * with authentication or invalid properties */
+  else if(!sqlState.compare("08001")){
+    std::string msg(snappyEx.what());
+    if(!msg.empty() &&
+        ((msg.find("rror")!=std::string::npos)  // cater to CONNECT_UNABLE_TO_CONNECT_TO_SERVER
+            || (msg.find("xception")!=std::string::npos ) // cater to CONNECT_SOCKET_EXCEPTION
+            ||(msg.find("ocket")!=std::string::npos))// cater to CONNECT_UNABLE_TO_OPEN_SOCKET_STREAM
+      ){
+      return FailoverStatus::NEW_SERVER;
+    }
+  }
+  /* for 08004 we have to, unfortunately, resort to string search to
+   *  determine if failover makes sense or it is due to some problem
+   *  with authentication
+   */
+  else if(!sqlState.compare("08004")){
+      std::string msg(snappyEx.what());
+      if(!msg.empty() &&
+         (msg.find("connection refused") !=std::string::npos)
+         ){
+        return FailoverStatus::NEW_SERVER;
+      }
+    }
+  else if(failoverSQLStateSet.find(sqlState)!= failoverSQLStateSet.end()){
+    return FailoverStatus::NEW_SERVER;
+  }
+  return FailoverStatus::NONE;
+}
+
+

--- a/native/src/snappyclient/cpp/impl/NetConnection.h
+++ b/native/src/snappyclient/cpp/impl/NetConnection.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2010-2015 Pivotal Software, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+/*
+ * Changes for SnappyData data platform.
+ *
+ * Portions Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+/*
+ * NetConnection.h
+ *
+ *  Created on: 15-Jul-2019
+ *      Author: pbisen
+ */
+
+#ifndef SRC_SNAPPYCLIENT_CPP_IMPL_NETCONNECTION_H_
+#define SRC_SNAPPYCLIENT_CPP_IMPL_NETCONNECTION_H_
+
+#include <thrift/Thrift.h>
+
+using namespace apache::thrift;
+
+namespace io {
+namespace snappydata {
+namespace client {
+namespace impl {
+
+  enum class FailoverStatus :unsigned char{
+    NONE,         /** no failover to be done */
+    NEW_SERVER,   /** failover to a new server */
+    RETRY         /** retry to the same server */
+  };
+  class NetConnection{
+  private:
+    /** set of SQLState strings that denote failover should be done */
+    static std::set<std::string> failoverSQLStateSet;
+  public:
+    static FailoverStatus getFailoverStatus(const std::string& sqlState,
+        const int32_t& errorCode, const TException& snappyEx);
+  };
+
+} /* namespace impl */
+} /* namespace client */
+} /* namespace snappydata */
+} /* namespace io */
+
+#endif /* SRC_SNAPPYCLIENT_CPP_IMPL_NETCONNECTION_H_ */

--- a/native/src/snappyclient/headers/SQLState.h
+++ b/native/src/snappyclient/headers/SQLState.h
@@ -377,6 +377,11 @@ namespace client {
      * protocol is detected (can be due to server failure).
      */
     static const SQLState THRIFT_PROTOCOL_ERROR;
+    /**
+     * SQLState of the exception thrown when an error
+     *  is detected due to bucket moved.
+     */
+    static const SQLState NODE_BUCKET_MOVED;
   };
 
 } /* namespace client */

--- a/native/tests/unitTest.cpp
+++ b/native/tests/unitTest.cpp
@@ -1,0 +1,49 @@
+#include "Connection.h"
+#include <iostream>
+//#include <fstream>
+#include <thread>
+using namespace io::snappydata::client;
+using namespace std;
+
+void stopServer(string command){
+  system(command.c_str());
+}
+
+int main(int argc, char **argv) {
+  try {
+    string snappyHomeDir(argv[1]);
+    string serverStopScript ;
+    serverStopScript.append("cd  ").append(snappyHomeDir).append("; ./sbin/snappy-server.sh stop -dir=");
+    std::map<std::string, std::string> properties;
+    properties.insert(std::pair<std::string, std::string>("load-balance","true"));
+    Connection conn;
+    conn.open("localhost", 1527,"app","app",properties);
+
+    int connectPort = conn.getCurrentHostAddress().port;
+    string serverDir="./work/";
+    if(connectPort > 1528){
+      serverDir.append("localhost-server-2");
+    }
+    serverDir.append("localhost-server-1");
+    serverStopScript.append(serverDir);
+
+    for(int i=0;i <10;i++)
+    {
+      conn.executeQuery("Show databases");
+    }
+    std::cout << "before thread connected to :"<< conn.getCurrentHostAddress() <<std::endl;
+
+    std::thread t1(stopServer,serverStopScript);
+    t1.join();
+    for(int i=0;i <10;i++)
+    {
+      conn.executeQuery("Show databases");
+    }
+    std::cout << "after thread connected to :"<< conn.getCurrentHostAddress() <<std::endl;
+    } catch (SQLException& sqle) {
+        sqle.printStackTrace(std::cout);
+    }
+}
+
+
+

--- a/native/tests/unitTest.cpp
+++ b/native/tests/unitTest.cpp
@@ -10,18 +10,18 @@ void stopServer(string command){
 }
 
 int main(int argc, char **argv) {
+  Connection conn;
   try {
     string snappyHomeDir(argv[1]);
     string serverStopScript ;
     serverStopScript.append("cd  ").append(snappyHomeDir).append("; ./sbin/snappy-server.sh stop -dir=");
     std::map<std::string, std::string> properties;
     properties.insert(std::pair<std::string, std::string>("load-balance","true"));
-    Connection conn;
+    
     conn.open("localhost", 1527,"app","app",properties);
     std::cout << "before thread connected to :"<< conn.getCurrentHostAddress() <<std::endl;
 
     //executing query in table already present-before stopping server
-    //for(int i=0;i <10;i++)
     auto count = conn.executeQuery("Show databases");
     
     if(count > 0 )
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
     std::thread t1(stopServer,serverStopScript);
     t1.join();
     //executing query in table already present-after stopping server
-    //for(int i=0;i <10;i++)
+    
     count =  conn.executeQuery("Show databases");
     if(count > 0 )
     {
@@ -49,6 +49,8 @@ int main(int argc, char **argv) {
     }
     std::cout << "after thread connected to :"<< conn.getCurrentHostAddress() <<std::endl;
     } catch (SQLException& sqle) {
+        if(conn.isOpen()) conn.close();
+        std::cout<< "ExecuteQuery failed, throws exception"<<std::endl;
         sqle.printStackTrace(std::cout);
     }
 }

--- a/native/tests/unitTest.sh
+++ b/native/tests/unitTest.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+_cwd="$2"
+_snappyNativeDir="$(dirname "$_cwd")"
+_testDir=${_snappyNativeDir}/tests/
+#echo "${_snappyNativeDir}"
+distDir=${_snappyNativeDir}/dist
+#echo "${distDir}"
+SNAPPY_HOME_DIR="$1"
+if [ -z ${THRIFT_VERSION} ]; then
+  THRIFT_VERSION=1.0.0-2
+fi
+if [ -z ${BOOST_VERSION} ]; then
+  BOOST_VERSION=1.65.1
+fi
+
+thrftLibPath=${distDir}/thrift-${THRIFT_VERSION}/lin64/lib
+bostLibPath=${distDir}/boost-${BOOST_VERSION}/lin64/lib
+snappClientLibPath=${_snappyNativeDir}/build-artifacts/lin/snappyclient/lin64/lib/debug
+
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${thrftLibPath}:${bostLibPath}:${snappClientLibPath}:${_snappyNativeDir}/Debug#!/bin/sh
+
+#echo "$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH
+
+#echo "${_cwd}"
+headerLoc=${_snappyNativeDir}/src/snappyclient/headers
+boostHeadeLoc=${_snappyNativeDir}/dist/boost-${BOOST_VERSION}/include
+
+g++ -std=c++11 -I"${headerLoc}" -I"${boostHeadeLoc}" -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"${_testDir}/unitTest.d" -MT"${_testDir}unitTest.o" -o "${_testDir}unitTest.o" "${_testDir}unitTest.cpp"
+
+g++ -L${bostLibPath} -L${thrftLibPath} -L${snappClientLibPath} -L${_snappyNativeDir}/Debug -rdynamic -o "${_testDir}unitTest"  ${_testDir}unitTest.o -lcrypto -lodbc -lpthread -lssl -lsnappydata-native -lboost_chrono -lboost_date_time -lboost_filesystem -lboost_log -lboost_log_setup -lboost_system -lboost_thread -lthrift -lpthread -lrt -lgmp
+
+chmod 777 ${_testDir}unitTest ${_testDir}unitTest.d
+cd ${_testDir}
+./unitTest $SNAPPY_HOME_DIR
+
+rm unitTest unitTest.d unitTest.o

--- a/native/tests/unitTest_2.cpp
+++ b/native/tests/unitTest_2.cpp
@@ -10,13 +10,14 @@ void stopServer(string command){
 }
 
 int main(int argc, char **argv) {
+  Connection conn;
   try {
     string snappyHomeDir(argv[1]);
     string serverStopScript ;
     serverStopScript.append("cd  ").append(snappyHomeDir).append("; ./sbin/snappy-server.sh stop -dir=");
     std::map<std::string, std::string> properties;
     properties.insert(std::pair<std::string, std::string>("load-balance","true"));
-    Connection conn;
+    
     conn.open("localhost", 1527,"app","app",properties);
     std::cout << "before stopping server- connected to :"<< conn.getCurrentHostAddress() <<std::endl;
     // creating dummy data
@@ -47,6 +48,7 @@ int main(int argc, char **argv) {
 
     conn.close();
     } catch (SQLException& sqle) {
+        if(conn.isOpen()) conn.close();
         std::cout<< "ExecuteQuery failed, throws exception"<<std::endl;
         sqle.printStackTrace(std::cout);
     }

--- a/native/tests/unitTest_2.sh
+++ b/native/tests/unitTest_2.sh
@@ -27,11 +27,11 @@ export LD_LIBRARY_PATH
 headerLoc=${_snappyNativeDir}/src/snappyclient/headers
 boostHeadeLoc=${_snappyNativeDir}/dist/boost-${BOOST_VERSION}/include
 
-g++ -std=c++11 -I"${headerLoc}" -I"${boostHeadeLoc}" -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"${_testDir}/unitTest_2.d" -MT"${_testDir}unitTest_2.o" -o "${_testDir}unitTest_2.o" "${_testDir}unitTest.cpp"
+g++ -std=c++11 -I"${headerLoc}" -I"${boostHeadeLoc}" -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"${_testDir}/unitTest_2.d" -MT"${_testDir}unitTest_2.o" -o "${_testDir}unitTest_2.o" "${_testDir}unitTest_2.cpp"
 
 g++ -L${bostLibPath} -L${thrftLibPath} -L${snappClientLibPath} -L${_snappyNativeDir}/Debug -rdynamic -o "${_testDir}unitTest_2"  ${_testDir}unitTest_2.o -lcrypto -lodbc -lpthread -lssl -lsnappydata-native -lboost_chrono -lboost_date_time -lboost_filesystem -lboost_log -lboost_log_setup -lboost_system -lboost_thread -lthrift -lpthread -lrt -lgmp
 
-chmod 777 ${_testDir}unitTest ${_testDir}unitTest.d
+chmod 777 ${_testDir}unitTest_2 ${_testDir}unitTest_2.d
 cd ${_testDir}
 ./unitTest_2 $SNAPPY_HOME_DIR
 

--- a/native/tests/unitTest_2.sh
+++ b/native/tests/unitTest_2.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+_cwd="$2"
+_snappyNativeDir="$(dirname "$_cwd")"
+_testDir=${_snappyNativeDir}/tests/
+#echo "${_snappyNativeDir}"
+distDir=${_snappyNativeDir}/dist
+#echo "${distDir}"
+SNAPPY_HOME_DIR="$1"
+if [ -z ${THRIFT_VERSION} ]; then
+  THRIFT_VERSION=1.0.0-2
+fi
+if [ -z ${BOOST_VERSION} ]; then
+  BOOST_VERSION=1.65.1
+fi
+
+thrftLibPath=${distDir}/thrift-${THRIFT_VERSION}/lin64/lib
+bostLibPath=${distDir}/boost-${BOOST_VERSION}/lin64/lib
+snappClientLibPath=${_snappyNativeDir}/build-artifacts/lin/snappyclient/lin64/lib/debug
+
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${thrftLibPath}:${bostLibPath}:${snappClientLibPath}:${_snappyNativeDir}/Debug#!/bin/sh
+
+#echo "$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH
+
+#echo "${_cwd}"
+headerLoc=${_snappyNativeDir}/src/snappyclient/headers
+boostHeadeLoc=${_snappyNativeDir}/dist/boost-${BOOST_VERSION}/include
+
+g++ -std=c++11 -I"${headerLoc}" -I"${boostHeadeLoc}" -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"${_testDir}/unitTest_2.d" -MT"${_testDir}unitTest_2.o" -o "${_testDir}unitTest_2.o" "${_testDir}unitTest.cpp"
+
+g++ -L${bostLibPath} -L${thrftLibPath} -L${snappClientLibPath} -L${_snappyNativeDir}/Debug -rdynamic -o "${_testDir}unitTest_2"  ${_testDir}unitTest_2.o -lcrypto -lodbc -lpthread -lssl -lsnappydata-native -lboost_chrono -lboost_date_time -lboost_filesystem -lboost_log -lboost_log_setup -lboost_system -lboost_thread -lthrift -lpthread -lrt -lgmp
+
+chmod 777 ${_testDir}unitTest ${_testDir}unitTest.d
+cd ${_testDir}
+./unitTest_2 $SNAPPY_HOME_DIR
+
+rm unitTest_2 unitTest_2.d unitTest_2.o


### PR DESCRIPTION
After adding code for implementing failover functionality, it was not working on the soft kill of the server.
Added code to resolve this issue. The reason behind branch name SNAP-2994-Clean, is that, this issue has been resolved in branch SNAP-2994 and PR has been generated for the same. But by mistake, SNAP-2994 was not created from master, instead was created from SNAP-2591, so changes required to give support for Visual studio 2017 also got pushed in this branch. So I have made a clean branch with SNAP-2994-clean and generating PR for the same. This branch only contains changes for the mentioned issue.