### PR TITLE
skipping oplog recovery in recovery mode

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PersistentOplogSet.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/PersistentOplogSet.java
@@ -729,7 +729,7 @@ public class PersistentOplogSet implements OplogSet {
       if (!parent.isOffline()) {
         // schedule GFXD index recovery first
         parent.scheduleIndexRecovery(oplogSet, false);
-        if(recoverValues() && !recoverValuesSync()) {
+        if(!parent.getCache().isSnappyRecoveryMode() && recoverValues() && !recoverValuesSync()) {
           //TODO DAN - should we defer compaction until after
           //value recovery is complete? Or at least until after
           //value recovery for a given oplog is complete?


### PR DESCRIPTION
## Changes proposed in this pull request

oplog recovery in recovery mode is not required. Eviction is also not happening in recovery mode, leaving less memory available for scans in recovery mode.
This PR skips oplog recovery in recovery mode

## Patch testing

Tests are already present which lead to required scenarios

## Is precheckin with -Pstore clean?

Verifying prechecking with -Pstore is in progress

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)
no
## Other PRs 
no