### PR TITLE
SNAP-2779 and SNAP-1338 :

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStats.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStats.java
@@ -37,6 +37,8 @@ public class SnappyRegionStats implements VersionedDataSerializable {
   private long totalSize = 0;
   private boolean isReplicatedTable = false;
   private int bucketCount;
+  private int redundancy = 0;
+  private boolean isRedundancyImpaired = false;
 
   public SnappyRegionStats() {
   }
@@ -123,6 +125,22 @@ public class SnappyRegionStats implements VersionedDataSerializable {
     this.bucketCount = bucketCount;
   }
 
+  public int getRedundancy() {
+    return redundancy;
+  }
+
+  public void setRedundancy(int redundancy) {
+    this.redundancy = redundancy;
+  }
+
+  public boolean isRedundancyImpaired() {
+    return isRedundancyImpaired;
+  }
+
+  public void setRedundancyImpaired(boolean redundancyImpaired) {
+    isRedundancyImpaired = redundancyImpaired;
+  }
+
   public SnappyRegionStats getCombinedStats(SnappyRegionStats stats) {
     String tableName = this.isColumnTable ? stats.tableName : this.tableName;
     SnappyRegionStats combinedStats = new SnappyRegionStats(tableName);
@@ -139,6 +157,8 @@ public class SnappyRegionStats implements VersionedDataSerializable {
     combinedStats.setColumnTable(this.isColumnTable || stats.isColumnTable);
     combinedStats.setReplicatedTable(this.isReplicatedTable());
     combinedStats.setBucketCount(this.bucketCount);
+    combinedStats.setRedundancy(this.redundancy);
+    combinedStats.setRedundancyImpaired(this.isRedundancyImpaired);
     return combinedStats;
   }
 
@@ -163,6 +183,8 @@ public class SnappyRegionStats implements VersionedDataSerializable {
     toDataPre_STORE_1_6_2_0(out);
     out.writeInt(bucketCount);
     out.writeLong(sizeSpillToDisk);
+    out.writeInt(redundancy);
+    out.writeBoolean(isRedundancyImpaired);
   }
 
   public void fromDataPre_STORE_1_6_2_0(DataInput in) throws IOException {
@@ -179,6 +201,8 @@ public class SnappyRegionStats implements VersionedDataSerializable {
     fromDataPre_STORE_1_6_2_0(in);
     this.bucketCount = in.readInt();
     this.sizeSpillToDisk = in.readLong();
+    this.redundancy = in.readInt();
+    this.isRedundancyImpaired = in.readBoolean();
   }
 
   @Override
@@ -186,6 +210,7 @@ public class SnappyRegionStats implements VersionedDataSerializable {
     return "RegionStats for " + tableName + ": totalSize=" + totalSize +
         " sizeInMemory=" + sizeInMemory + " sizeSpillToDisk=" + sizeSpillToDisk +
         " rowCount=" + rowCount + " isColumnTable=" + isColumnTable + " isReplicatedTable=" +
-        isReplicatedTable + " bucketCount=" + bucketCount;
+        isReplicatedTable + " bucketCount=" + bucketCount + " redundancy=" + redundancy
+        + " isRedundancyImpaired=" + isRedundancyImpaired;
   }
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStats.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStats.java
@@ -39,6 +39,7 @@ public class SnappyRegionStats implements VersionedDataSerializable {
   private int bucketCount;
   private int redundancy = 0;
   private boolean isRedundancyImpaired = false;
+  private boolean isAnyBucketLost = false;
 
   public SnappyRegionStats() {
   }
@@ -141,6 +142,14 @@ public class SnappyRegionStats implements VersionedDataSerializable {
     isRedundancyImpaired = redundancyImpaired;
   }
 
+  public boolean isAnyBucketLost() {
+    return isAnyBucketLost;
+  }
+
+  public void setAnyBucketLost(boolean anyBucketLost) {
+    isAnyBucketLost = anyBucketLost;
+  }
+
   public SnappyRegionStats getCombinedStats(SnappyRegionStats stats) {
     String tableName = this.isColumnTable ? stats.tableName : this.tableName;
     SnappyRegionStats combinedStats = new SnappyRegionStats(tableName);
@@ -159,6 +168,7 @@ public class SnappyRegionStats implements VersionedDataSerializable {
     combinedStats.setBucketCount(this.bucketCount);
     combinedStats.setRedundancy(this.redundancy);
     combinedStats.setRedundancyImpaired(this.isRedundancyImpaired);
+    combinedStats.setAnyBucketLost(this.isAnyBucketLost);
     return combinedStats;
   }
 
@@ -185,6 +195,7 @@ public class SnappyRegionStats implements VersionedDataSerializable {
     out.writeLong(sizeSpillToDisk);
     out.writeInt(redundancy);
     out.writeBoolean(isRedundancyImpaired);
+    out.writeBoolean(isAnyBucketLost);
   }
 
   public void fromDataPre_STORE_1_6_2_0(DataInput in) throws IOException {
@@ -203,6 +214,7 @@ public class SnappyRegionStats implements VersionedDataSerializable {
     this.sizeSpillToDisk = in.readLong();
     this.redundancy = in.readInt();
     this.isRedundancyImpaired = in.readBoolean();
+    this.isAnyBucketLost = in.readBoolean();
   }
 
   @Override
@@ -211,6 +223,6 @@ public class SnappyRegionStats implements VersionedDataSerializable {
         " sizeInMemory=" + sizeInMemory + " sizeSpillToDisk=" + sizeSpillToDisk +
         " rowCount=" + rowCount + " isColumnTable=" + isColumnTable + " isReplicatedTable=" +
         isReplicatedTable + " bucketCount=" + bucketCount + " redundancy=" + redundancy
-        + " isRedundancyImpaired=" + isRedundancyImpaired;
+        + " isRedundancyImpaired=" + isRedundancyImpaired + " isAnyBucketLost=" + isAnyBucketLost;
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request

 - Adding Redundancy and isRedundancyImpaired variables to maintain details of count of redundancy
   copies and redundancy satisfaction/broken status.

## Patch testing

 - Tested manually

## Is precheckin with -Pstore clean?

 - Ran precheckin and no relevant failure found.

## ReleaseNotes changes

 - Yes, to be updated

## Other PRs 

 **Spark:** https://github.com/SnappyDataInc/spark/pull/160
 **SnappyData:** https://github.com/SnappyDataInc/snappydata/pull/1373


