### PR TITLE
Snap 3193

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLReal.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/types/SQLReal.java
@@ -41,8 +41,10 @@
 package com.pivotal.gemfirexd.internal.iapi.types;
 
 import com.gemstone.gemfire.internal.DSCODE;
+import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
 import com.gemstone.gemfire.internal.offheap.ByteSource;
 import com.gemstone.gemfire.pdx.internal.unsafe.UnsafeWrapper;
+import com.pivotal.gemfirexd.internal.engine.Misc;
 import com.pivotal.gemfirexd.internal.engine.store.RowFormatter;
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
 import com.pivotal.gemfirexd.internal.iapi.reference.SQLState;
@@ -462,7 +464,7 @@ public final class SQLReal
         // we might have rounding error (different than DB2 behaviour)
 		float fv = (float) theValue;
         // detect rounding taking place at cast time
-        if (fv == 0.0f && theValue != 0.0d) {
+        if (fv == 0.0f && theValue != 0.0d && !Misc.getMemStore().isSnappyStore()) {
 			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, TypeId.REAL_NAME, (String)null);
         }
         setValue(fv);

--- a/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
+++ b/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
@@ -5437,8 +5437,11 @@ approximateNumericType() throws StandardException :
 		/*
 			When not specified, default is DOUBLE_PRECISION
 		 */
-		if (prec == -1)
-			prec = TypeId.DOUBLE_PRECISION;
+		if (prec == -1) {
+			//prec = TypeId.DOUBLE_PRECISION;
+			// To Fix bug SNAP-3193
+			prec = Misc.getMemStore().isSnappyStore()? TypeId.REAL_PRECISION : TypeId.DOUBLE_PRECISION;
+		}
 
 		if (prec > 0 && prec <= TypeId.REAL_PRECISION)
 		{


### PR DESCRIPTION
## Changes proposed in this pull request
The issue is that if a Float column type Column is present in DDL, then if the table is created as column table, the data type of column is correctly present as float. But if a row table is created, then the data type is double. This is because for row table in gfxd, the float is mapped to REAL type. And a Real Type without precision is assumed to be a Double Precision in sqlGrammar.jj.
The first change is that in sqlGrammar.jj where if the precision type with Real is not specified it is taken as max precision allowed for REAL rather than Double's precision, if the system is a snapy store.
The second change is in SQLReal, where if the value passed is a double, and rounding of occurs, then exception is thrown, for row table. But for column table , the double is rounded to 0 to fit in the Float data type.  So the change is that in case of snappy store , do not thrown an exception if rounding occurs.
Added bug test in 
cluster  org.apache.spark.sql.store.BugTest

The bug test will be found in the snappydata repo in the following PR
[bug-test](https://github.com/SnappyDataInc/snappydata/pull/1460/files)

## Patch testing

precheckin run
will be running precheckin with -Pstore 

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
