### PR TITLE
PreparedStatement not working with snappydata GitHUb issue 1436

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLChar.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLChar.java
@@ -1349,6 +1349,12 @@ readingLoop:
 
 
         rawData = str;
+        if (strlen < utflen) {
+          char[] newCharArray = new char[strlen];
+          System.arraycopy(str, 0, newCharArray, 0, strlen);
+          rawData = newCharArray;
+        }
+
         rawLength = strlen;
         value = null;
         //stream = null;


### PR DESCRIPTION
## Changes proposed in this pull request

Fixed issue in getCharArray() method of SQLChar for non-ascii characters which was leading to wrong UTFString being formed after deserialization because rawData char[] was containing garbage characters as per utflength and not actual string length.

## Patch testing

Shirish added a dunit test for this which passes now.

## Is precheckin with -Pstore clean?

Going on.

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/1438