### PR TITLE
change critical-heap-percentage to leave out max 200MB (upper limit of 99%)

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/NanoTimer.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/NanoTimer.java
@@ -55,7 +55,7 @@ public final class NanoTimer {
 
   private static final NativeCalls nativeCall = NativeCalls.getInstance();
 
-  public static final int CLOCKID_BEST;
+  public static int CLOCKID_BEST;
   public static boolean CLOCKID_USE_SYSNANOTIME;
 
   public final static String NATIVETIMER_TYPE_PROPERTY =
@@ -64,6 +64,10 @@ public final class NanoTimer {
   public static int nativeTimerType;
 
   static {
+    init();
+  }
+
+  public static void init() {
     /*
      * currently _nanoTime(..) isn't implemented in gemfire lib.
      * for gemfirexd, its implemented only for Linux/Solaris as of now.

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -2983,11 +2983,8 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   }
 
   public long getSizeInMemory() {
-    return Math.max(this.bytesInMemory.get(), 0L);
-  }
-
-  public long getDirectBufferSizeInMemory() {
-    return this.directBufferBytesInMemory.get();
+    return Math.max(this.bytesInMemory.get(), 0L) +
+        this.directBufferBytesInMemory.get();
   }
 
   public long getInProgressSize() {

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/LauncherBase.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/LauncherBase.java
@@ -300,21 +300,22 @@ public abstract class LauncherBase {
     if (maxHeapStr != null && maxHeapStr.equals(this.initialHeapSize)) {
       String criticalHeapStr = (String)map.get(CRITICAL_HEAP_PERCENTAGE);
       if (criticalHeapStr == null) {
-        // for larger heaps, keep critical as 95% and 90% for smaller ones;
+        // for larger heaps, keep critical as 95-99% and 90% for smaller ones;
         // also limit memory remaining beyond critical to 4GB
         double heapSize = ClientSharedUtils.parseMemorySize(maxHeapStr, 0L, 0);
         if (heapSize > (40.0 * 1024.0 * 1024.0 * 1024.0)) {
-          // calculate percent that will leave out at max 4GB
-          criticalPercent = (float)(100.0 * (1.0 - twoGB / heapSize));
-          // don't exceed 98%
-          if (criticalPercent > 98.0f) criticalPercent = 98.0f;
+          // calculate percent that will leave out at max 1GB
+          criticalPercent = (float)(100.0 * (1.0 - oneGB / heapSize));
         } else if (heapSize >= twoGB) {
-          criticalPercent = 95.0f;
+          // leave out max 200MB
+          criticalPercent = (float)(100.0 * (1.0 - (200.0 * 1024.0 * 1024.0) / heapSize));
         } else {
           criticalPercent = 90.0f;
         }
+        // don't exceed 99%
+        if (criticalPercent > 99.0f) criticalPercent = 99.0f;
         map.put(CRITICAL_HEAP_PERCENTAGE, "-" + CRITICAL_HEAP_PERCENTAGE +
-            '=' + criticalPercent);
+            '=' + String.format("%.2f", criticalPercent));
       } else {
         criticalPercent = Float.parseFloat(criticalHeapStr.substring(
             criticalHeapStr.indexOf('=') + 1).trim());

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/NativeCalls.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/NativeCalls.java
@@ -501,6 +501,12 @@ public abstract class NativeCalls {
   public boolean loadNativeLibrary() {
     return false;
   }
+
+  /**
+   * Try to reinitialize native timer if available.
+   */
+  public void reInitNativeTimer() {
+  }
   
   /**
    * whether o/s supports high resolution clock or equivalent 
@@ -511,7 +517,7 @@ public abstract class NativeCalls {
   public boolean isNativeTimerEnabled() {
     return false;
   }
-  
+
   /**
    * This is fall back for jni based library implementation of NanoTimer which
    * is more efficient than current impl through jna.

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/jna/LinuxNativeCalls.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/jna/LinuxNativeCalls.java
@@ -126,10 +126,18 @@ final class LinuxNativeCalls extends POSIXNativeCalls {
   private static boolean isJNATimerEnabled = false;
 
   public static class TimeSpec extends Structure {
-    public int tv_sec;
-    public int tv_nsec;
+    int tv_sec;
+    int tv_nsec;
 
     static {
+      init();
+    }
+
+    static void loadClass() {
+      // just to ensure class is loaded
+    }
+
+    static void init() {
       try {
         Native.register("rt");
         TimeSpec res = new TimeSpec();
@@ -146,10 +154,6 @@ final class LinuxNativeCalls extends POSIXNativeCalls {
       }
     }
 
-    static void init() {
-      // just invoke the static block
-    }
-
     public static native int clock_getres(int clkId, TimeSpec time)
         throws LastErrorException;
 
@@ -163,10 +167,18 @@ final class LinuxNativeCalls extends POSIXNativeCalls {
   }
 
   public static class TimeSpec64 extends Structure {
-    public long tv_sec;
-    public long tv_nsec;
+    long tv_sec;
+    long tv_nsec;
 
     static {
+      init();
+    }
+
+    static void loadClass() {
+      // just to ensure class is loaded
+    }
+
+    static void init() {
       try {
         Native.register("rt");
         TimeSpec64 res = new TimeSpec64();
@@ -181,10 +193,6 @@ final class LinuxNativeCalls extends POSIXNativeCalls {
       } catch (Throwable t) {
         isJNATimerEnabled = false;
       }
-    }
-
-    static void init() {
-      // just invoke the static block
     }
 
     public static native int clock_getres(int clkId, TimeSpec64 time)
@@ -207,12 +215,24 @@ final class LinuxNativeCalls extends POSIXNativeCalls {
    * {@inheritDoc}
    */
   @Override
-  public boolean isNativeTimerEnabled() {
-    // initialize static blocks
+  public void reInitNativeTimer() {
     if (NativeCallsJNAImpl.is64BitPlatform) {
       TimeSpec64.init();
     } else {
       TimeSpec.init();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean isNativeTimerEnabled() {
+    // initialization already done in static blocks
+    if (NativeCallsJNAImpl.is64BitPlatform) {
+      TimeSpec64.loadClass();
+    } else {
+      TimeSpec.loadClass();
     }
     return isJNATimerEnabled;
   }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorFunction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorFunction.java
@@ -228,7 +228,6 @@ public class SnappyRegionStatsCollectorFunction implements Function, Declarable 
       PartitionedRegionDataStore datastore = pr.getDataStore();
       long sizeInMemory = 0L;
       long sizeOfRegion = 0L;
-      long offHeapBytes = 0L;
       long entryOverhead = 0L;
       long entryCount = 0L;
       if (datastore != null) {
@@ -243,18 +242,18 @@ public class SnappyRegionStatsCollectorFunction implements Function, Declarable 
               entryOverhead = getEntryOverhead(re, sizer);
             }
           }
-          sizeInMemory += constantOverhead + br.getSizeInMemory();
+          sizeInMemory += constantOverhead + br.getSizeInMemory() +
+              br.getDirectBufferSizeInMemory();
           sizeOfRegion += constantOverhead + br.getTotalBytes();
           entryCount += br.entryCount();
         }
-        offHeapBytes = pr.getPrStats().getOffHeapSizeInBytes();
       }
       if (entryOverhead > 0) {
         entryOverhead *= entryCount;
       }
 
-      tableStats.setSizeInMemory(sizeInMemory + offHeapBytes + entryOverhead);
-      tableStats.setTotalSize(sizeOfRegion + offHeapBytes + entryOverhead);
+      tableStats.setSizeInMemory(sizeInMemory + entryOverhead);
+      tableStats.setTotalSize(sizeOfRegion + entryOverhead);
       tableStats.setSizeSpillToDisk(tableStats.getTotalSize() - tableStats.getSizeInMemory());
     }
     return tableStats;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorFunction.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ui/SnappyRegionStatsCollectorFunction.java
@@ -242,8 +242,7 @@ public class SnappyRegionStatsCollectorFunction implements Function, Declarable 
               entryOverhead = getEntryOverhead(re, sizer);
             }
           }
