### PR TITLE
some changes for use of reserveSpace boolean

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
@@ -275,11 +275,11 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
 
   // extra reserved space to be freed when standby oplog is in use,
   // so that renaming of standby oplog, & creation of krf idxkrf etc is successful
-  // This is to be specified in MB & default is 256 , i.e 256 MB
-  private static int extraReservedSpace = Integer.getInteger("gemfire.EXTRA_RESERVED_SPACE", 256);
+  // This is to be specified in MB & default is 10 , i.e 10 MB
+  private static int extraReservedSpace = Integer.getInteger("gemfire.EXTRA_RESERVED_SPACE", 10);
 
   // Property to switch off reserving space in unit tests and hydra
-  public static boolean reserveSpace = !Boolean.getBoolean("gemfire.DISALLOW_RESERVE_SPACE");
+  private static boolean reserveSpace = !Boolean.getBoolean("gemfire.DISALLOW_RESERVE_SPACE");
 
   // //////////////////// Instance Fields ///////////////////////
 
@@ -544,36 +544,30 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
         tempMaxDirSize = dirSizes[i];
       }
     }
+
+    this.deleteFiles((File parent, String fileName) ->
+      fileName.equals(standByFileName + ".crf")
+        || fileName.equals(standByFileName + ".drf")
+        || fileName.equals(extraReservedSpaceFileName + ".oplog"));
+
+
+    this.standbyCrfSize = (long)(maxOplogSizeInBytes * (crfPct / 100.0));
+    this.standbyDrfSize = maxOplogSizeInBytes - this.standbyCrfSize;
+    // now create the stand by oplog file space in the 0th directory
+
+    this.standByCrf = new Oplog.OplogFile();
+    this.standByDrf = new Oplog.OplogFile();
+    File crfFile = new File(dirs[0], standByFileName + ".crf");
+    File drfFile = new File(dirs[0], standByFileName + ".drf");
+
+
+    // preblow the file
+    this.standByCrf.f = crfFile;
+    this.standByDrf.f = drfFile;
+    File extraSpaceFile = new File(dirs[0], extraReservedSpaceFileName + ".oplog");
+    this.extraSpaceReservedFile = new Oplog.OplogFile();
+    this.extraSpaceReservedFile.f = extraSpaceFile;
     if (reserveSpace) {
-      // first delete any existing stand by oplog file in any of the disk dirs.
-      for (File dir: dirs) {
-        if (dir.exists() && reserveSpace) {
-          File []  standByOplogFiles = dir.listFiles((File parent, String fileName) ->
-                  fileName.equals(standByFileName + ".crf")
-                          || fileName.equals(standByFileName + ".drf")
-                          || fileName.equals(extraReservedSpaceFileName + ".oplog"));
-          for ( File f: standByOplogFiles) {
-            f.delete();
-          }
-        }
-      }
-
-      this.standbyCrfSize = (long) (maxOplogSizeInBytes * (crfPct / 100.0));
-      this.standbyDrfSize = maxOplogSizeInBytes - this.standbyCrfSize;
-      // now create the stand by oplog file space in the 0th directory
-
-      this.standByCrf = new Oplog.OplogFile();
-      this.standByDrf = new Oplog.OplogFile();
-      File crfFile = new File(dirs[0], standByFileName + ".crf");
-      File drfFile = new File(dirs[0], standByFileName + ".drf");
-
-
-      // preblow the file
-      this.standByCrf.f = crfFile;
-      this.standByDrf.f = drfFile;
-      File extraSpaceFile = new File(dirs[0], extraReservedSpaceFileName + ".oplog");
-      this.extraSpaceReservedFile = new Oplog.OplogFile();
-      this.extraSpaceReservedFile.f = extraSpaceFile;
       try {
         this.preblow(this.standByCrf, this.standbyCrfSize, directories[0]);
         this.preblow(this.standByDrf, this.standbyDrfSize, directories[0]);
@@ -581,13 +575,8 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
       } catch (IOException ioe) {
         throw new IllegalStateException("Unable to reserve space for stand by oplogs");
       }
-    } else {
-      this.standByCrf = null;
-      this.standByDrf = null;
-      this.standbyCrfSize = 0;
-      this.standbyDrfSize = 0;
-      this.extraSpaceReservedFile = null;
     }
