### PR TITLE
Fix for SNAP-2999

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/GfxdIndexManager.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/index/GfxdIndexManager.java
@@ -2472,7 +2472,7 @@ public final class GfxdIndexManager implements Dependent, IndexUpdater,
       }      
       
      
-      if (!deleted &&  exceptionToThrow == null) {
+      if (!deleted && exceptionToThrow == null && (rowLocation == null || !rowLocation.isDestroyedOrRemoved())) {
         try {
         handleNotDeleted(event.isPossibleDuplicate(), owner, indexContainer,
             rowLocation, entry, indexKey, firstThrowable);  

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/operations/SortedMap2IndexDeleteOperation.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/operations/SortedMap2IndexDeleteOperation.java
@@ -463,9 +463,13 @@ public final class SortedMap2IndexDeleteOperation extends MemIndexOperation {
       else {
         if (newValues != null) {
           if (index == newLength) {
-            // means that we exhausted all entries without finding the one
-            // to be deleted
-            return null;
+            if (((RowLocation)deletedRow).isDestroyedOrRemoved()) {
+              return newValue;
+            } else {
+              // means that we exhausted all entries without finding the one
+              // to be deleted
+              return null;
+            }
           }
           newValues[index++] = existingRow;
         }
@@ -474,7 +478,7 @@ public final class SortedMap2IndexDeleteOperation extends MemIndexOperation {
         }
       }
     }
-    if (foundDeleted) {
+    if (foundDeleted || ((RowLocation)deletedRow).isDestroyedOrRemoved()) {
       return newValue;
     }
     else {
@@ -524,7 +528,7 @@ public final class SortedMap2IndexDeleteOperation extends MemIndexOperation {
 
     // Rahul: I dont think the following assert is need.
     // assert existingValues.size() >= ROWLOCATION_THRESHOLD;
-    if (!existingValues.remove(deletedRow)) {
+    if (!existingValues.remove(deletedRow) && !((RowLocation)deletedRow).isDestroyedOrRemoved()) {
       return null;
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request

The hydra test fails when the product tries to remove a value corresponding to deleted row from index.  From logs, the value now has become TOMBSTONE and therefore not found in index due concurrent destroy.  Now not failing if value not found in the index has already become TOMBSTONE

For example refer to the message below-

`com.pivotal.gemfirexd.internal.engine.jdbc.GemFireXDRuntimeException: index replace: value to be replaced not found [VersionedLocalRowLocationThinDiskLRURegionEntryHeap@779490d5(key=(397); rawValue=TOMBSTONE; lockState=0x0)] with existing [VersionedLocalRowLocationThinDiskLRURegionEntryHeap@597f6c5b(key=(994); rawValue=(2,0,0,3,-30,0,0,1,90,0,0,0,-80,0,0,2,-59,20,1,78,127,9,104,42,-51,-96,0,0,7,-29,4,30,0,10,14,57,51,-7,-86,0,99,97,110,99,101,108,108,101,100,0,0,0,5,5,9,13,17,28,40,49); lockState=0x0)] for key [tableinfo(true).CompactCompositeIndexKey@62d97ea1=(346)] in: [local-index: TRADE.6__BUYORDERS__CID:base-table:TRADE.BUYORDERS, id: Container(0, 193), isAppTable=false], myID: 10.80.141.115(39788)<v3>:61144`

## Patch testing
Failing hydra tests pass with the patch

## Is precheckin with -Pstore clean?
Yes, no unexpected failures

## ReleaseNotes changes


## Other PRs 
