### PR TITLE
Allowing NAN values to be displayed

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/BigIntegerDecimal.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/BigIntegerDecimal.java
@@ -90,13 +90,13 @@ public final class BigIntegerDecimal extends BinaryDecimal
     {
 		if (isNull())
 			return 0.0f;
-		return NumberDataType.normalizeREAL(Float.parseFloat(getString()));
+		return NumberDataType.normalizeREALAllowNaN(Float.parseFloat(getString()));
 	}
 	public double getDouble() throws StandardException
     {
 		if (isNull())
 			return 0.0;
-		return NumberDataType.normalizeDOUBLE(Double.parseDouble(getString()));
+		return NumberDataType.normalizeDOUBLEAllowNaN(Double.parseDouble(getString()));
 	}	
 	
     // 0 or null is false, all else is true

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/BinaryDecimal.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/BinaryDecimal.java
@@ -252,7 +252,7 @@ abstract class BinaryDecimal extends NumberDataType
 	 */
 	public final void setValue(double theValue) throws StandardException
 	{
-		setCoreValue(NumberDataType.normalizeDOUBLE(theValue));
+		setCoreValue(NumberDataType.normalizeDOUBLEAllowNaN(theValue));
 	}
 
 	/**
@@ -262,7 +262,7 @@ abstract class BinaryDecimal extends NumberDataType
 	public final void setValue(float theValue)
 		throws StandardException
 	{
-		setCoreValue((double)NumberDataType.normalizeREAL(theValue));
+		setCoreValue((double)NumberDataType.normalizeREALAllowNaN(theValue));
 	}
 	
 	private void setCoreValue(double theValue) throws StandardException {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/DataTypeUtilities.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/DataTypeUtilities.java
@@ -1877,7 +1877,7 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal localValue = SQLDecimal.getAsBigDecimal(inBytes,
             offset, columnWidth);
-        return NumberDataType.normalizeREAL(localValue.floatValue());
+        return NumberDataType.normalizeREALAllowNaN(localValue.floatValue());
       }
       case StoredFormatIds.LONGINT_TYPE_ID:
         return RowFormatter.readLong(inBytes, offset);
@@ -1937,7 +1937,7 @@ public abstract class DataTypeUtilities {
       case StoredFormatIds.DECIMAL_TYPE_ID: {
         final BigDecimal localValue = SQLDecimal.getAsBigDecimal(
             memOffset, columnWidth);
-        return NumberDataType.normalizeREAL(localValue.floatValue());
+        return NumberDataType.normalizeREALAllowNaN(localValue.floatValue());
       }
       case StoredFormatIds.LONGINT_TYPE_ID:
         return RowFormatter.readLong(memOffset);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/NumberDataType.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/NumberDataType.java
@@ -495,6 +495,25 @@ public abstract class NumberDataType extends DataType
 	}
 
 	/**
+	 normalizeREAL checks the validity of the given java float that
+	 it fits within the range of DB2 REALs. In addition it
+	 normalizes the value, so that negative zero (-0.0) becomes positive.
+	 */
+	public static float normalizeREALAllowNaN(float v) throws StandardException
+	{
+		if ( ((v < Limits.DB2_SMALLEST_REAL) || (v > Limits.DB2_LARGEST_REAL)) ||
+				((v > 0) && (v < Limits.DB2_SMALLEST_POSITIVE_REAL)) ||
+				((v < 0) && (v > Limits.DB2_LARGEST_NEGATIVE_REAL)) )
+		{
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME, (String)null);
+		}
+		// Normalize negative floats to be "positive" (can't detect easily without using Float object because -0.0f = 0.0f)
+		if (v == 0.0f) v = 0.0f;
+
+		return v;
+	}
+
+	/**
        normalizeREAL checks the validity of the given java double that
        it fits within the range of DB2 REALs. In addition it
        normalizes the value, so that negative zero (-0.0) becomes positive.
@@ -521,6 +540,31 @@ public abstract class NumberDataType extends DataType
     }
 
 	/**
+	 normalizeREAL checks the validity of the given java double that
+	 it fits within the range of DB2 REALs. In addition it
+	 normalizes the value, so that negative zero (-0.0) becomes positive.
+
+	 The reason for having normalizeREAL with two signatures is to
+	 avoid that normalizeREAL is called with a casted (float)doublevalue,
+	 since this invokes an unwanted rounding (of underflow values to 0.0),
+	 in contradiction to DB2s casting semantics. also allows NAN values
+	 */
+	public static float normalizeREALAllowNaN(double v) throws StandardException
+	{
+		// can't just cast it to float and call normalizeFloat(float) since casting can round down to 0.0
+		if ( ((v < Limits.DB2_SMALLEST_REAL) || (v > Limits.DB2_LARGEST_REAL)) ||
+				((v > 0) && (v < Limits.DB2_SMALLEST_POSITIVE_REAL)) ||
+				((v < 0) && (v > Limits.DB2_LARGEST_NEGATIVE_REAL)) )
+		{
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME, (String)null);
+		}
+		// Normalize negative floats to be "positive" (can't detect easily without using Float object because -0.0f = 0.0f)
+		if (v == 0.0d) v = 0.0d;
+
+		return (float)v;
+	}
+
+	/**
        normalizeDOUBLE checks the validity of the given java double that
        it fits within the range of DB2 DOUBLEs. In addition it
        normalizes the value, so that negative zero (-0.0) becomes positive.
@@ -540,6 +584,23 @@ public abstract class NumberDataType extends DataType
         return v;
 	}
 
+	/**
+	 normalizeDOUBLEAllowNaN checks the validity of the given java double that
+	 it fits within the range of DB2 DOUBLEs. In addition it
+	 normalizes the value, so that negative zero (-0.0) becomes positive.
+	 also allows NAN values
+	 */
+	public static double normalizeDOUBLEAllowNaN(double v) throws StandardException {
+		if (((v < Limits.DB2_SMALLEST_DOUBLE) || (v > Limits.DB2_LARGEST_DOUBLE)) ||
+				((v > 0) && (v < Limits.DB2_SMALLEST_POSITIVE_DOUBLE)) ||
+				((v < 0) && (v > Limits.DB2_LARGEST_NEGATIVE_DOUBLE)) ) {
+			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.DOUBLE_NAME, (String)null);
+		}
+		// Normalize negative doubles to be "positive" (can't detect easily without using Double object because -0.0f = 0.0f)
+		if (v == 0.0d) v = 0.0d;
+
+		return v;
+	}
 
 }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLDecimal.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLDecimal.java
