### PR TITLE
Snap 3053

### DIFF
--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/BufferAllocator.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/BufferAllocator.java
@@ -196,8 +196,10 @@ public abstract class BufferAllocator implements Closeable {
   protected static int expandedSize(int currentUsed, int required) {
     final long minRequired = (long)currentUsed + required;
     // increase the size by 50%
+    //// max word boundary: 2147483640
+    int maxSize = ((Integer.MAX_VALUE - 1)/8)*8;
     final int newLength = (int)Math.min(Math.max((currentUsed * 3) >>> 1L,
-        minRequired), Integer.MAX_VALUE - 1);
+        minRequired), maxSize);
     if (newLength >= minRequired) {
       return newLength;
     } else {

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/BufferAllocator.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/BufferAllocator.java
@@ -197,7 +197,7 @@ public abstract class BufferAllocator implements Closeable {
     final long minRequired = (long)currentUsed + required;
     // increase the size by 50%
     //// max word boundary: 2147483640
-    int maxSize = ((Integer.MAX_VALUE - 7) >>>3) << 3;
+    int maxSize = ((Integer.MAX_VALUE - 7) >>> 3) << 3;
     final int newLength = (int)Math.min(Math.max((currentUsed * 3) >>> 1L,
         minRequired), maxSize);
     if (newLength >= minRequired) {

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/BufferAllocator.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/BufferAllocator.java
@@ -197,7 +197,7 @@ public abstract class BufferAllocator implements Closeable {
     final long minRequired = (long)currentUsed + required;
     // increase the size by 50%
     //// max word boundary: 2147483640
-    int maxSize = ((Integer.MAX_VALUE - 1)/8)*8;
+    int maxSize = ((Integer.MAX_VALUE - 7) >>>3) << 3;
     final int newLength = (int)Math.min(Math.max((currentUsed * 3) >>> 1L,
         minRequired), maxSize);
     if (newLength >= minRequired) {

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
@@ -177,17 +177,11 @@ public abstract class UnsafeHolder {
     return hasUnsafe;
   }
 
-  public static int getAllocationSize(int originalSize) {
+  public static int getAllocationSize(int size) {
     // round to word size
-    int size = ((originalSize + 7) >>> 3) << 3;
+    size = ((size + 7) >>> 3) << 3;
     if (size > 0) return size;
-    else {
-      if (originalSize > 0 && size < 0) {
-        return originalSize;
-      } else {
-        throw new BufferOverflowException();
-      }
-    }
+    else throw new BufferOverflowException();
   }
 
   public static ByteBuffer allocateDirectBuffer(int size,

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
@@ -177,11 +177,17 @@ public abstract class UnsafeHolder {
     return hasUnsafe;
   }
 
-  public static int getAllocationSize(int size) {
+  public static int getAllocationSize(int originalSize) {
     // round to word size
-    size = ((size + 7) >>> 3) << 3;
+    int size = ((originalSize + 7) >>> 3) << 3;
     if (size > 0) return size;
-    else throw new BufferOverflowException();
+    else {
+      if (originalSize > 0 && size < 0) {
+        return originalSize;
+      } else {
+        throw new BufferOverflowException();
+      }
+    }
   }
 
   public static ByteBuffer allocateDirectBuffer(int size,


### PR DESCRIPTION
## Changes proposed in this pull request

The max limit is taken to be less than Integer.MAX_VALUE such that its satisfies 8 byte multiple.
This is needed because if it is Integer.MAX_VALUE -1, then in UnsafeHolder.allocateSize, it is rounded to next multiple of 8, which exceeds Integer.MAX_VALUE & overflows to -ve, throwing unexpected exception.

## Patch testing

(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

[snappydata-pr](https://github.com/SnappyDataInc/snappydata/pull/1366)