### PR TITLE
[SNAP-3176] Suppress the unnecessary log messages

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RowFormatter.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/RowFormatter.java
@@ -1039,8 +1039,12 @@ public final class RowFormatter implements Serializable {
     this.metadata = null;
     this.isTableFormatter = false;
     this.isPrimaryKeyFormatter = false;
-    SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_ROW_FORMATTER,
-        "RowFormatter#cqi#column[] = " + ArrayUtils.toString(this.columns));
+    if (SanityManager.DEBUG) {
+      if (GemFireXDUtils.TraceRowFormatter) {
+        SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_ROW_FORMATTER,
+            "RowFormatter#cqi#column[] = " + ArrayUtils.toString(this.columns));
+      }
+    }
   }
 
   /**
@@ -1105,8 +1109,12 @@ public final class RowFormatter implements Serializable {
       this.isTableFormatter = true;
     }
     this.isPrimaryKeyFormatter = false;
-    SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_ROW_FORMATTER,
-        "RowFormatter#const1#column[] = " + ArrayUtils.toString(this.columns));
+    if (SanityManager.DEBUG) {
+      if (GemFireXDUtils.TraceRowFormatter) {
+        SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_ROW_FORMATTER,
+            "RowFormatter#const1#column[] = " + ArrayUtils.toString(this.columns));
+      }
+    }
   }
 
   /**
@@ -1225,8 +1233,12 @@ public final class RowFormatter implements Serializable {
     this.metadata = null;
     this.isTableFormatter = false;
     this.isPrimaryKeyFormatter = false;
-    SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_ROW_FORMATTER,
-        "RowFormatter#const3#column[] = " + ArrayUtils.toString(this.columns));
+    if (SanityManager.DEBUG) {
+      if (GemFireXDUtils.TraceRowFormatter) {
+        SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_ROW_FORMATTER,
+            "RowFormatter#const3#column[] = " + ArrayUtils.toString(this.columns));
+      }
+    }
   }
 
   /**
@@ -1287,14 +1299,23 @@ public final class RowFormatter implements Serializable {
     this.metadata = getMetaData(schemaName, tableName, schemaVersion);
     this.isTableFormatter = false;
     this.isPrimaryKeyFormatter = isPrimaryKeyFormatter;
-    SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_ROW_FORMATTER,
-        "RowFormatter#const4#column[] = " + ArrayUtils.toString(this.columns));
+    if (SanityManager.DEBUG) {
+      if (GemFireXDUtils.TraceRowFormatter) {
+        SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_ROW_FORMATTER,
+            "RowFormatter#const4#column[] = " + ArrayUtils.toString(this.columns));
+      }
+    }
   }
 
   public void printColumnArray() {
-    SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_ROW_FORMATTER,
-        "RowFormatter#Recovery#column[] = " + ArrayUtils.toString(this.columns));
+    if (SanityManager.DEBUG) {
+      if (GemFireXDUtils.TraceRowFormatter) {
+        SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_ROW_FORMATTER,
+            "RowFormatter#Recovery#column[] = " + ArrayUtils.toString(this.columns));
+      }
+    }
   }
+
   /**
    * Get the fixed width, variable width and LOB column positions for this
    * formatter.

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/services/context/ContextManager.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/iapi/services/context/ContextManager.java
@@ -52,6 +52,7 @@ import com.pivotal.gemfirexd.internal.iapi.error.PassThroughException;
 import com.pivotal.gemfirexd.internal.iapi.error.ShutdownException;
 import com.pivotal.gemfirexd.internal.iapi.error.StandardException;
 import com.pivotal.gemfirexd.internal.iapi.reference.Property;
+import com.pivotal.gemfirexd.internal.iapi.reference.SQLState;
 import com.pivotal.gemfirexd.internal.iapi.services.i18n.LocaleFinder;
 import com.pivotal.gemfirexd.internal.iapi.services.monitor.Monitor;
 import com.pivotal.gemfirexd.internal.iapi.services.property.PropertyUtil;
@@ -741,6 +742,11 @@ cleanup:	for (int index = holder.size() - 1; index >= 0; index--) {
 				        .getSystemInt(Property.LOG_SEVERITY_LEVEL,
 				            this.errorStream.getLogSeverityLevel());
 				  }
+				}
+				// SNAP-3176
+				if (se.getSQLState().equals(SQLState.LANG_SYNTAX_ERROR)
+						|| se.getSQLState().equals(SQLState.LANG_LEXICAL_ERROR)) {
+					return false;
 				}
 // GemStone changes END
 				return (level >= logSeverityLevel) ||


### PR DESCRIPTION
## Changes proposed in this pull request
* Suppress the unnecessary log messages coming out from Hive client initialization DDLs. (SNAP-3176)
* Also, wrap the debug messages in RowFormatter with appropriate checks so that they don't show up, by default.

## Patch testing
Manual

## Is precheckin with -Pstore clean?
Running precheckin

## ReleaseNotes changes
NA

## Other PRs 
NA