### PR TITLE
Couple of additions to ldap-test-server

### DIFF
--- a/ldap-test-server/auth.ldif
+++ b/ldap-test-server/auth.ldif
@@ -1,5 +1,65 @@
 # entries for basic LDAP authentication first
 
+dn: uid=snappydatauser1,ou=ldapTesting,dc=pune,dc=gemstone,dc=com
+objectClass: person
+objectClass: inetOrgPerson
+uid: snappydatauser1
+sn: SNAPPYDATAUSER1
+givenName: SnappyDataUser1
+cn: SNAPPYDATAUSER1
+displayName: SNAPPYDATAUSER1
+userPassword:: e1NTSEF9M2J4NkhTcHJ4VlBhTjRPdzZlbURoYi81R3h5SUZzOEtEQWgxS1E9PQ==
+
+dn: uid=snappydatauser2,ou=ldapTesting,dc=pune,dc=gemstone,dc=com
+objectClass: person
+objectClass: inetOrgPerson
+uid: snappydatauser2
+sn: SNAPPYDATAUSER2
+givenName: SnappyDataUser2
+cn: SNAPPYDATAUSER2
+displayName: SNAPPYDATAUSER2
+userPassword:: e1NTSEF9K000cTJnNGNVTStmcllxWlJVb3o5RDdXYXZsSWRUVm1HM3JXY3c9PQ==
+
+dn: uid=snappydatauser3,ou=ldapTesting,dc=pune,dc=gemstone,dc=com
+objectClass: person
+objectClass: inetOrgPerson
+uid: snappydatauser3
+sn: SNAPPYDATAUSER3
+givenName: SnappyDataUser3
+cn: SNAPPYDATAUSER3
+displayName: SNAPPYDATAUSER3
+userPassword:: e1NTSEF9V0htMnZQelFOUk1PalNGNTdoTThnb01NMHdNVXRZZzJYUlU3bGc9PQ==
+
+dn: uid=snappydatauser4,ou=ldapTesting,dc=pune,dc=gemstone,dc=com
+objectClass: person
+objectClass: inetOrgPerson
+uid: snappydatauser4
+sn: SNAPPYDATAUSER4
+givenName: SnappyDataUser4
+cn: SNAPPYDATAUSER4
+displayName: SNAPPYDATAUSER4
+userPassword:: e1NTSEF9WjRXUlNWMmdSSzVzQ3JFS3lRbnFVaXRMcjRSeHpadDdqbTBLOUE9PQ==
+
+dn: uid=snappydatauser5,ou=ldapTesting,dc=pune,dc=gemstone,dc=com
+objectClass: person
+objectClass: inetOrgPerson
+uid: snappydatauser5
+sn: SNAPPYDATAUSER5
+givenName: SnappyDataUser5
+cn: SNAPPYDATAUSER5
+displayName: SNAPPYDATAUSER5
+userPassword:: e1NTSEF9QWNGcjVibDl5MTdJN2NEdWVXbVAxYWdvVHliVzVGNS9yRTZzQ0E9PQ==
+
+dn: uid=snappyodbc,ou=ldapTesting,dc=pune,dc=gemstone,dc=com
+objectClass: person
+objectClass: inetOrgPerson
+uid: snappyodbc
+sn: SNAPPYODBC
+givenName: SnappyODBC
+cn: SNAPPYODBC
+displayName: SNAPPYODBC
+userPassword:: e1NTSEF9bzJyOUZ0R1ZWQ2NIbElMQWR1Q0J5ZGk4Rk5BWVRZSzFNV0JYenc9PQ==
+
 dn: uid=gemfire1,ou=ldapTesting,dc=pune,dc=gemstone,dc=com
 objectClass: person
 objectClass: inetOrgPerson

