### PR TITLE
Add an unsafe method to get process-wide memory used by ByteBuffer.allocateDirect

### DIFF
--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
@@ -44,6 +44,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.BiConsumer;
 
@@ -68,6 +69,8 @@ public abstract class UnsafeHolder {
 
     static final sun.misc.Unsafe unsafe;
     static final boolean unaligned;
+    // reserved memory by ByteBuffer.allocateDirect in java.nio.Bits
+    static final AtomicLong directReservedMemory;
     static final Constructor<?> directBufferConstructor;
     static final Field cleanerField;
     static final Field cleanerRunnableField;
@@ -112,6 +115,15 @@ public abstract class UnsafeHolder {
         Method m = bitsClass.getDeclaredMethod("unaligned");
         m.setAccessible(true);
         unaligned = Boolean.TRUE.equals(m.invoke(null));
+
+        AtomicLong reserved = null;
+        try {
+          Field f = bitsClass.getDeclaredField("reservedMemory");
+          f.setAccessible(true);
+          reserved = (AtomicLong)f.get(null);
+        } catch (Throwable ignored) {
+        }
+        directReservedMemory = reserved;
 
       } catch (LinkageError le) {
         throw le;
@@ -330,6 +342,11 @@ public abstract class UnsafeHolder {
         // ignore any exceptions in releasing pending references
       }
     }
+  }
+
+  public static long getDirectReservedMemory() {
+    final AtomicLong reserved = Wrapper.directReservedMemory;
+    return reserved != null ? reserved.get() : 0L;
   }
 
   public static sun.misc.Unsafe getUnsafe() {


### PR DESCRIPTION
## Changes proposed in this pull request

UnsafeHolder.getDirectReservedMemory() method to get the total off-heap memory reserved
by calls to ByteBuffer.allocateDirect

## Patch testing

precheckin

## Is precheckin with -Pstore clean?

NA

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/1411