### PR TITLE
SNAP-3317

### DIFF
--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/BufferAllocator.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/BufferAllocator.java
@@ -66,8 +66,15 @@ public abstract class BufferAllocator implements Closeable {
    * Fill the given portion of the buffer setting it with given byte.
    */
   public final void fill(ByteBuffer buffer, byte b, int position, int numBytes) {
-    Platform.setMemory(baseObject(buffer), baseOffset(buffer) + position,
-        numBytes, b);
+    if (UnsafeHolder.hasUnsafe()) {
+      Platform.setMemory(baseObject(buffer), baseOffset(buffer) + position,
+          numBytes, b);
+    } else {
+      final int endPosition = position + numBytes;
+      for (int index = position; index < endPosition; index++) {
+        buffer.put(index, b);
+      }
+    }
   }
 
   /**

--- a/gemfirexd/core/src/main/java/io/snappydata/thrift/server/ConnectionHolder.java
+++ b/gemfirexd/core/src/main/java/io/snappydata/thrift/server/ConnectionHolder.java
@@ -49,6 +49,7 @@ import java.util.Properties;
 import com.gemstone.gemfire.internal.cache.locks.NonReentrantLock;
 import com.gemstone.gemfire.internal.shared.ClientSharedUtils;
 import com.gemstone.gemfire.internal.shared.FinalizeObject;
+import com.pivotal.gemfirexd.internal.engine.distributed.utils.GemFireXDUtils;
 import com.pivotal.gemfirexd.internal.iapi.jdbc.EngineConnection;
 import com.pivotal.gemfirexd.internal.iapi.jdbc.EngineStatement;
 import com.pivotal.gemfirexd.internal.jdbc.EmbedXAConnection;
@@ -646,7 +647,7 @@ final class ConnectionHolder {
         return Arrays.equals(otherId.array(), connToken.array());
       } else {
         // don't create intermediate byte[]
-        return ClientSharedUtils.equalBuffers(connToken.array(), otherId);
+        return GemFireXDUtils.equalBuffers(connToken.array(), otherId);
       }
     } else {
       return false;

--- a/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/shared/common/ResolverUtils.java
+++ b/gemfirexd/shared/src/main/java/com/pivotal/gemfirexd/internal/shared/common/ResolverUtils.java
@@ -101,7 +101,7 @@ public abstract class ResolverUtils extends ClientResolverUtils {
       strChars = null;
     }
     bigIntCons = cons;
-    stringCharsOffset = strChars != null
+    stringCharsOffset = strChars != null && UnsafeHolder.hasUnsafe()
         ? UnsafeHolder.getUnsafe().objectFieldOffset(strChars) : -1L;
   }
 

--- a/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/SnappyTSocket.java
+++ b/gemfirexd/shared/src/main/java/io/snappydata/thrift/common/SnappyTSocket.java
@@ -57,8 +57,6 @@ import com.gemstone.gemfire.internal.shared.unsafe.UnsafeHolder;
 import io.snappydata.thrift.HostAddress;
 import org.apache.thrift.transport.TNonblockingTransport;
 import org.apache.thrift.transport.TTransportException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A custom TSocket allowing to increase input/output buffer sizes and use NIO
@@ -112,6 +110,7 @@ public final class SnappyTSocket extends TNonblockingTransport implements
    *
    * @param srvChannel Already created socket object from server accept
    * @param params     Socket parameters like buffer sizes, keep-alive settings
+   *
    * @throws TTransportException if there is an error setting up the streams
    */
   public SnappyTSocket(SocketChannel srvChannel, boolean useSSL,
@@ -185,13 +184,13 @@ public final class SnappyTSocket extends TNonblockingTransport implements
   /**
    * Initializes the socket object
    */
-  private static SocketChannel initSocket(boolean blocking)
-      throws TTransportException, IOException {
+  private static SocketChannel initSocket(boolean blocking) throws IOException {
     SocketChannel socketChannel = SocketChannel.open();
     socketChannel.configureBlocking(blocking);
     return socketChannel;
   }
 
+  @SuppressWarnings("SameParameterValue")
   private ByteChannel initChannel(String id, SelectionKey key, boolean ssl,
       SocketParameters params, boolean forClient)
       throws TTransportException, IOException {
@@ -199,7 +198,8 @@ public final class SnappyTSocket extends TNonblockingTransport implements
       // setup the SSL engine
       SSLEngine engine = SSLFactory.createEngine(this.socketAddress.getHostName(),
           this.socketAddress.getPort(), params, forClient);
-      return SSLSocketChannel.create(id, socketChannel, key, engine, true);
+      return SSLSocketChannel.create(id, socketChannel, key, engine,
+          UnsafeHolder.hasUnsafe());
     } else {
       return this.socketChannel;
     }
@@ -249,7 +249,7 @@ public final class SnappyTSocket extends TNonblockingTransport implements
    * @param params Socket parameters like buffer sizes, keep-alive settings
    */
   protected void setProperties(Socket socket, int timeout,
-      SocketParameters params) throws TTransportException, IOException {
+      SocketParameters params) throws IOException {
     this.inputBufferSize = params.getInputBufferSize();
     this.outputBufferSize = params.getOutputBufferSize();
     socket.setSoLinger(false, 0);


### PR DESCRIPTION
Making provision to allow applications,running on Java 11, use
the JDBC jar, which is compiled on Java 8.


## Changes proposed in this pull request

* The code changes majorly include bypassing the use of classes/packages
  that are not available(or moved) in JDK 11. Has Sumedh's patch(attached in Jira ticket).
* Also changed a warning from printing whole stacktrace to just message. Warning is
  triggered when using the JDBC jar with Java 11 apps.

## Patch testing

Manual. Ran Precheckin with store. Performance testing is underway.

## Is precheckin with -Pstore clean?
There were no relevant failures. The failures are tracked separately.

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
