### PR TITLE
Store side support for returning df content in resultset based on 'exec scala' option

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/execution/LeadNodeExecutionObject.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/execution/LeadNodeExecutionObject.java
@@ -7,7 +7,8 @@ import com.pivotal.gemfirexd.internal.snappy.LeadNodeExecutionContext;
 import com.pivotal.gemfirexd.internal.snappy.SparkSQLExecute;
 
 public abstract class LeadNodeExecutionObject implements GfxdSerializable {
-  public abstract SparkSQLExecute getSparkSQlExecute(Version v, LeadNodeExecutionContext ctx) throws Exception;
+  public abstract SparkSQLExecute getSparkSQlExecute(Version v,
+    LeadNodeExecutionContext ctx, Object dfObject) throws Exception;
   public abstract boolean isUpdateOrDeleteOrPut();
   public abstract void reset();
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/execution/SQLLeadNodeExecutionObject.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/execution/SQLLeadNodeExecutionObject.java
@@ -57,11 +57,12 @@ public class SQLLeadNodeExecutionObject  extends LeadNodeExecutionObject {
    */
   public SQLLeadNodeExecutionObject() {}
 
-  public SparkSQLExecute getSparkSQlExecute(Version v, LeadNodeExecutionContext ctx) throws Exception {
+  public SparkSQLExecute getSparkSQlExecute(Version v,
+      LeadNodeExecutionContext ctx, Object dfObject) throws Exception {
     if (isPreparedStatement() && !isPreparedPhase())  {
       getParams();
     }
-    return CallbackFactoryProvider.getClusterCallbacks().getSQLExecute(
+    return CallbackFactoryProvider.getClusterCallbacks().getSQLExecute(dfObject,
       sql, schema, ctx, v, this.isPreparedStatement(), this.isPreparedPhase(), this.pvs);
   }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/execution/SampleInsertExecutionObject.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/execution/SampleInsertExecutionObject.java
@@ -34,8 +34,8 @@ public class SampleInsertExecutionObject extends LeadNodeExecutionObject {
    */
   public SampleInsertExecutionObject() {}
 
-  public SparkSQLExecute getSparkSQlExecute(Version v, LeadNodeExecutionContext ctx) throws Exception {
-
+  public SparkSQLExecute getSparkSQlExecute(Version v,
+      LeadNodeExecutionContext ctx, Object dfOject) throws Exception {
     return CallbackFactoryProvider.getClusterCallbacks().getSampleInsertExecute( this.baseTableName,
       ctx, v, this.rows, this.serializedDVDs);
   }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/LeadNodeExecutorMsg.java
@@ -123,7 +123,7 @@ public final class LeadNodeExecutorMsg extends MemberExecutorMessage<Object> {
       }
       InternalDistributedMember m = this.getSenderForReply();
       final Version v = m.getVersionObject();
-      exec = this.execObject.getSparkSQlExecute(v, ctx);
+      exec = this.execObject.getSparkSQlExecute(v, ctx, null);
       SnappyResultHolder srh = new SnappyResultHolder(exec,
         execObject.isUpdateOrDeleteOrPut());
 
@@ -144,7 +144,7 @@ public final class LeadNodeExecutorMsg extends MemberExecutorMessage<Object> {
     }
   }
 
-  private boolean interpreterExecution() {
+  private boolean interpreterExecution() throws Exception {
     String sql = this.execObject.getSql();
     if (sql != null) {
       if (sql.startsWith("exec") || sql.startsWith("EXEC")) {
@@ -153,9 +153,18 @@ public final class LeadNodeExecutorMsg extends MemberExecutorMessage<Object> {
         final Version v = member.getVersionObject();
         InterpreterExecute intpexec =
           CallbackFactoryProvider.getClusterCallbacks().getInterpreterExecution(sql, v, ctx.getConnId());
-        String[] results = intpexec.execute(user, this.ctx.getAuthToken());
-        SnappyResultHolder srh = new SnappyResultHolder(results);
-        this.lastResult(srh);
+        Object results = intpexec.execute(user, this.ctx.getAuthToken());
+        if (results instanceof String[]) {
+          SnappyResultHolder srh = new SnappyResultHolder((String[])results);
+          this.lastResult(srh);
+        } else {
+          // result itself is dataframe
+          exec = this.execObject.getSparkSQlExecute(v, ctx, results);
+          SnappyResultHolder srh = new SnappyResultHolder(exec, false);
+          srh.prepareSend(this, execObject);
+          this.lastResultSent = true;
+          this.endMessage();
+        }
         return true;
       }
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/CallbackFactoryProvider.java
@@ -54,7 +54,7 @@ public abstract class CallbackFactoryProvider {
     }
 
     @Override
-    public SparkSQLExecute getSQLExecute(String sql, String schema,
+    public SparkSQLExecute getSQLExecute(Object dfObj, String sql, String schema,
         LeadNodeExecutionContext ctx, Version v, boolean isPreparedStatement,
         boolean isPreparedPhase, ParameterValueSet pvs) {
        return null;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/ClusterCallbacks.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/ClusterCallbacks.java
@@ -41,7 +41,7 @@ public interface ClusterCallbacks {
 
   void stopExecutor();
 
-  SparkSQLExecute getSQLExecute(String sql, String schema, LeadNodeExecutionContext ctx,
+  SparkSQLExecute getSQLExecute(Object dfObject, String sql, String schema, LeadNodeExecutionContext ctx,
       Version v, boolean isPreparedStatement, boolean isPreparedPhase, ParameterValueSet pvs);
 
   InterpreterExecute getInterpreterExecution(String sql, Version v, Long connId);

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/InterpreterExecute.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/InterpreterExecute.java
@@ -19,6 +19,6 @@ package com.pivotal.gemfirexd.internal.snappy;
 
 public interface InterpreterExecute {
 
-  String[] execute(String user, String authToken);
+  Object execute(String user, String authToken);
 
 }


### PR DESCRIPTION

## Changes proposed in this pull request

The 'exec scala' by default returns whatever is written to standard out by the interpreter while interpreting a block of code it runs. But it may not be very useful in certain situations. Fir example the user does ten things but just wants the result of a df created so that he can use standard products which uses jdbc/odbc connectivity to use the output in resultset form to plot charts/graphs etc.

Added unit tests for 'exec scala', 'snappy-scala' including security etc.
## Patch testing

Unit test aded. Manual too.

## Is precheckin with -Pstore clean?

Underway.

## ReleaseNotes changes

Yes
## Other PRs 

https://github.com/SnappyDataInc/snappydata/pull/1488