+
 
     // stored in bytes
     this.maxDirSize = tempMaxDirSize * 1024 * 1024;
@@ -2687,6 +2676,16 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
       if (rte != null) {
         throw rte;
       }
+      try {
+        this.closeAndDeleteAfterEx(null, this.standByCrf);
+      } catch (Exception ignore) {}
+      try {
+        this.closeAndDeleteAfterEx(null, this.standByDrf);
+      } catch (Exception ignore) {}
+      try {
+        this.closeAndDeleteAfterEx(null, this.extraSpaceReservedFile);
+      } catch (Exception ignore) {}
+
     } finally {
       this.closed = true;
     }
@@ -5384,7 +5383,6 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
   }
 
   void shutdownDiskStoreAndAffiliatedRegions(DiskAccessException dae) {
-    if(!reserveSpace) return;
     final ThreadGroup exceptionHandlingGroup = LogWriterImpl.createThreadGroup(
       "Disk Store Exception Handling Group", cache.getLoggerI18n());
 

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
@@ -576,8 +576,6 @@ public class DiskStoreImpl implements DiskStore, ResourceListener<MemoryEvent> {
         throw new IllegalStateException("Unable to reserve space for stand by oplogs");
       }
     }
-
-
     // stored in bytes
     this.maxDirSize = tempMaxDirSize * 1024 * 1024;
     this.infoFileDirIndex = 0;

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/Oplog.java
@@ -4580,21 +4580,17 @@ public final class Oplog implements CompactableOplog {
 
         finishedAppending();
       } catch (InsufficientDiskSpaceException temp) {
-        if (DiskStoreImpl.reserveSpace) {
-          idse = temp;
-          if (this.isStandByOplog) {
-            throw new DiskAccessException("Even stand by oplog exhausted !!!?. handle it later");
-          }
-          DirectoryHolder standByHolder = this.getParent().directories[0];
-          Oplog newOplog = new Oplog(this.oplogId + 1, standByHolder, this, true);
-          newOplog.firstRecord = true;
-          this.doneAppending = true;
-          getOplogSet().setChild(newOplog);
-          // start the asynch thread to shut down the system
-          this.parent.shutdownDiskStoreAndAffiliatedRegions(temp);
-        } else {
-          throw temp;
+        idse = temp;
+        if (this.isStandByOplog) {
+          throw new DiskAccessException("Even stand by oplog exhausted !!!?. handle it later");
         }
+        DirectoryHolder standByHolder = this.getParent().directories[0];
+        Oplog newOplog = new Oplog(this.oplogId + 1, standByHolder, this, true);
+        newOplog.firstRecord = true;
+        this.doneAppending = true;
+        getOplogSet().setChild(newOplog);
+        // start the asynch thread to shut down the system
+        this.parent.shutdownDiskStoreAndAffiliatedRegions(temp);
       }
 
       Runnable delayedExpensiveWriter = new Runnable() {


### PR DESCRIPTION
Modified the code such that if reserved space flag is false, the standBy oplog & extra space file are not preblown. Rest every thing remains same as the original code of pull request.
The reason for this is that in the previous change, the function of shutdown region was returning without doing anything if the reserved space flag was false. This will be logically incorrect as that is the only place where the shutdown of region & disk store happens in case of exception. The code of AbstractRegionMap on getting disk access exception during operation no longer does the shutdown.
Also now I am deleting the resreved space & stand by files during diskstore close , which will be the case during graceful shutdown
(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?
Will be running it.
## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
