### PR TITLE
Snap 2502

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketPersistenceAdvisor.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketPersistenceAdvisor.java
@@ -225,10 +225,14 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
         }
         
         Set<PersistentMemberID> membersToWaitFor = getPersistedMembers();
-        
+
         if(!membersToWaitFor.isEmpty()) {
           try {
             listener.waitForChange(membersToWaitFor, membersToWaitFor);
+
+            if (memberManager.unblockNonHostingBuckets()) {
+              break;
+            }
           } catch (InterruptedException e) {
             interrupted = true;
           }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketPersistenceAdvisor.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketPersistenceAdvisor.java
@@ -229,7 +229,7 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
         if(!membersToWaitFor.isEmpty()) {
           try {
             listener.waitForChange(membersToWaitFor, membersToWaitFor);
-
+            // for non redundant case, if unblock is executed by user then don't wait
             if (memberManager.unblockNonHostingBuckets()) {
               break;
             }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -235,6 +235,8 @@ public class LocalRegion extends AbstractRegion
 
   public volatile boolean isDestroyed = false;
 
+  public volatile GemFireException daeException;
+
   // In case of parallel wan, when a destroy is called on userPR, it waits for
   // parallelQueue to drain and then destroys paralleQueue. In this time if
   // operation like put happens on userPR then it will keep on building parallel
@@ -7881,6 +7883,7 @@ public class LocalRegion extends AbstractRegion
           // unhooking this region from the parent subregion map, and
           // sending listener events
           Assert.assertTrue(this.isDestroyed);
+          this.daeException = event.getDiskException();
           
           /**
            * Added for M&M : At this point we can safely call ResourceEvent
@@ -9364,6 +9367,9 @@ public class LocalRegion extends AbstractRegion
         ex = new RegionReinitializedException(toString(), getFullPath());
       } else if (this.cache.isCacheAtShutdownAll()) {
         throw new CacheClosedException("Cache is being closed by ShutdownAll");
+      }
+      else if(daeException != null) {
+        throw daeException;
       }
       else {
         ex = new RegionDestroyedException(toString(), getFullPath());

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -235,7 +235,7 @@ public class LocalRegion extends AbstractRegion
 
   public volatile boolean isDestroyed = false;
 
-  public volatile GemFireException daeException;
+  public volatile GemFireException diskConflictingException;
 
   // In case of parallel wan, when a destroy is called on userPR, it waits for
   // parallelQueue to drain and then destroys paralleQueue. In this time if
@@ -7883,7 +7883,7 @@ public class LocalRegion extends AbstractRegion
           // unhooking this region from the parent subregion map, and
           // sending listener events
           Assert.assertTrue(this.isDestroyed);
-          this.daeException = event.getDiskException();
+          this.diskConflictingException = event.getDiskException();
           
           /**
            * Added for M&M : At this point we can safely call ResourceEvent
@@ -9368,8 +9368,8 @@ public class LocalRegion extends AbstractRegion
       } else if (this.cache.isCacheAtShutdownAll()) {
         throw new CacheClosedException("Cache is being closed by ShutdownAll");
       }
-      else if(daeException != null) {
-        throw daeException;
+      else if(diskConflictingException != null) {
+        throw diskConflictingException;
       }
       else {
         ex = new RegionDestroyedException(toString(), getFullPath());

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PRHARedundancyProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PRHARedundancyProvider.java
@@ -1858,13 +1858,14 @@ public class PRHARedundancyProvider
               try {
                 super.run();
               } finally {
+                getLogger().info(LocalizedStrings.DEBUG, "CountDown the allBucketRecovery.");
                 allBucketsRecoveredFromDisk.countDown();
               }
             }
 
             @Override
             public void run2() {
-                proxyBucket.recoverFromDiskRecursively();
+                proxyBucket.recoverFromDiskRecursively(allBucketsRecoveredFromDisk);
             }
           };
           Thread recoveryThread = new Thread(recoveryRunnable, "Recovery thread for bucket " + proxyBucket.getName());
@@ -1884,7 +1885,7 @@ public class PRHARedundancyProvider
           proxyBucket.waitForPrimaryPersistentRecovery();
         }
         for(final ProxyBucketRegion proxyBucket : bucketsNotHostedLocally) {
-          proxyBucket.recoverFromDiskRecursively();
+          proxyBucket.recoverFromDiskRecursively(allBucketsRecoveredFromDisk);
         }
       } finally {
         for(final ProxyBucketRegion proxyBucket : bucketsNotHostedLocally) {

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PRHARedundancyProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PRHARedundancyProvider.java
@@ -111,7 +111,7 @@ public class PRHARedundancyProvider
   private final Object shutdownLock = new Object();
   private boolean shutdown = false;
   
-  volatile CountDownLatch allBucketsRecoveredFromDisk;
+  volatile CountDownLatch allBucketsRecoveredFromDiskLatch;
   
   /**
    * Used to consolidate logging for bucket regions waiting on other
@@ -1815,7 +1815,7 @@ public class PRHARedundancyProvider
     /*
      * Start the redundancy logger before recovering any proxy buckets.
      */
-      allBucketsRecoveredFromDisk = new CountDownLatch(proxyBucketArray.length);
+      allBucketsRecoveredFromDiskLatch = new CountDownLatch(proxyBucketArray.length);
       try {
         if(proxyBucketArray.length > 0) {
           this.redundancyLogger = new RedundancyLogger(this);
@@ -1823,7 +1823,7 @@ public class PRHARedundancyProvider
           loggingThread.start();
         }    
       } catch(RuntimeException e) {
-        allBucketsRecoveredFromDisk = null;
+        allBucketsRecoveredFromDiskLatch = null;
         throw e;
       }
       /*
@@ -1858,13 +1858,13 @@ public class PRHARedundancyProvider
               try {
                 super.run();
               } finally {
-                allBucketsRecoveredFromDisk.countDown();
+                allBucketsRecoveredFromDiskLatch.countDown();
               }
             }
 
             @Override
             public void run2() {
-                proxyBucket.recoverFromDiskRecursively(allBucketsRecoveredFromDisk);
+                proxyBucket.recoverFromDiskRecursively(allBucketsRecoveredFromDiskLatch);
             }
           };
           Thread recoveryThread = new Thread(recoveryRunnable, "Recovery thread for bucket " + proxyBucket.getName());
@@ -1884,11 +1884,11 @@ public class PRHARedundancyProvider
           proxyBucket.waitForPrimaryPersistentRecovery();
         }
         for(final ProxyBucketRegion proxyBucket : bucketsNotHostedLocally) {
-          proxyBucket.recoverFromDiskRecursively(allBucketsRecoveredFromDisk);
+          proxyBucket.recoverFromDiskRecursively(allBucketsRecoveredFromDiskLatch);
         }
       } finally {
         for(final ProxyBucketRegion proxyBucket : bucketsNotHostedLocally) {
-          allBucketsRecoveredFromDisk.countDown();
+          allBucketsRecoveredFromDiskLatch.countDown();
         }
       }
       
@@ -2109,7 +2109,7 @@ public class PRHARedundancyProvider
    * or for the region to be closed, whichever happens first.
    */
   protected void waitForPersistentBucketRecoveryOrClose() {
-    CountDownLatch recoveryLatch = allBucketsRecoveredFromDisk;
+    CountDownLatch recoveryLatch = allBucketsRecoveredFromDiskLatch;
     if(recoveryLatch != null) {
       boolean interrupted =  false;
       while (true) {
@@ -2141,7 +2141,7 @@ public class PRHARedundancyProvider
    * regardless of whether the region is currently being closed.
    */
   protected void waitForPersistentBucketRecovery() {
-    CountDownLatch recoveryLatch = allBucketsRecoveredFromDisk;
+    CountDownLatch recoveryLatch = allBucketsRecoveredFromDiskLatch;
     if(recoveryLatch != null) {
       boolean interrupted =  false;
       while (true) {
@@ -2163,8 +2163,8 @@ public class PRHARedundancyProvider
       return false;
     }
     
-    if(allBucketsRecoveredFromDisk != null
-        && allBucketsRecoveredFromDisk.getCount() > 0) {
+    if(allBucketsRecoveredFromDiskLatch != null
+        && allBucketsRecoveredFromDiskLatch.getCount() > 0) {
       return false;
     }
     
@@ -2172,8 +2172,8 @@ public class PRHARedundancyProvider
     
     for(PartitionedRegion region : colocatedRegions.values()) {
       PRHARedundancyProvider redundancyProvider = region.getRedundancyProvider();
-      if(redundancyProvider.allBucketsRecoveredFromDisk != null
-          && redundancyProvider.allBucketsRecoveredFromDisk.getCount() > 0) {
+      if(redundancyProvider.allBucketsRecoveredFromDiskLatch != null
+          && redundancyProvider.allBucketsRecoveredFromDiskLatch.getCount() > 0) {
         return false;
       }
     }
@@ -2451,6 +2451,6 @@ public class PRHARedundancyProvider
   }
 
   public CountDownLatch getAllBucketsRecoveredFromDiskLatch() {
-    return allBucketsRecoveredFromDisk;
+    return allBucketsRecoveredFromDiskLatch;
   }
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PRHARedundancyProvider.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PRHARedundancyProvider.java
@@ -1858,7 +1858,6 @@ public class PRHARedundancyProvider
               try {
                 super.run();
               } finally {
-                getLogger().info(LocalizedStrings.DEBUG, "CountDown the allBucketRecovery.");
                 allBucketsRecoveredFromDisk.countDown();
               }
             }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyBucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyBucketRegion.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.gemstone.gemfire.CancelCriterion;
@@ -421,8 +422,8 @@ public final class ProxyBucketRegion implements Bucket {
     }
   }
   
-  public void recoverFromDiskRecursively() {
-    recoverFromDisk();
+  public void recoverFromDiskRecursively(CountDownLatch bucketReceoverLatch) {
+    recoverFromDisk(bucketReceoverLatch);
     
     List<PartitionedRegion> colocatedWithList = ColocationHelper.getColocatedChildRegions(partitionedRegion);
     for(PartitionedRegion childPR : colocatedWithList) {
@@ -430,13 +431,13 @@ public final class ProxyBucketRegion implements Bucket {
         ProxyBucketRegion[] childBucketArray = childPR.getRegionAdvisor().getProxyBucketArray();
         if(childBucketArray != null) {
           ProxyBucketRegion childBucket = childBucketArray[getBucketId()];
-          childBucket.recoverFromDisk();
+          childBucket.recoverFromDisk(bucketReceoverLatch);
         }
       }
     }
   }
 
-  public void recoverFromDisk() {
+  public void recoverFromDisk(CountDownLatch bucketReceoverLatch) {
     LogWriterI18n logger = partitionedRegion.getLogWriterI18n();
     RuntimeException exception = null;
     if(logger.fineEnabled()) {
@@ -504,6 +505,10 @@ public final class ProxyBucketRegion implements Bucket {
       
       persistenceAdvisor.initializeMembershipView();
     } catch (DiskAccessException dae) {
+      // count down to make sure that if region is destroyed
+      // it doesn't wait for bucket recovery to finish.
+      bucketReceoverLatch.countDown();
+      // we will be closing this region and cache.
       this.partitionedRegion.handleDiskAccessException(dae, true);
       throw dae;
     }
@@ -511,6 +516,7 @@ public final class ProxyBucketRegion implements Bucket {
       exception=e;
       throw e;
     } finally {
+      partitionedRegion.getLogWriterI18n().info(LocalizedStrings.DEBUG, "SK RecoveryDonw for butcket " + getBucketId());
       persistenceAdvisor.recoveryDone(exception);
     }
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyBucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/ProxyBucketRegion.java
@@ -516,7 +516,6 @@ public final class ProxyBucketRegion implements Bucket {
       exception=e;
       throw e;
     } finally {
-      partitionedRegion.getLogWriterI18n().info(LocalizedStrings.DEBUG, "SK RecoveryDonw for butcket " + getBucketId());
       persistenceAdvisor.recoveryDone(exception);
     }
   }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/PersistenceAdvisorImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/PersistenceAdvisorImpl.java
@@ -1274,6 +1274,8 @@ public class PersistenceAdvisorImpl implements PersistenceAdvisor {
         try {
           setWaitingOnMembers(allMembersToWaitFor, offlineMembersToWaitFor);
           while(!membershipChanged && !isClosed && !doNotWait) {
+            // In case bucket is not hosted here, persistent id will be null
+            // if unblock is executed by user then don't wait
             if (getPersistentID() == null) {
               if (memberManager.unblockNonHostingBuckets())
                 doNotWait = true;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/PersistenceAdvisorImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/PersistenceAdvisorImpl.java
@@ -92,7 +92,7 @@ public class PersistenceAdvisorImpl implements PersistenceAdvisor {
   private boolean IGNORE_CONFLICTING_PERSISTENT_DISK_STORE_CHECK = Boolean.getBoolean(
           "gemfire.IGNORE_CONFLICTING_PERSISTENT_DISK_STORES");
 
-  public static final boolean TRACE = true;//Boolean.getBoolean("gemfire.TRACE_PERSISTENCE_ADVISOR");
+  public static final boolean TRACE = Boolean.getBoolean("gemfire.TRACE_PERSISTENCE_ADVISOR");
   
   public PersistenceAdvisorImpl(CacheDistributionAdvisor advisor, DistributedLockService dl, PersistentMemberView storage, String regionPath, DiskRegionStats diskStats, PersistentMemberManager memberManager) {
     this.advisor = advisor;
@@ -137,9 +137,6 @@ public class PersistenceAdvisorImpl implements PersistenceAdvisor {
     }
     
     advisor.addProfileChangeListener(listener);
-
-    advisor.getLogWriter().info(LocalizedStrings.DEBUG, "addign revocationListerner " + listener +
-            " for " +advisor.getAdvisee().getFullPath());
     Set<PersistentMemberPattern> revokedMembers = this.memberManager.addRevocationListener(listener, storage.getRevokedMembers());
 
     for(PersistentMemberPattern pattern : revokedMembers) {
@@ -1275,9 +1272,7 @@ public class PersistenceAdvisorImpl implements PersistenceAdvisor {
       boolean warned = false;
       synchronized(this) {
         try {
-          advisor.getLogWriter().info(LocalizedStrings.DEBUG, " Going to wait for ALL " + allMembersToWaitFor + " offline " + offlineMembersToWaitFor);
           setWaitingOnMembers(allMembersToWaitFor, offlineMembersToWaitFor);
-
           while(!membershipChanged && !isClosed && !doNotWait) {
             if (getPersistentID() == null) {
               if (memberManager.unblockNonHostingBuckets())
@@ -1422,12 +1417,10 @@ public class PersistenceAdvisorImpl implements PersistenceAdvisor {
     @Override
     public void addPersistentIDs(Set<PersistentMemberID> localData) {
       PersistentMemberID id = getPersistentID();
-      advisor.getLogWriter().info(LocalizedStrings.DEBUG, "The ids are " + id);
       if(id != null) {
         localData.add(id);
       }
       id = getInitializingID();
-      advisor.getLogWriter().info(LocalizedStrings.DEBUG, "The initialized ids are " + id);
       if(id != null) {
         localData.add(id);
       }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -2686,7 +2686,7 @@ public class GfxdSystemProcedures extends SystemProcedures {
     context.setSnapshotTXState(state);
     tc.setActiveTXState(state, false);
     // If already then throw exception?
-    if (GemFireXDUtils.TraceProcedureExecution) {
+    if (GemFireXDUtils.TraceExecution) {
       SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_EXECUTION,
           "In useSnapshotTXId() for txid " + txId1 +
               " txState : " + state + " connId" + tc.getConnectionID());

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/recovery/RecoverConflictingDiskStoreDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/recovery/RecoverConflictingDiskStoreDUnit.java
@@ -1,0 +1,201 @@
+package com.pivotal.gemfirexd.recovery;
+
+import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
+import com.gemstone.gemfire.internal.cache.persistence.PersistentMemberID;
+import com.gemstone.gemfire.internal.cache.persistence.PersistentMemberManager;
+import com.gemstone.gemfire.internal.cache.persistence.PersistentMemberPattern;
+import com.pivotal.gemfirexd.DistributedSQLTestBase;
+import com.pivotal.gemfirexd.TestUtil;
+import com.pivotal.gemfirexd.internal.engine.Misc;
+import io.snappydata.test.dunit.SerializableCallable;
+import io.snappydata.test.dunit.SerializableRunnable;
+import io.snappydata.test.dunit.VM;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+public class RecoverConflictingDiskStoreDUnit extends DistributedSQLTestBase {
+
+    protected File diskDir;
+
+    public RecoverConflictingDiskStoreDUnit(String name) {
+        super(name);
+    }
+
+    protected static final int MAX_WAIT = 60 * 1000;
+
+    @Override
+    protected String reduceLogging() {
+        return "fine";
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void tearDown2() throws Exception {
+        super.tearDown2();
+    }
+
+    @Override
+    protected void setOtherCommonProperties(Properties props, int mcastPort,
+                                            String serverGroups) {
+        System.setProperty("gemfire.DISALLOW_CLUSTER_RESTART_CHECK", "true");
+        System.setProperty("gemfire.IGNORE_CONFLICTING_PERSISTENT_DISK_STORES", "true");
+
+    }
+
+    public void testWaitForLatestMember22() throws Exception {
+        Properties p = new Properties();
+        p.setProperty("default-recovery-delay", "-1");
+        p.setProperty("default-startup-recovery-delay", "-1");
+        startVMs(1, 2, 0, null, p);
+        Properties props = new Properties();
+        final Connection conn = TestUtil.getConnection(props);
+        Statement st1 = conn.createStatement();
+        VM server1 = this.serverVMs.get(0);
+        VM server2 = this.serverVMs.get(1);
+
+
+        st1.execute("DROP TABLE IF EXISTS T1");
+        //st1.execute("CREATE TABLE T1 (COL1 int, COL2 int) partition by column (COL1) persistent redundancy 2 buckets 1");
+        st1.execute("CREATE TABLE T1 (COL1 int, COL2 int) persistent redundancy 1 buckets 2");
+
+        for (int i = 0; i < 10; i++) {
+            st1.execute("INSERT INTO T1 values(" + i + "," + i + ")");
+        }
+
+        stopVMNum(-1);
+
+        for (int i = 10; i < 20; i++) {
+            st1.execute("INSERT INTO T1 values(" + i + "," + i + ")");
+        }
+
+        stopVMNum(-2);
+
+        Thread t = new Thread(
+                new SerializableRunnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            restartVMNums(new int[]{-1}, 0, null, p);
+                        } catch (Exception e) {
+                            getLogWriter().info("Got exception while restarting server1");
+                            e.printStackTrace();
+                        }
+                    }
+                });
+        t.start();
+        assertTrue(t.isAlive());
+
+        getLogWriter().info("Going to wait for initialization. ");
+        waitForBlockedInitialization(server1);
+
+        server1.invoke(
+                new SerializableCallable() {
+                    @Override
+                    public Object call() throws Exception {
+                        GemFireCacheImpl cache = Misc.getGemFireCache();
+                        PersistentMemberManager pmm = cache.getPersistentMemberManager();
+                        Map<String, Set<PersistentMemberID>> regions = pmm.getWaitingRegions();
+                        getLogWriter().info("Waiting regions are " + regions);
+                        Set<PersistentMemberID> ids = pmm.getWaitingIds();
+                        getLogWriter().info("Waiting ids are " + ids);
+                        pmm.unblockMemberForPattern(new PersistentMemberPattern(ids.iterator().next()));
+                        return null;
+                    }
+                }
+        );
+        t.join();
+
+        getLogWriter().info("After server1 restart.");
+
+        ResultSet rs = st1.executeQuery("select * from T1");
+        int count = 0;
+        while (rs.next()) {
+            getLogWriter().info("The value is " + rs.getInt(1) + " " + rs.getInt(2));
+            count++;
+        }
+        assertEquals(10, count);
+
+        for (int i = 20; i < 30; i++) {
+            st1.execute("INSERT INTO T1 values(" + i + "," + i + ")");
+        }
+
+        stopVMNum(-1);
+
+        restartVMNums(new int[]{-2}, 0, null, p);
+        getLogWriter().info("After server2 restart.");
+
+        rs = st1.executeQuery("select * from T1");
+        count = 0;
+        while (rs.next()) {
+            getLogWriter().info("The value is " + rs.getInt(1) + " " + rs.getInt(2));
+            count++;
+        }
+        assertEquals(20, count);
+
+        restartVMNums(new int[]{-1}, 0, null, p);
+
+        rs = st1.executeQuery("select * from T1");
+        count = 0;
+        while (rs.next()) {
+            getLogWriter().info("The value is " + rs.getInt(1) + " " + rs.getInt(2));
+            count++;
+        }
+        assertEquals(20, count);
+
+
+        stopVMNum(-2);
+        stopVMNum(-1);
+
+        restartVMNums(new int[]{-1}, 0, null, p);
+        restartVMNums(new int[]{-2}, 0, null, p);
+
+        rs = st1.executeQuery("select * from T1");
+        count = 0;
+        while (rs.next()) {
+            getLogWriter().info("The value is " + rs.getInt(1) + " " + rs.getInt(2));
+            count++;
+        }
+        assertEquals(20, count);
+
+
+    }
+
+
+    protected void waitForBlockedInitialization(VM vm) {
+        vm.invoke(new SerializableRunnable() {
+
+            public void run() {
+                waitForCriterion(new WaitCriterion() {
+
+                    public String description() {
+                        return "Waiting for another persistent member to come online";
+                    }
+
+                    public boolean done() {
+                        GemFireCacheImpl cache = Misc.getGemFireCacheNoThrow();
+                        if (cache != null) {
+                            PersistentMemberManager mm = cache.getPersistentMemberManager();
+                            Map<String, Set<PersistentMemberID>> regions = mm.getWaitingRegions();
+                            boolean done = !regions.isEmpty();
+                            return done;
+                        } else {
+                            return false;
+                        }
+
+                    }
+
+                }, MAX_WAIT, 100, true);
+            }
+        });
+    }
+
+}

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/recovery/RecoverConflictingDiskStoreDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/recovery/RecoverConflictingDiskStoreDUnit.java
@@ -32,7 +32,7 @@ public class RecoverConflictingDiskStoreDUnit extends DistributedSQLTestBase {
 
     @Override
     protected String reduceLogging() {
-        return "fine";
+        return "config";
     }
 
     @Override
@@ -52,7 +52,20 @@ public class RecoverConflictingDiskStoreDUnit extends DistributedSQLTestBase {
 
     }
 
-    public void testWaitForLatestMember22() throws Exception {
+    // 2 server, 1 table with redundancy and Some insert
+    // server1 down
+    // more insert
+    // server2 down
+    // server1 up, which will wait
+    // force start server1
+    // some insert (conflcting data)
+    // server1 down
+    // server2 up, it will start without wait
+    // server1 start, will fail with conflictingdiskexception in normal case
+    // with the flag it will start and do GII from server1
+    // conflicting data will be lost
+
+    public void testForceStartOneServerAndIgnoreConflictingDiskStoreDataLoss() throws Exception {
         Properties p = new Properties();
         p.setProperty("default-recovery-delay", "-1");
         p.setProperty("default-startup-recovery-delay", "-1");
@@ -168,6 +181,11 @@ public class RecoverConflictingDiskStoreDUnit extends DistributedSQLTestBase {
         assertEquals(20, count);
     }
 
+    /**
+     * Same as above test except that this has one more table which doesn't do any operation when a node is down
+     * When everythign is up, it shouldn't lose any data.
+     * @throws Exception
+     */
 
 
     public void testUnlrelatedTableForLatestMember22() throws Exception {


### PR DESCRIPTION
## Changes proposed in this pull request
Avoid the ConflictingDiskStoreException and let the recovery continue with the local disk data.
Ensure that, Tables with 0 redundancy can be recovered independently with unblock.
Tested the scenarios where recovery can lead to partial data loss in one of the table but other tables which did not have any updates during node down can recover all data.

This feature is only for last resort when user cant bring the cluster up and is sure that no external members were added in the cluster while some were down.

Has to be used with care.

In case a cluster is down due to user shutdown or crash and on restart some servers don't start complaining ConflictingPersistentDataException. It is recommended that, user starts ALL members of the cluster.
For the members, that are waiting for data from other members with the message "It is waiting for another member to recover the latest data." start them using the command

./bin/snappy unblock-disk-store <diskID of the waiting server> <locator>

This will let the cluster start with partial data. No user operation should take place on the cluster with partial data.
After this, for all the servers that are not starting with the exception: ConflictingPersistentDataException,
please add -J-Dgemfire.IGNORE_CONFLICTING_PERSISTENT_DISK_STORES=true in the conf file of that server and start them.

This will allow the server to start with the data it had locally and will do GII from any copies already available in the cluster.

Once the cluster is started, the system property can be removed from the conf file.

# Patch testing

(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
