### PR TITLE
Change in the exit status if already running is in "waiting"

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
@@ -553,7 +553,7 @@ public class CacheServerLauncher extends LauncherBase {
     // Complain if a cache server is already running in the specified working directory.
     // See bug 32574.
     int state = verifyAndClearStatus();
-    if (state != 0) {
+    if (state != Status.SHUTDOWN) {
       if (state == Status.RUNNING) {
         System.exit(10);
       }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/CacheServerLauncher.java
@@ -552,9 +552,11 @@ public class CacheServerLauncher extends LauncherBase {
 
     // Complain if a cache server is already running in the specified working directory.
     // See bug 32574.
-    String msg = verifyAndClearStatus();
-    if (msg != null) {
-      System.err.println(msg);
+    int state = verifyAndClearStatus();
+    if (state != 0) {
+      if (state == Status.RUNNING) {
+        System.exit(10);
+      }
       System.exit(1);
     }
 

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/cache/Status.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/cache/Status.java
@@ -261,29 +261,7 @@ public class Status {
   public String shortStatus() {
     final StringBuilder buffer = new StringBuilder();
     buffer.append(this.baseName).append(" pid: ").append(pid).append(" status: ");
-    switch (state) {
-      case SHUTDOWN:
-        buffer.append("stopped");
-        break;
-      case STARTING:
-        buffer.append("starting");
-        break;
-      case RUNNING:
-        buffer.append("running");
-        break;
-      case SHUTDOWN_PENDING:
-        buffer.append("stopping");
-        break;
-      case WAITING:
-        buffer.append("waiting");
-        break;
-      case STANDBY:
-        buffer.append("standby");
-        break;
-      default:
-        buffer.append("unknown");
-        break;
-    }
+    buffer.append(getStateString(state));
     if (exceptionStr != null || msg != null) {
       if (msg != null) {
         buffer.append("\n").append(msg);
@@ -297,7 +275,7 @@ public class Status {
     return buffer.toString();
   }
 
-  public static String getStatus(int state) {
+  public String getStateString(int state) {
     switch (state) {
       case SHUTDOWN:
         return "stopped";

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/cache/Status.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/cache/Status.java
@@ -296,4 +296,23 @@ public class Status {
     }
     return buffer.toString();
   }
+
+  public static String getStatus(int state) {
+    switch (state) {
+      case SHUTDOWN:
+        return "stopped";
+      case STARTING:
+        return "starting";
+      case RUNNING:
+        return "running";
+      case SHUTDOWN_PENDING:
+        return "stopping";
+      case WAITING:
+        return "waiting";
+      case STANDBY:
+        return "standby";
+      default:
+        return "unknown";
+    }
+  }
 }

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/LauncherBase.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/LauncherBase.java
@@ -101,7 +101,7 @@ public abstract class LauncherBase {
       "The server is still starting. " +
           "{0} seconds have elapsed since the last log message: \n {1}";
   public static final String LAUNCHER_IS_ALREADY_RUNNING_IN_DIRECTORY =
-      "WARN: A {0} is already running in directory \"{1}\"";
+      "WARN: A {0} is already running in directory \"{1}\" in \"{2}\" state";
   private static final String LAUNCHER_EXPECTED_BOOLEAN =
       "Expected true or false for \"{0}=<value>\" but was \"{1}\"";
 
@@ -391,7 +391,7 @@ public abstract class LauncherBase {
     final Status status = getStatus();
     if (status != null && status.state != Status.SHUTDOWN) {
       return MessageFormat.format(LAUNCHER_IS_ALREADY_RUNNING_IN_DIRECTORY,
-          this.baseName, getWorkingDirPath());
+          this.baseName, getWorkingDirPath(), Status.getStatus(status.state));
     }
     deleteStatus();
     return null;
@@ -505,6 +505,9 @@ public abstract class LauncherBase {
       }
       writePidToFile(status);
       System.out.println(status);
+      if (statusWaiting(status)) {
+        return 2;
+      }
       return 0;
     }
   }
@@ -544,6 +547,10 @@ public abstract class LauncherBase {
     // start node even in WAITING state if the "-sync" option is false
     return (status.state == Status.STARTING ||
         (this.waitForData && status.state == Status.WAITING));
+  }
+
+  protected boolean statusWaiting(Status status) {
+    return !this.waitForData && status.state == Status.WAITING;
   }
 
   public static String readPassword(String prompt) {

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/LauncherBase.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/LauncherBase.java
@@ -395,7 +395,7 @@ public abstract class LauncherBase {
       return status.state;
     }
     deleteStatus();
-    return status.state;
+    return Status.SHUTDOWN;
   }
 
   protected final void setStatusField(Status s) {

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/LauncherBase.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/LauncherBase.java
@@ -387,14 +387,15 @@ public abstract class LauncherBase {
    * Verify and clear the status. If a server is detected as already running
    * then returns an error string else null.
    */
-  protected String verifyAndClearStatus() throws IOException {
+  protected int verifyAndClearStatus() throws IOException {
     final Status status = getStatus();
     if (status != null && status.state != Status.SHUTDOWN) {
-      return MessageFormat.format(LAUNCHER_IS_ALREADY_RUNNING_IN_DIRECTORY,
-          this.baseName, getWorkingDirPath(), Status.getStatus(status.state));
+      System.err.println(MessageFormat.format(LAUNCHER_IS_ALREADY_RUNNING_IN_DIRECTORY,
+          this.baseName, getWorkingDirPath(), status.getStateString(status.state)));
+      return status.state;
     }
     deleteStatus();
-    return null;
+    return status.state;
   }
 
   protected final void setStatusField(Status s) {


### PR DESCRIPTION
and if already running is in "running" state to be used in startup script to decide whether lead should be started or not.

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

Manual.

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