@@ -608,7 +608,7 @@ public final class SQLDecimal extends NumberDataType implements VariableSizeData
 
 		// If the BigDecimal is out of range for the float
 		// then positive or negative infinity is returned.
-		float value = NumberDataType.normalizeREAL(localValue.floatValue());
+		float value = NumberDataType.normalizeREALAllowNaN(localValue.floatValue());
 
 		return value;
 	}
@@ -635,7 +635,7 @@ public final class SQLDecimal extends NumberDataType implements VariableSizeData
 
 	  // If the BigDecimal is out of range for double
 	  // then positive or negative infinity is returned.
-	  double value = NumberDataType.normalizeDOUBLE(localValue.doubleValue());
+	  double value = NumberDataType.normalizeDOUBLEAllowNaN(localValue.doubleValue());
 	  return value;
 	}
 
@@ -1090,7 +1090,7 @@ public final class SQLDecimal extends NumberDataType implements VariableSizeData
 	 */
 	public void setValue(double theValue) throws StandardException
 	{
-		setCoreValue(NumberDataType.normalizeDOUBLE(theValue));
+		setCoreValue(NumberDataType.normalizeDOUBLEAllowNaN(theValue));
 	}
 
 	/**
@@ -1100,7 +1100,7 @@ public final class SQLDecimal extends NumberDataType implements VariableSizeData
 	public void setValue(float theValue)
 		throws StandardException
 	{
-		setCoreValue((double)NumberDataType.normalizeREAL(theValue));
+		setCoreValue((double)NumberDataType.normalizeREALAllowNaN(theValue));
 	}
 
 	/**

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLDouble.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLDouble.java
@@ -334,7 +334,7 @@ public final class SQLDouble extends NumberDataType
             if (isnull)
                 value = 0;
             else 
-                value = NumberDataType.normalizeDOUBLE(dv);
+                value = NumberDataType.normalizeDOUBLEAllowNaN(dv);
 	}
 	/**
 		Set the value into a PreparedStatement.
@@ -377,19 +377,19 @@ public final class SQLDouble extends NumberDataType
 
 	public SQLDouble(double val) throws StandardException
 	{
-		value = NumberDataType.normalizeDOUBLE(val);
+		value = NumberDataType.normalizeDOUBLEAllowNaN(val);
 	}
 
 	public SQLDouble(Double obj) throws StandardException {
 		if (isnull = (obj == null))
             ;
 		else
-			value = NumberDataType.normalizeDOUBLE(obj.doubleValue());
+			value = NumberDataType.normalizeDOUBLEAllowNaN(obj.doubleValue());
 	}
 
 	private SQLDouble(double val, boolean startsnull) throws StandardException
 	{
-		value = NumberDataType.normalizeDOUBLE(val); // maybe only do if !startsnull
+		value = NumberDataType.normalizeDOUBLEAllowNaN(val); // maybe only do if !startsnull
 		isnull = startsnull;
 	}
 
@@ -413,7 +413,7 @@ public final class SQLDouble extends NumberDataType
 			} catch (NumberFormatException nfe) {
 			    throw invalidFormat();
 			}
-			value = NumberDataType.normalizeDOUBLE(doubleValue);
+			value = NumberDataType.normalizeDOUBLEAllowNaN(doubleValue);
 			isnull = false;
 		}
 	}
@@ -423,7 +423,7 @@ public final class SQLDouble extends NumberDataType
 	 */
 	public void setValue(double theValue) throws StandardException
 	{
-		value = NumberDataType.normalizeDOUBLE(theValue);
+		value = NumberDataType.normalizeDOUBLEAllowNaN(theValue);
 		isnull = false;
 	}
 