-          sizeInMemory += constantOverhead + br.getSizeInMemory() +
-              br.getDirectBufferSizeInMemory();
+          sizeInMemory += constantOverhead + br.getSizeInMemory();
           sizeOfRegion += constantOverhead + br.getTotalBytes();
           entryCount += br.entryCount();
         }

--- a/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/TestUtil.java
+++ b/gemfirexd/tools/src/test/java/com/pivotal/gemfirexd/TestUtil.java
@@ -56,8 +56,8 @@ import com.gemstone.gemfire.internal.cache.xmlcache.RegionAttributesCreation;
 import com.gemstone.gemfire.internal.cache.xmlcache.RegionCreation;
 import com.gemstone.gemfire.internal.shared.ClientSharedUtils;
 import com.gemstone.gemfire.internal.shared.NativeCalls;
-import com.gemstone.gemfire.internal.shared.jna.OSType;
 import com.gemstone.gemfire.internal.shared.StringPrintWriter;
+import com.gemstone.gemfire.internal.shared.jna.OSType;
 import com.pivotal.gemfirexd.internal.engine.GemFireXDQueryObserver;
 import com.pivotal.gemfirexd.internal.engine.GemFireXDQueryObserverAdapter;
 import com.pivotal.gemfirexd.internal.engine.GfxdConstants;
@@ -2231,8 +2231,13 @@ public class TestUtil extends TestCase {
   }
 
   public static void assertTimerLibraryLoaded() {
-    final OSType ostype = NativeCalls.getInstance().getOSType();
+    NativeCalls nc = NativeCalls.getInstance();
+    final OSType ostype = nc.getOSType();
     if (ostype == OSType.LINUX) {
+      if (!NanoTimer.isJNINativeTimerEnabled()) {
+        NanoTimer.init();
+        nc.reInitNativeTimer();
+      }
       assertTrue("Couldn't initialize jni native timer for " + ostype,
           NanoTimer.isJNINativeTimerEnabled());
       assertTrue("Couldn't initialize the native timer for " + ostype,


### PR DESCRIPTION
## Changes proposed in this pull request

- For large heaps >40GB leave out max 1GB, for <2GB heaps leave 90% like before while for rest
  leave 200MB for critical-heap-percentage. This translates to 97.5% with 8GB and 98.8% for 16GB.
  An upper limit of 99% percent is still applied to be a bit on the safe side.
- Track off-heap size in BucketRegion and add to getSizeInMemory() and getTotalBytes(). This fixes
  the callers of getTotalBytes() including rebalancing and determination of smallest bucket in SD.
- Update SnappyRegionStatsCollectorFunction to avoid separate collection of off-heap size.
- Tests checking for native timer being loaded occasionally fail due to some previous tests
  initializing system in a different way. Now re-initialize the native timer for such a case.

## Patch testing

precheckin

## Is precheckin with -Pstore clean?

in progress

## ReleaseNotes changes

Document the default critical-heap-percentage and conditions under which user may want to tweak.

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/1403