### PR TITLE
changes in the grammar to support datatype specification as just varc…

### DIFF
--- a/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
+++ b/gemfirexd/core/src/main/javacc/com/pivotal/gemfirexd/internal/impl/sql/compile/sqlgrammar.jj
@@ -5108,25 +5108,32 @@ characterStringType() throws StandardException :
 	int					length = DEFAULT_STRING_COLUMN_LENGTH;
 	Token				varyingToken = null;
 	int type;
+	boolean explicitLength = false;
 }
 {
   (
 	(
-		<VARCHAR> length = charLength()
+		<VARCHAR> [length = charLength() { explicitLength = true;}]
 	)
 	{
 		type = Types.VARCHAR;
+		if (!explicitLength) {
+		  length = Limits.DB2_VARCHAR_MAXWIDTH;
+		}
 	}
 |
 	charOrCharacter()
 	(
 		// Length is optional for CHARACTER, not for plain CHARACTER VARYING
-		varyingToken = <VARYING> length = charLength() |
-		[ length = charLength() ]
+		varyingToken = <VARYING> [ length = charLength() {explicitLength = true;}]
+		| [ length = charLength() ]
 	)
 	{
 		// If the user says CHARACTER VARYING, it's really VARCHAR
 		type = (varyingToken == null ? Types.CHAR : Types.VARCHAR);
+		if (!explicitLength && type == Types.VARCHAR) {
+		  length = Limits.DB2_VARCHAR_MAXWIDTH;
+		}
 	}
   ) [ type = forBitData(type) ]
 


### PR DESCRIPTION
…har only

Modification of grammar to support column datatype sepcification as just "varchar" without length specification.

(Fill in the changes here)

## Patch testing

(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 
[snappydata-pr](https://github.com/SnappyDataInc/snappydata/pull/1536)
(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
