### PR TITLE
[SNAP-3007] Delete without parameters using PreparedStatement fails to remove data

### DIFF
--- a/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientPreparedStatement.java
+++ b/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientPreparedStatement.java
@@ -618,7 +618,6 @@ public class ClientPreparedStatement extends ClientStatement implements
   public void addBatch() throws SQLException {
     checkClosed();
 
-//    if (this.parameterMetaData != null && this.parameterMetaData.size() > 0) {
     if (this.parameterMetaData != null) {
       if (this.paramsBatch == null) {
         this.paramsBatch = new ArrayList<>();

--- a/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientPreparedStatement.java
+++ b/gemfirexd/client/src/main/java/io/snappydata/thrift/internal/ClientPreparedStatement.java
@@ -618,7 +618,8 @@ public class ClientPreparedStatement extends ClientStatement implements
   public void addBatch() throws SQLException {
     checkClosed();
 
-    if (this.parameterMetaData != null && this.parameterMetaData.size() > 0) {
+//    if (this.parameterMetaData != null && this.parameterMetaData.size() > 0) {
+    if (this.parameterMetaData != null) {
       if (this.paramsBatch == null) {
         this.paramsBatch = new ArrayList<>();
       }


### PR DESCRIPTION
## Changes proposed in this pull request

[SNAP-3007]:- Delete all rows using PreparedStatement fails to remove data
Currently io.snappydata.thrift.internal.ClientPreparedStatement#executeBatch executes the prepared statement only if there are parameters. In io.snappydata.thrift.internal.ClientPreparedStatement#addBatch() allowing empty paramsBatch with a paramList to be crated so that  executeBatch executes the statement.

## Patch testing
Added a unit test in BugTest (Snappy repo). Refer to https://github.com/SnappyDataInc/snappydata/pull/1334
precheckin

## ReleaseNotes changes
NA


