### PR TITLE
Fix for SNAP-2765

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
@@ -707,16 +707,25 @@ public class GenericStatement
 						qt.bindStatement();
 					}
 					catch(StandardException | AssertFailure ex) {
-				      boolean routeToSnappy = (ex instanceof StandardException && ((StandardException)ex).
-									getMessageId().equals(SQLState.ROW_LEVEL_SECURITY_ENABLED)) ||
-									(routeQuery && !NON_ROUTED_QUERY.matcher(source).find());
+						  boolean isDML = DML_TABLE_PATTERN.matcher(source).find();
+						  String messageId = ex instanceof StandardException ? ((StandardException)ex).getMessageId() : "";
+						  boolean routeToSnappy = messageId.equals(SQLState.ROW_LEVEL_SECURITY_ENABLED) ||
+									(routeQuery && !NON_ROUTED_QUERY.matcher(source).find()
+									// don't route if failure due to error such as invalid column name in prepared statement
+									&& !(isDML && this.isPreparedStatement() &&
+											(messageId.equals(SQLState.LANG_COLUMN_NOT_FOUND_IN_TABLE)
+											|| messageId.equals(SQLState.LANG_DB2_INVALID_COLS_SPECIFIED)
+											|| messageId.equals(SQLState.LANG_DUPLICATE_COLUMN_NAME_INSERT)
+											|| messageId.equals(SQLState.LANG_DUPLICATE_COLUMN_NAME_UPDATE)
+											|| messageId.equals(SQLState.LANG_COLUMN_NOT_FOUND))
+											));
 
 					  if (routeToSnappy) {
 					    if (observer != null) {
 					      observer.testExecutionEngineDecision(qinfo, ExecutionEngine.SPARK, this.statementText);
 					    }
 							return getPreparedStatementForSnappy(true, statementContext, lcc, false,
-							  checkCancellation, DML_TABLE_PATTERN.matcher(source).find(), ex);
+							  checkCancellation, isDML, ex);
 					  }
 					  throw ex;
 					}

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
@@ -711,7 +711,7 @@ public class GenericStatement
 						  String messageId = ex instanceof StandardException ? ((StandardException)ex).getMessageId() : "";
 						  boolean routeToSnappy = messageId.equals(SQLState.ROW_LEVEL_SECURITY_ENABLED) ||
 									(routeQuery && !NON_ROUTED_QUERY.matcher(source).find()
-									// don't route if failure due to error such as invalid column name in prepared statement
+									//SNAP-2765 don't route if failure due to error such as invalid column name in prepared statement
 									&& !(isDML && this.isPreparedStatement() &&
 											(messageId.equals(SQLState.LANG_COLUMN_NOT_FOUND_IN_TABLE)
 											|| messageId.equals(SQLState.LANG_DB2_INVALID_COLS_SPECIFIED)

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/GenericStatement.java
@@ -712,13 +712,7 @@ public class GenericStatement
 						  boolean routeToSnappy = messageId.equals(SQLState.ROW_LEVEL_SECURITY_ENABLED) ||
 									(routeQuery && !NON_ROUTED_QUERY.matcher(source).find()
 									//SNAP-2765 don't route if failure due to error such as invalid column name in prepared statement
-									&& !(isDML && this.isPreparedStatement() &&
-											(messageId.equals(SQLState.LANG_COLUMN_NOT_FOUND_IN_TABLE)
-											|| messageId.equals(SQLState.LANG_DB2_INVALID_COLS_SPECIFIED)
-											|| messageId.equals(SQLState.LANG_DUPLICATE_COLUMN_NAME_INSERT)
-											|| messageId.equals(SQLState.LANG_DUPLICATE_COLUMN_NAME_UPDATE)
-											|| messageId.equals(SQLState.LANG_COLUMN_NOT_FOUND))
-											));
+									&& !(isDML && isPrepStmtInvalidColumnError(messageId)));
 
 					  if (routeToSnappy) {
 					    if (observer != null) {
@@ -1317,6 +1311,15 @@ public class GenericStatement
 
 
 		return preparedStmt;
+	}
+
+	private boolean isPrepStmtInvalidColumnError(String messageId) {
+		return this.isPreparedStatement() &&
+				(messageId.equals(SQLState.LANG_COLUMN_NOT_FOUND_IN_TABLE)
+				|| messageId.equals(SQLState.LANG_DB2_INVALID_COLS_SPECIFIED)
+				|| messageId.equals(SQLState.LANG_DUPLICATE_COLUMN_NAME_INSERT)
+				|| messageId.equals(SQLState.LANG_DUPLICATE_COLUMN_NAME_UPDATE)
+				|| messageId.equals(SQLState.LANG_COLUMN_NOT_FOUND));
 	}
 
 	public boolean invalidQueryOnColumnTable(LanguageConnectionContext _lcc,


### PR DESCRIPTION
## Changes proposed in this pull request

Prepared insert statement that refer to invalid columns (for example columns dropped using alter table command) of table do not error out at prepare time. Instead they fail while setting parameters for the prepared statements with a cryptic error message such as "column position '1' is out of range. The number of columns for this ResultSet is '0'". This is because, the erroneous insert gets routed to lead node on detecting invalid columns. For Snappy at prepare time, only a plan for DMLExternalTable node is created with actual insert query is encapsulated as a command without detecting the issue.

As a fix now not routing such DMLs that contain invalid column names.  

## Patch testing
Unit test is added refer to PR at Snappy layer (https://github.com/SnappyDataInc/snappydata/pull/1359)
Snappy precheckin

## Is precheckin with -Pstore clean?
Snappy precheckin is run as code change affects only snappy layer

## ReleaseNotes changes
NA

## Other PRs 
