### PR TITLE
Fixing [SNAP-2653]

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/sql/dictionary/StatementColumnPermission.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/sql/dictionary/StatementColumnPermission.java
@@ -127,8 +127,7 @@ public class StatementColumnPermission extends StatementTablePermission
                 }
                 // GemStone changes END
 
-		if( hasPermissionOnTable(dd, authorizationId, forGrant) || isSelectOnHiveMetastore
-				(getTableDescriptor(dd)))
+		if( hasPermissionOnTable(dd, authorizationId, forGrant))
 			return;
 		FormatableBitSet permittedColumns = null;
 		if( ! forGrant)

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/sql/dictionary/StatementTablePermission.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/sql/dictionary/StatementTablePermission.java
@@ -134,9 +134,7 @@ public class StatementTablePermission extends StatementPermission
 		throws StandardException
 	{
 		DataDictionary dd = lcc.getDataDictionary();
-	
-		if( ! hasPermissionOnTable( dd, authorizationId, forGrant) && !isSelectOnHiveMetastore
-				(getTableDescriptor(dd)))
+		if(!hasPermissionOnTable( dd, authorizationId, forGrant))
 		{
 			TableDescriptor td = getTableDescriptor( dd);
 			throw StandardException.newException( forGrant ? SQLState.AUTH_NO_TABLE_PERMISSION_FOR_GRANT


### PR DESCRIPTION
* Disallow access non-admin user to the tables in SNAPPY_HIVE_METASTORE.

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

Precheckin in progress

## Is precheckin with -Pstore clean?

Precheckin with -Pstore in progress

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
