### PR TITLE
Added a connection property  "allow-explicit-commit"

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/GfxdConstants.java
@@ -770,6 +770,8 @@ public interface GfxdConstants {
   final String GFXD_ROUTE_QUERY = GFXD_PREFIX + Attribute.ROUTE_QUERY;
 
   final String INTERNAL_CONNECTION = GFXD_PREFIX + Attribute.INTERNAL_CONNECTION;
+
+  final String ALLOW_EXPLICIT_COMMIT = GFXD_PREFIX + Attribute.ALLOW_EXPLICIT_COMMIT;
   /*
    * @see Attribute.NCJ_BATCH_SIZE
    */

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/sql/conn/LanguageConnectionContext.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/sql/conn/LanguageConnectionContext.java
@@ -1511,6 +1511,10 @@ public interface LanguageConnectionContext extends Context {
 
    boolean isSnappyInternalConnection();
 
+   void setAllowExplicitCommit(boolean allowExplicitCommit);
+
+   boolean isAllowExplicitCommitTrue();
+
 	/**
 	 * If set then all tables created on this connection will be PERSISTENT
 	 * by default even if not specified in the DDL.

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedConnection.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedConnection.java
@@ -2076,8 +2076,13 @@ public abstract class EmbedConnection implements EngineConnection
 		if (this.autoCommit != autoCommit)
 			commit();
 
-		this.autoCommit = autoCommit;
-		getLanguageConnection().setAutoCommit(autoCommit);
+		LanguageConnectionContext lcc = getLanguageConnection();
+		if (lcc.isAllowExplicitCommitTrue()) {
+			this.autoCommit = true;
+		} else {
+			this.autoCommit = autoCommit;
+		}
+		lcc.setAutoCommit(this.autoCommit);
 	}
 	
 	public void setAutoCommit(boolean autoCommit, boolean isInit) throws SQLException {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedConnection.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedConnection.java
@@ -2073,17 +2073,17 @@ public abstract class EmbedConnection implements EngineConnection
 				throw newSQLException(SQLState.NO_AUTO_COMMIT_ON);
 		}
 
-		if (this.autoCommit != autoCommit)
-			commit();
-
 		LanguageConnectionContext lcc = getLanguageConnection();
 		if (lcc.isAllowExplicitCommitTrue()) {
 			// always set autoCommit to true if "allow-explicit-commit"
 			// connection property is true
-			this.autoCommit = true;
-		} else {
-			this.autoCommit = autoCommit;
+			autoCommit = true;
 		}
+
+		if (this.autoCommit != autoCommit)
+			commit();
+
+		this.autoCommit = autoCommit;
 		lcc.setAutoCommit(this.autoCommit);
 	}
 	

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedConnection.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/EmbedConnection.java
@@ -2078,6 +2078,8 @@ public abstract class EmbedConnection implements EngineConnection
 
 		LanguageConnectionContext lcc = getLanguageConnection();
 		if (lcc.isAllowExplicitCommitTrue()) {
+			// always set autoCommit to true if "allow-explicit-commit"
+			// connection property is true
 			this.autoCommit = true;
 		} else {
 			this.autoCommit = autoCommit;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/TransactionResourceImpl.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/jdbc/TransactionResourceImpl.java
@@ -79,6 +79,8 @@ import com.pivotal.gemfirexd.internal.iapi.sql.conn.LanguageConnectionContext;
 import com.pivotal.gemfirexd.internal.iapi.util.IdUtil;
 import com.pivotal.gemfirexd.internal.jdbc.InternalDriver;
 
+import static com.pivotal.gemfirexd.internal.engine.GfxdConstants.ALLOW_EXPLICIT_COMMIT;
+
 /** 
  *	An instance of a TransactionResourceImpl is a bundle of things that
  *	connects a connection to the database - it is the transaction "context" in
@@ -273,6 +275,8 @@ public final class TransactionResourceImpl
 		    GfxdConstants.GFXD_ROUTE_QUERY, info, false);
 		this.snappyInternalConnection = getPropertyValue(Attribute.INTERNAL_CONNECTION,
 				GfxdConstants.INTERNAL_CONNECTION, info, false);
+		this.allowExplicitCommit = getPropertyValue(Attribute.ALLOW_EXPLICIT_COMMIT,
+				GfxdConstants.ALLOW_EXPLICIT_COMMIT, info, false);
 		this.defaultPersistent = getPropertyValue(
 		    Attribute.DEFAULT_PERSISTENT, GfxdConstants.GFXD_PREFIX
 			+ Attribute.DEFAULT_PERSISTENT, info, false);
@@ -345,6 +349,8 @@ public final class TransactionResourceImpl
 
 	private final boolean snappyInternalConnection;
 
+	private final boolean allowExplicitCommit;
+
 	private final boolean defaultPersistent;
 
 	private final boolean skipConstraintChecks;
@@ -409,6 +415,7 @@ public final class TransactionResourceImpl
 		this.lcc.setQueryHDFS(this.queryHDFS);
 		this.lcc.setQueryRoutingFlag(this.routeQuery);
 		this.lcc.setSnappyInternalConnection(this.snappyInternalConnection);
+		this.lcc.setAllowExplicitCommit(this.allowExplicitCommit);
 		this.lcc.setDefaultPersistent(this.defaultPersistent);
 		this.lcc.setEnableBulkFkChecks(this.enableBulkFkChecks);
 		this.lcc.setSkipConstraintChecks(this.skipConstraintChecks);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -4159,7 +4159,7 @@ public final class GenericLanguageConnectionContext
 
 	private static final int ALLOW_EXPLICIT_COMMIT = 0x40000;
 
-	private static final int FLAGS_DEFAULT = ALLOW_EXPLICIT_COMMIT;
+	private static final int FLAGS_DEFAULT = METASTORE_IN_DD;
 
   /** flags that cannot be changed via {@link #setFlags(int)} */
   private static final int FLAGS_IMMUTABLE = CONNECTION_REMOTE

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -4157,7 +4157,9 @@ public final class GenericLanguageConnectionContext
 
 	private static final int METASTORE_IN_DD = 0x20000;
 
-	private static final int FLAGS_DEFAULT = METASTORE_IN_DD;
+	private static final int ALLOW_EXPLICIT_COMMIT = 0x40000;
+
+	private static final int FLAGS_DEFAULT = ALLOW_EXPLICIT_COMMIT;
 
   /** flags that cannot be changed via {@link #setFlags(int)} */
   private static final int FLAGS_IMMUTABLE = CONNECTION_REMOTE
@@ -5013,6 +5015,17 @@ public final class GenericLanguageConnectionContext
 	@Override
 	public boolean isSnappyInternalConnection() {
 		return GemFireXDUtils.isSet(this.gfxdFlags, SNAPPY_INTERNAL_CONNECTION);
+	}
+
+	@Override
+	public void setAllowExplicitCommit(boolean allowExplicitCommit) {
+		this.gfxdFlags = GemFireXDUtils.set(this.gfxdFlags, ALLOW_EXPLICIT_COMMIT,
+				allowExplicitCommit);
+	}
+
+	@Override
+	public boolean isAllowExplicitCommitTrue() {
+		return GemFireXDUtils.isSet(this.gfxdFlags, ALLOW_EXPLICIT_COMMIT);
 	}
 
 	@Override

--- a/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/Attribute.java
+++ b/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/Attribute.java
@@ -466,6 +466,12 @@ public interface Attribute {
   String INTERNAL_CONNECTION = "internal-connection";
 
   /**
+   * Connection property to implicitly autocommit transactions even in
+   * SnappyData irrespective of autocommit setting
+   */
+  String ALLOW_EXPLICIT_COMMIT = "allow-explicit-commit";
+
+  /**
    * Embedded connection property to create tables as persistent by default
    * for the connection.
    */

--- a/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/Attribute.java
+++ b/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/Attribute.java
@@ -466,7 +466,7 @@ public interface Attribute {
   String INTERNAL_CONNECTION = "internal-connection";
 
   /**
-   * Connection property to implicitly autocommit transactions even in
+   * Connection property to implicitly autocommit transactions in
    * SnappyData irrespective of autocommit setting
    */
   String ALLOW_EXPLICIT_COMMIT = "allow-explicit-commit";


### PR DESCRIPTION
## Changes proposed in this pull request
- Added a connection property  "allow-explicit-commit"
- This property will allow using the JDBC autocommit(false) and commit/rollback APIs, all of these will no-op with no change in product behavior when the property is set
- New property needs to be documented. Will provide details for docs separately

This fixes SNAP-3088

## Patch testing
Added a unit test at Snappy layer. Link to PR here:- https://github.com/SnappyDataInc/snappydata/pull/1397

## Is precheckin with -Pstore clean?
precheckin is to be run before merge

## ReleaseNotes changes
New property needs to be documented. Will provide details for docs separately

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