--- a/ldap-test-server/src/main/java/io/snappydata/ldap/LdapTestServer.java
+++ b/ldap-test-server/src/main/java/io/snappydata/ldap/LdapTestServer.java
@@ -117,13 +117,25 @@ public class LdapTestServer {
   }
 
   public static void main(String[] args) throws Exception {
-    if (args.length != 1) {
-      System.err.println("Require LDIF file. Usage: LdapTestServer <ldif-path>");
+    final String portOption = "--port=";
+    if (args.length < 1 || args.length > 2) {
+      System.err.println("Require LDIF file. Usage: LdapTestServer [" + portOption
+          + "<port>] <ldif-path>");
       System.exit(1);
     }
-    LdapTestServer server = LdapTestServer.getInstance(args[0]);
+
+    final String ldifFile;
+    final int port;
+    if (args.length == 2 && args[0].startsWith(portOption)) {
+      port = Integer.parseInt(args[0].substring(portOption.length()));
+      ldifFile = args[1];
+    } else {
+      port = new java.util.Random().nextInt(30000) + 10000;
+      ldifFile = args[0];
+    }
+
+    LdapTestServer server = LdapTestServer.getInstance(ldifFile);
     if (!server.isServerStarted()) {
-      int port = new java.util.Random().nextInt(30000) + 10000;
       server.startServer("0.0.0.0", port);
     }
     InetAddress myHost = InetAddress.getLocalHost();

--- a/ldap-test-server/util/GenerateSHA1PasswordEntry.java
+++ b/ldap-test-server/util/GenerateSHA1PasswordEntry.java
@@ -28,7 +28,7 @@ public class GenerateSHA1PasswordEntry {
     md.update(salt);
     byte[] hashedBytes = md.digest();
 
-    // add hash bytes at the end
+    // add has bytes followed by salt at the end
     byte[] hashAndSalt = new byte[hashedBytes.length + salt.length];
     System.arraycopy(hashedBytes, 0, hashAndSalt, 0, hashedBytes.length);
     System.arraycopy(salt, 0, hashAndSalt, hashedBytes.length, salt.length);

--- a/ldap-test-server/util/GenerateSHA1PasswordEntry.java
+++ b/ldap-test-server/util/GenerateSHA1PasswordEntry.java
@@ -28,7 +28,9 @@ public class GenerateSHA1PasswordEntry {
     md.update(salt);
     byte[] hashedBytes = md.digest();
 
-    // add has bytes followed by salt at the end
+    // Add hash bytes followed by salt at the end.
+    // Hash value itself includes the salt (as expected) plus the encoded value has
+    // the salt separately at the end so that decoder can first extract the salt.
     byte[] hashAndSalt = new byte[hashedBytes.length + salt.length];
     System.arraycopy(hashedBytes, 0, hashAndSalt, 0, hashedBytes.length);
     System.arraycopy(salt, 0, hashAndSalt, hashedBytes.length, salt.length);

--- a/ldap-test-server/util/GenerateSHA1PasswordEntry.java
+++ b/ldap-test-server/util/GenerateSHA1PasswordEntry.java
@@ -1,0 +1,126 @@
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import sun.misc.BASE64Decoder;
+import sun.misc.BASE64Encoder;
+
+public class GenerateSHA1PasswordEntry {
+
+  private static final String ALGORITHM = "SHA";
+  private static final String ENCALGORITHM = "{SSHA}";
+  private static final int SHA1LENGTH = 20;
+
+  private static String encode(String password,
+      boolean twice) throws Exception {
+    // use a random 8 byte salt
+    byte[] salt = new byte[8];
+    SecureRandom rnd = new SecureRandom();
+    rnd.nextBytes(salt);
+
+    return encode(password, salt, twice);
+  }
+
+  private static String encode(String password, byte[] salt,
+      boolean twice) throws Exception {
+    // Calculate hash value
+    MessageDigest md = MessageDigest.getInstance(ALGORITHM);
+    md.update(password.getBytes());
+    md.update(salt);
+    byte[] hashedBytes = md.digest();
+
+    // add hash bytes at the end
+    byte[] hashAndSalt = new byte[hashedBytes.length + salt.length];
+    System.arraycopy(hashedBytes, 0, hashAndSalt, 0, hashedBytes.length);
+    System.arraycopy(salt, 0, hashAndSalt, hashedBytes.length, salt.length);
+
+    // Print out value in Base64 encoding
+    BASE64Encoder base64encoder = new BASE64Encoder();
+    String encodedPassword = ENCALGORITHM + base64encoder.encode(hashAndSalt);
+    if (twice) {
+      encodedPassword = base64encoder.encode(encodedPassword.getBytes("UTF-8"));
+    }
+    return encodedPassword;
+  }
+
+  private static void check(String password,
+      String encodedPassword) throws Exception {
+    BASE64Decoder base64decoder = new BASE64Decoder();
+    if (encodedPassword.charAt(0) != '{') {
+      // assume double encoded
+      encodedPassword = new String(
+          base64decoder.decodeBuffer(encodedPassword), "UTF-8");
+    }
+    if (!encodedPassword.startsWith(ENCALGORITHM)) {
+      System.out.println("Only supports salted SHA1 but got: " + encodedPassword);
+      System.exit(1);
+    }
+
+    byte[] encodedBytes = base64decoder.decodeBuffer(
+        encodedPassword.substring(ENCALGORITHM.length()));
+    byte[] salt = Arrays.copyOfRange(encodedBytes, SHA1LENGTH, encodedBytes.length);
+
+    String expected = encode(password, salt, false);
+    if (encodedPassword.equals(expected)) {
+      System.out.println("Success");
+    } else {
+      System.out.println("FAILED comparison.\nProvided: " + encodedPassword
+          + "\nExpected: " + expected);
+      System.exit(1);
+    }
+  }
+
+  private static void showHelp() {
+    System.out.println("java -cp ... GenerateSHA1PasswordEntry [arguments]");
+    System.out.println("Generate SHA1 hash entry (with random salt) for userPassword");
+    System.out.println("attribute in LDIF (Apache Directory Server compliant).");
+    System.out.println("Arguments are optional as below:");
+    System.out.println();
+    System.out.println("-2\t\t\tBase64 encode the result twice.");
+    System.out.println("[-c|--check] <enc>\tCheck password against the given value.");
+    System.out.println("\t\t\tThe provided value must be SHA1 encoded with salt.");
+    System.out.println("[-h|--help]\t\tThis message.");
+  }
+
+  public static void main(String[] args) throws Exception {
+    boolean doCheck = false;
+    boolean twice = false;
+
+    if (args.length >= 2) {
+      if (args.length == 2
+          && (args[0].equals("-c") || args[0].equals("--check"))) {
+        doCheck = true;
+      } else {
+        showHelp();
+        System.exit(1);
+      }
+    }
+    if (args.length == 1) {
+      if (args[0].equals("-h") || args[0].equals("--help")) {
+        showHelp();
+        System.exit(0);
+      } else if (args[0].equals("-2")) {
+        twice = true;
+      } else {
+        showHelp();
+        System.exit(1);
+      }
+    }
+
+    java.io.Console console = System.console();
+    char[] password1 = console.readPassword("Password: ");
+    char[] password2 = console.readPassword("Retype Password: ");
+
+    if (!Arrays.equals(password1, password2)) {
+      System.err.println("Passwords do not match!");
+      System.exit(1);
+    }
+
+    String password = new String(password1);
+
+    if (doCheck) {
+      check(password, args[1]);
+    } else {
+      System.out.println(encode(password, twice));
+    }
+  }
+}

--- a/ldap-test-server/util/README.txt
+++ b/ldap-test-server/util/README.txt
@@ -1,0 +1,10 @@
+A simple utility to generate encrypted password entries appropriate for userPassword attribute in LDIF files for Apache Directory Server.
+
+This is not supposed to be terribly secure since SHA1 is no longer secure but using a more secure algorithm requires moving to Apache DS 2.x while this test server still is based on 1.x release.
+
+To run compile GenerateSHA1PasswordEntry.java with javac and run: java -cp . GenerateSHA1PasswordEntry
+Enter the password twice and the output can be put in ldif file like:
+
+userPassword:: ...
+
+See the available options by passing "-h" or "--help" argument.


### PR DESCRIPTION
- Added password entry generator utility to ldap-test-server
- Added optional --port argument to force a port instead of random everytime. This is to avoid having to update the SD confs whenever the LDAP server is restarted.
- Also updated auth.ldif with entries used by ODBC tests