### PR TITLE
SNAP-3243:Removing procedure GENERATE_LOAD_SCRIPTS

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/ddl/catalog/GfxdSystemProcedures.java
@@ -1610,26 +1610,6 @@ public class GfxdSystemProcedures extends SystemProcedures {
     }
   }
 
-  public static void GENERATE_LOAD_SCRIPTS() throws SQLException {
-    try {
-      if (GemFireXDUtils.TraceSysProcedures) {
-        SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_SYS_PROCEDURES,
-            "Executing GENERATE_LOAD_SCRIPTS");
-      }
-      Long connectionId = Misc.getLanguageConnectionContext().getConnectionId();
-      GfxdListResultCollector collector = new GfxdListResultCollector();
-      GetLeadNodeInfoAsStringMessage msg = new GetLeadNodeInfoAsStringMessage(
-          collector, GetLeadNodeInfoAsStringMessage.DataReqType.GENERATE_LOAD_SCRIPTS, connectionId);
-      msg.executeFunction();
-      if (GemFireXDUtils.TraceSysProcedures) {
-        SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_SYS_PROCEDURES,
-            "GENERATE_LOAD_SCRIPTS successful.");
-      }
-    } catch(StandardException e) {
-      throw PublicAPI.wrapStandardException(e);
-    }
-  }
-
   /**
    * Create or drop reservoir region for sampler. Note that the creat and drop operation
    * are intentionally combined in single procedure here to make conflation of create and

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/GetLeadNodeInfoAsStringMessage.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/message/GetLeadNodeInfoAsStringMessage.java
@@ -41,9 +41,10 @@ public class GetLeadNodeInfoAsStringMessage extends MemberExecutorMessage<Object
   private DataReqType requestType;
   private Long connID;
 
-  public enum DataReqType {GET_JARS, EXPORT_DATA, EXPORT_DDLS, GENERATE_LOAD_SCRIPTS}
+  public enum DataReqType {GET_JARS, EXPORT_DATA, EXPORT_DDLS}
 
-  public GetLeadNodeInfoAsStringMessage(final ResultCollector<Object, Object> rc, DataReqType reqType, Long connID, Object... args) {
+  public GetLeadNodeInfoAsStringMessage(final ResultCollector<Object, Object> rc,
+      DataReqType reqType, Long connID, Object... args) {
     super(rc, null, false, true);
     this.requestType = reqType;
     this.additionalArgs = args;
@@ -99,13 +100,6 @@ public class GetLeadNodeInfoAsStringMessage extends MemberExecutorMessage<Object
           }
           result = exportDDLs();
           break;
-        case GENERATE_LOAD_SCRIPTS:
-          if (GemFireXDUtils.TraceQuery) {
-            SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_QUERYDISTRIB,
-                "GetLeadNodeInfoAsStringMessage - case GENERATE_LOAD_SCRIPTS");
-          }
-          result = generateLoadScripts();
-          break;
         default:
           throw new IllegalArgumentException("GetLeadNodeInfoAsStringMessage:" +
               " Unknown data request type: " + this.requestType);
@@ -119,19 +113,17 @@ public class GetLeadNodeInfoAsStringMessage extends MemberExecutorMessage<Object
 
 
   private String exportData() {
-    com.pivotal.gemfirexd.internal.snappy.CallbackFactoryProvider.getClusterCallbacks().exportData(connID,
-        additionalArgs[0].toString(), additionalArgs[1].toString(), additionalArgs[2].toString(), Boolean.parseBoolean(additionalArgs[3].toString()));
+    com.pivotal.gemfirexd.internal.snappy.CallbackFactoryProvider
+        .getClusterCallbacks().exportData(connID, additionalArgs[0].toString(),
+        additionalArgs[1].toString(), additionalArgs[2].toString(),
+        Boolean.parseBoolean(additionalArgs[3].toString()));
     return "Data recovered";
   }
 
   private String exportDDLs() {
-    com.pivotal.gemfirexd.internal.snappy.CallbackFactoryProvider.getClusterCallbacks().exportDDLs(connID, additionalArgs[0].toString());
+    com.pivotal.gemfirexd.internal.snappy.CallbackFactoryProvider
+        .getClusterCallbacks().exportDDLs(connID, additionalArgs[0].toString());
     return "DDLs recovered.";
-  }
-
-  private String generateLoadScripts() {
-    com.pivotal.gemfirexd.internal.snappy.CallbackFactoryProvider.getClusterCallbacks().generateLoadScripts(connID);
-    return "load scripts generated";
   }
 
   private String handleGetJarsRequest() {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/impl/sql/catalog/GfxdDataDictionary.java
@@ -1837,12 +1837,6 @@ public final class GfxdDataDictionary extends DataDictionaryImpl {
     }
 
     {
-      String[] arg_name = new String[] {};
-      TypeDescriptor[] arg_types = new TypeDescriptor[] {};
-      super.createSystemProcedureOrFunction("GENERATE_LOAD_SCRIPTS", sysUUID, arg_name, arg_types, 0, 0, RoutineAliasInfo.READS_SQL_DATA, null, newlyCreatedRoutines, tc, GFXD_SYS_PROC_CLASSNAME, false);
-    }
-
-    {
       // GET_BUCKET_TO_SERVER_MAPPING
       String[] arg_names = new String[] { "FQTN", "BKT_TO_SERVER_MAPPING" };
       TypeDescriptor[] arg_types = new TypeDescriptor[] { DataTypeDescriptor

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/CallbackFactoryProvider.java
@@ -78,10 +78,6 @@ public abstract class CallbackFactoryProvider {
     }
 
     @Override
-    public void generateLoadScripts(Long connId) {
-    }
-
-    @Override
     public Object readDataType(ByteArrayDataInput in) {
       return null;
     }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/ClusterCallbacks.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/ClusterCallbacks.java
@@ -49,11 +49,10 @@ public interface ClusterCallbacks {
   SparkSQLExecute getSampleInsertExecute(String baseTable,  LeadNodeExecutionContext ctx,
       Version v, List<DataValueDescriptor[]> dvdRows, byte[] serializedDVDs);
 
-  void exportData(Long connId, String exportUri, String formatType, String tableNames, Boolean ignoreError);
+  void exportData(Long connId, String exportUri, String formatType, String tableNames,
+      Boolean ignoreError);
 
   void exportDDLs(Long connId, String exportUri);
-
-  void generateLoadScripts(Long connId);
 
   Object readDataType(ByteArrayDataInput in);
 


### PR DESCRIPTION

## Changes proposed in this pull request
* A separate procedure is not required to generate load script.
  Load script will be generated on every EXPORT_DATA call in a separate directory.

## Patch testing
Manual testing, running relevant tests

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
