### PR TITLE
[SNAP-2976] Transaction state is illegal while ingesting data in a column table

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/GemFireTransaction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/access/GemFireTransaction.java
@@ -2918,8 +2918,12 @@ public final class GemFireTransaction extends RawTransaction implements
       final TXStateInterface gemfireTx = TXManagerImpl.getCurrentSnapshotTXState();
 
       if (tx != null && tx != TXStateProxy.TX_NOT_SET && gemfireTx != tx) {
-        this.txManager.commit(tx, this.connectionID, TXManagerImpl.FULL_COMMIT,
-            null, false);
+        // don't commit as it may have reference to other one whereas gemfire tx is
+        // going to be used.
+        if (gemfireTx == null) {
+          this.txManager.commit(tx, this.connectionID, TXManagerImpl.FULL_COMMIT,
+                  null, false);
+        }
       }
       // now start tx for every operation.
       if (isolationLevel != IsolationLevel.NONE /*|| isSnapshotEnabled()*/) {


### PR DESCRIPTION
Don't commit the tx in GemFireTransaction when snapshot tx is going to be used

In some cases, the tx in GemFireTransaction is still active
and will be committed by client using procedure

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