@@ -432,7 +432,7 @@ public final class SQLDouble extends NumberDataType
 	 */
 	public void setValue(float theValue) throws StandardException
 	{
-		value = NumberDataType.normalizeDOUBLE(theValue);
+		value = NumberDataType.normalizeDOUBLEAllowNaN(theValue);
 		isnull = false;
 	}
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLReal.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLReal.java
@@ -280,7 +280,7 @@ public final class SQLReal
 
         // jsk: should use double? depends on DB2
 		float thisValue = this.getFloat();
-		float otherValue = NumberDataType.normalizeREAL(arg.getFloat()); // could gotten from "any type", may not be a float
+		float otherValue = NumberDataType.normalizeREALAllowNaN(arg.getFloat()); // could gotten from "any type", may not be a float
 
 		if (thisValue == otherValue)
 			return 0;
@@ -371,13 +371,13 @@ public final class SQLReal
 	public SQLReal(float val)
 		throws StandardException
 	{
-		value = NumberDataType.normalizeREAL(val);
+		value = NumberDataType.normalizeREALAllowNaN(val);
 	}
 	public SQLReal(Float obj) throws StandardException {
 		if (isnull = (obj == null))
 			;
 		else {
-			value = NumberDataType.normalizeREAL(obj.floatValue());
+			value = NumberDataType.normalizeREALAllowNaN(obj.floatValue());
 		}
 	}
 
@@ -435,7 +435,7 @@ public final class SQLReal
 	public void setValue(float theValue)
 		throws StandardException
 	{
-		value = NumberDataType.normalizeREAL(theValue);
+		value = NumberDataType.normalizeREALAllowNaN(theValue);
 		isnull = false;
 	}
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/CastNode.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/compile/CastNode.java
@@ -709,7 +709,7 @@ public class CastNode extends ValueNode
 
 			case Types.REAL:
 				nodeType = C_NodeTypes.FLOAT_CONSTANT_NODE;
-				constantObject = new Float(NumberDataType.normalizeREAL(constantValue.getDouble()));
+				constantObject = new Float(NumberDataType.normalizeREALAllowNaN(constantValue.getDouble()));
 				break;
 
 			case Types.DOUBLE:


### PR DESCRIPTION
DESC: select acos(2) should return NAN. When done though jdbc, snappy throws exception that value is out of range of double

## Changes proposed in this pull request
allowing NAN to be set into DVD for float, double, real types

## Patch testing
run with scala tests

## Is precheckin with -Pstore clean?
yes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)
None required

## Other PRs 
None
