### PR TITLE
ComputeDB ODBC Driver returns incorrect Decimal values

### DIFF
--- a/native/src/snappyclient/cpp/ColumnDescriptor.cpp
+++ b/native/src/snappyclient/cpp/ColumnDescriptor.cpp
@@ -191,7 +191,8 @@ uint32_t ColumnDescriptor::getDisplaySize() const noexcept {
       return (size > 0 ? size : 30);
     case thrift::SnappyType::DECIMAL:
       size = getPrecision();
-      return (size > 0 ? (size + 2) : 15);
+      // As per microsoft document for Dispaly Size, for decimal type display size = precision + 2
+      return (size + 2);
     default:
       size = getPrecision();
       return (size > 0 ? size : 15);

--- a/native/src/snappyclient/cpp/ColumnDescriptor.cpp
+++ b/native/src/snappyclient/cpp/ColumnDescriptor.cpp
@@ -189,8 +189,11 @@ uint32_t ColumnDescriptor::getDisplaySize() const noexcept {
     case thrift::SnappyType::BLOB:
       size = (2 * getPrecision());
       return (size > 0 ? size : 30);
-    default:
+    case thrift::SnappyType::DECIMAL:
       size = getPrecision();
       return (size > 0 ? (size + 2) : 15);
+    default:
+      size = getPrecision();
+      return (size > 0 ? size : 15);
   }
 }

--- a/native/src/snappyclient/cpp/ColumnDescriptor.cpp
+++ b/native/src/snappyclient/cpp/ColumnDescriptor.cpp
@@ -192,6 +192,7 @@ uint32_t ColumnDescriptor::getDisplaySize() const noexcept {
     case thrift::SnappyType::DECIMAL:
       size = getPrecision();
       // As per microsoft document for Dispaly Size, for decimal type display size = precision + 2
+      // Fixed- JIRA SDENT-76
       return (size + 2);
     default:
       size = getPrecision();

--- a/native/src/snappyclient/cpp/ColumnDescriptor.cpp
+++ b/native/src/snappyclient/cpp/ColumnDescriptor.cpp
@@ -191,6 +191,6 @@ uint32_t ColumnDescriptor::getDisplaySize() const noexcept {
       return (size > 0 ? size : 30);
     default:
       size = getPrecision();
-      return (size > 0 ? size : 15);
+      return (size > 0 ? (size + 2) : 15);
   }
 }

--- a/native/src/snappyclient/cpp/types/Decimal.cpp
+++ b/native/src/snappyclient/cpp/types/Decimal.cpp
@@ -360,15 +360,16 @@ size_t Decimal::toString(std::string& str) const {
   char buf[thrift::snappydataConstants::DECIMAL_MAX_PRECISION + 4];
   char* bufp = buf;
   io::snappydata::client::impl::FreePointer freep(0);
-  const size_t ndigits = mpz_sizeinbase(m_bigInt, 10);
+  size_t ndigits = mpz_sizeinbase(m_bigInt, 10);
   if (ndigits > 128) {
     bufp = new char[ndigits + 2];
     freep.reset(bufp);
   }
   mpz_get_str(bufp, 10, m_bigInt);
-
+  ndigits = strlen(bufp);// to get exact size
   // now the three cases of '.' inside, before and not at all
   const bool neg = (*bufp == '-');
+  if (neg) ndigits--;
   if (m_scale == 0) {
     str.append(bufp, ndigits + neg);
     return (ndigits + neg);

--- a/native/src/snappyclient/cpp/types/Decimal.cpp
+++ b/native/src/snappyclient/cpp/types/Decimal.cpp
@@ -370,6 +370,7 @@ size_t Decimal::toString(std::string& str) const {
   * mpz_sizeinbase, as per its implementation, it could return the exact size or 1 too big.
   * for values like -66 or other negative values it returns 3 instead of 2.
   * As solution of this using strlen
+  * Fixed- JIRA SDENT-76
   */
   ndigits = strlen(bufp);
   const bool neg = (*bufp == '-');

--- a/native/src/snappyclient/cpp/types/Decimal.cpp
+++ b/native/src/snappyclient/cpp/types/Decimal.cpp
@@ -367,7 +367,6 @@ size_t Decimal::toString(std::string& str) const {
   }
   mpz_get_str(bufp, 10, m_bigInt);
   ndigits = strlen(bufp);// to get exact size
-  // now the three cases of '.' inside, before and not at all
   const bool neg = (*bufp == '-');
   if (neg) ndigits--;
   if (m_scale == 0) {
@@ -375,6 +374,7 @@ size_t Decimal::toString(std::string& str) const {
     return (ndigits + neg);
   }
   // check for sign (using signed version of size_t)
+  // now the three cases of '.' inside, before and not at all
   ptrdiff_t wholeDigits = (ndigits - m_scale);
   if (wholeDigits > 0) {
     size_t wholeDigitsWithSign = static_cast<size_t>(wholeDigits + neg);

--- a/native/src/snappyclient/cpp/types/Decimal.cpp
+++ b/native/src/snappyclient/cpp/types/Decimal.cpp
@@ -366,7 +366,12 @@ size_t Decimal::toString(std::string& str) const {
     freep.reset(bufp);
   }
   mpz_get_str(bufp, 10, m_bigInt);
-  ndigits = strlen(bufp);// to get exact size
+  /*
+  * mpz_sizeinbase, as per its implementation, it could return the exact size or 1 too big.
+  * for values like -66 or other negative values it returns 3 instead of 2.
+  * As solution of this using strlen
+  */
+  ndigits = strlen(bufp);
   const bool neg = (*bufp == '-');
   if (neg) ndigits--;
   if (m_scale == 0) {


### PR DESCRIPTION
In Snappy C++ native client, to convert the decimal value into a string, the "mpz_sizeinbase" function of "GMP" library gets used, which returns the number of digits present in decimal value. As per its implementation, it could return the exact result or 1 too big. Since this function returns 1 too big (in other words, if there are 2 digits in decimal value, it returns the 3) which turns into the wrong result string. For example, if the column value is "0.66" then output is "6.6"

## Changes proposed in this pull request

Added code to resolve the mpz_sizeinbase (GMP library) function's "1 too big" issue.
Added "+2" for display size for data type decimal and numeric. Followed the Microsoft document on "Display size" for this change.(https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/display-size?view=sql-server-ver15)

## Patch testing
Manual testing
Unit test
## Is precheckin with -Pstore clean?
NA

## ReleaseNotes changes
NA

## Other PRs 
Unit test added in snappy-odbc branch https://github.com/SnappyDataInc/snappy-odbc/pull/13
