### PR TITLE
Instead of sync on PersistentMemberManager using CopyOnWrite structure

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/PersistentMemberManager.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/persistence/PersistentMemberManager.java
@@ -30,6 +30,7 @@ import com.gemstone.gemfire.distributed.internal.MembershipListener;
 import com.gemstone.gemfire.distributed.internal.ProfileListener;
 import com.gemstone.gemfire.distributed.internal.membership.InternalDistributedMember;
 import com.gemstone.gemfire.i18n.LogWriterI18n;
+import com.gemstone.gemfire.internal.CopyOnWriteHashSet;
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
 import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import com.gemstone.gemfire.internal.util.TransformUtils;
@@ -47,7 +48,7 @@ public class PersistentMemberManager {
   private Map<PersistentMemberPattern, PendingRevokeListener> pendingRevokes 
       = new HashMap<PersistentMemberPattern, PendingRevokeListener>();
 
-  private final Set<PersistentMemberPattern> doNotWait = new HashSet();
+  private final Set<PersistentMemberPattern> doNotWait = new CopyOnWriteHashSet();
   private volatile boolean unblockNonHostingBuckets = false;
 
   private static final Object TOKEN = new Object();
@@ -69,7 +70,7 @@ public class PersistentMemberManager {
   }
 
   public boolean doNotWaitOnMember(PersistentMemberID id) {
-    synchronized (this) {
+    if (this.unblockNonHostingBuckets) {
       for (PersistentMemberPattern p : this.doNotWait) {
         if (p.matches(id))
           return true;


### PR DESCRIPTION
  There was a deadlock with revoke and unblock where revoke was taking
  lock on PersistentMemberManager and then requires lock on PersistenceAdvisorImpl.
  The intialization thread takes lock PersistenceAdvisorImpl and then to check
  whether the diskid is unblocked and requires lock on PersistentmemberManager

## Changes proposed in this pull request

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
