### PR TITLE
Don't increment catalog schema version on rebalance

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/control/InternalResourceManager.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/control/InternalResourceManager.java
@@ -340,9 +340,6 @@ public class InternalResourceManager implements ResourceManager {
       RegionFilter filter = new FilterByPath(this.includedRegions, this.excludedRegions);
       RebalanceOperationImpl op = new RebalanceOperationImpl(InternalResourceManager.this.cache, false,filter);
       op.start();
-      // needed for Snappy Spark Smart connector as we cache buckets to server
-      // mapping for tables
-      CallbackFactoryProvider.getStoreCallbacks().registerCatalogSchemaChange();
       return op;
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request
Don't increment catalog schema version on rebalance as discussed in the huddle. SNAP-3025 will be kept open for automatic refresh of bucket to server mapping on smart connector side on rebalance.

## Patch testing
A unit test for query using smart connector after rebalance is added at Snappy layer (https://github.com/SnappyDataInc/snappydata/pull/1363)
Snappy precheckin to be run.

## Is precheckin with -Pstore clean?
Change applicable to Snappy layer only.

## ReleaseNotes changes


## Other PRs 
https://github.com/SnappyDataInc/snappydata/pull/1363

