### PR TITLE
 [SNAP-3332] pass back scale/precision array in PreparedStatement execution 

### DIFF
--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/execution/SQLLeadNodeExecutionObject.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/execution/SQLLeadNodeExecutionObject.java
@@ -140,7 +140,6 @@ public class SQLLeadNodeExecutionObject extends LeadNodeExecutionObject {
       final int numPartialCols = BitSetSet.umod8(paramCount);
       try {
         // Write Types
-        // TODO: See SparkSQLPreapreImpl
         if (this.pvsTypes == null) {
           this.pvsTypes = new int[paramCount * 3 + 1];
           this.pvsTypes[0] = paramCount;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/execution/SQLLeadNodeExecutionObject.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/execution/SQLLeadNodeExecutionObject.java
@@ -8,13 +8,10 @@ import java.util.Arrays;
 
 import com.gemstone.gemfire.DataSerializer;
 import com.gemstone.gemfire.internal.ByteArrayDataInput;
-import com.gemstone.gemfire.internal.DataSerializableFixedID;
 import com.gemstone.gemfire.internal.HeapDataOutputStream;
 import com.gemstone.gemfire.internal.InternalDataSerializer;
 import com.gemstone.gemfire.internal.shared.Version;
-import com.pivotal.gemfirexd.internal.engine.GfxdSerializable;
 import com.pivotal.gemfirexd.internal.engine.distributed.DVDIOUtil;
-import com.pivotal.gemfirexd.internal.engine.distributed.GfxdResultCollector;
 import com.pivotal.gemfirexd.internal.engine.distributed.SnappyResultHolder;
 import com.pivotal.gemfirexd.internal.engine.distributed.message.BitSetSet;
 import com.pivotal.gemfirexd.internal.engine.jdbc.GemFireXDRuntimeException;
@@ -28,7 +25,7 @@ import com.pivotal.gemfirexd.internal.snappy.CallbackFactoryProvider;
 import com.pivotal.gemfirexd.internal.snappy.LeadNodeExecutionContext;
 import com.pivotal.gemfirexd.internal.snappy.SparkSQLExecute;
 
-public class SQLLeadNodeExecutionObject  extends LeadNodeExecutionObject {
+public class SQLLeadNodeExecutionObject extends LeadNodeExecutionObject {
   private String sql;
   private String schema;
   // transient members set during deserialization and used in execute
@@ -42,11 +39,19 @@ public class SQLLeadNodeExecutionObject  extends LeadNodeExecutionObject {
   private static final byte IS_UPDATE_OR_DELETE_OR_PUT = 0x4;
 
   public SQLLeadNodeExecutionObject(String sql, String schema,
-    ParameterValueSet inpvs, boolean isPreparedStatement,
+      ParameterValueSet inpvs, boolean isPreparedStatement,
+      boolean isPreparedPhase, Boolean isUpdateOrDeleteOrPut) {
+    this(sql, schema, inpvs, null, isPreparedStatement,
+        isPreparedPhase, isUpdateOrDeleteOrPut);
+  }
+
+  public SQLLeadNodeExecutionObject(String sql, String schema,
+    ParameterValueSet inpvs, int[] pvsTypes, boolean isPreparedStatement,
     boolean isPreparedPhase, Boolean isUpdateOrDeleteOrPut) {
     this.schema = schema;
     this.sql = sql;
     this.pvs = inpvs;
+    this.pvsTypes = pvsTypes;
     if (isPreparedStatement) leadNodeFlags |= IS_PREPARED_STATEMENT;
     if (isPreparedPhase) leadNodeFlags |= IS_PREPARED_PHASE;
     if (isUpdateOrDeleteOrPut) leadNodeFlags |= IS_UPDATE_OR_DELETE_OR_PUT;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/execution/SQLLeadNodeExecutionObject.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/distributed/execution/SQLLeadNodeExecutionObject.java
@@ -62,8 +62,8 @@ public class SQLLeadNodeExecutionObject  extends LeadNodeExecutionObject {
     if (isPreparedStatement() && !isPreparedPhase())  {
       getParams();
     }
-    return CallbackFactoryProvider.getClusterCallbacks().getSQLExecute(dfObject,
-      sql, schema, ctx, v, this.isPreparedStatement(), this.isPreparedPhase(), this.pvs);
+    return CallbackFactoryProvider.getClusterCallbacks().getSQLExecute(dfObject, sql, schema,
+        ctx, v, this.isPreparedStatement(), this.isPreparedPhase(), this.pvs, this.pvsTypes);
   }
 
   public boolean isPreparedStatement() {

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/SnappyActivation.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/SnappyActivation.java
@@ -62,6 +62,7 @@ public class SnappyActivation extends BaseActivation {
   private final boolean isPrepStmt;
   private final boolean isUpdateOrDeleteOrPut;
   private LeadNodeExecutorMsg executorMsg;
+  private int[] pvsTypes;
 
   public SnappyActivation(LanguageConnectionContext lcc, ExecPreparedStatement eps, 
       boolean returnRows,  boolean isPrepStmt, boolean isUpdateOrDeleteOrPut) {
@@ -111,6 +112,7 @@ public class SnappyActivation extends BaseActivation {
         }
         gps.setResultDescription(preparedResult.makeResultDescription(statementType));
       }
+      this.pvsTypes = typeNames;
     }  catch (IOException ioex) {
       throw StandardException.newException(ioex.getMessage(), ioex);
     }
@@ -159,7 +161,7 @@ public class SnappyActivation extends BaseActivation {
       rs.open();
       this.resultSet = rs;
       SQLLeadNodeExecutionObject execObj = new SQLLeadNodeExecutionObject(sql, this.lcc
-        .getCurrentSchemaName(), pvs, this.isPrepStmt,false, isUpdateOrDeleteOrPut);
+        .getCurrentSchemaName(), pvs, pvsTypes, this.isPrepStmt,false, isUpdateOrDeleteOrPut);
       executeWithResultSet(rs, execObj);
       if (GemFireXDUtils.TraceQuery) {
         SanityManager.DEBUG_PRINT(GfxdConstants.TRACE_QUERYDISTRIB,

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/SnappyActivation.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/SnappyActivation.java
@@ -92,9 +92,9 @@ public class SnappyActivation extends BaseActivation {
       int numberOfParameters = typeNames[0];
       DataTypeDescriptor[] types = new DataTypeDescriptor[numberOfParameters];
       for (int i = 0; i < numberOfParameters; i++) {
-        int index = i * 4 + 1;
+        int index = i * 3 + 1;
         SnappyResultHolder.getNewNullDVD(typeNames[index], i, types,
-            typeNames[index + 1], typeNames[index + 2], typeNames[index + 2] == 1);
+            typeNames[index + 1], typeNames[index + 2], true);
       }
 
       pvs = lcc.getLanguageFactory().newParameterValueSet(

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/CallbackFactoryProvider.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/CallbackFactoryProvider.java
@@ -56,7 +56,7 @@ public abstract class CallbackFactoryProvider {
     @Override
     public SparkSQLExecute getSQLExecute(Object dfObj, String sql, String schema,
         LeadNodeExecutionContext ctx, Version v, boolean isPreparedStatement,
-        boolean isPreparedPhase, ParameterValueSet pvs) {
+        boolean isPreparedPhase, ParameterValueSet pvs, int[] pvsTypes) {
        return null;
     }
 

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/ClusterCallbacks.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/snappy/ClusterCallbacks.java
@@ -41,8 +41,9 @@ public interface ClusterCallbacks {
 
   void stopExecutor();
 
-  SparkSQLExecute getSQLExecute(Object dfObject, String sql, String schema, LeadNodeExecutionContext ctx,
-      Version v, boolean isPreparedStatement, boolean isPreparedPhase, ParameterValueSet pvs);
+  SparkSQLExecute getSQLExecute(Object dfObject, String sql, String schema,
+      LeadNodeExecutionContext ctx, Version v, boolean isPreparedStatement,
+      boolean isPreparedPhase, ParameterValueSet pvs, int[] pvsTypes);
 
   InterpreterExecute getInterpreterExecution(String sql, Version v, Long connId);
 


### PR DESCRIPTION
## Changes proposed in this pull request

The prepare phase of PreparedStatement returns the scale/precision of parameters for routed
queries. This should be passed back during execution so that the current set of parameters
are set on the SnappySession rather than those set by the last prepare (which can be different)

Also made the PVS info array size uniform to be three ints per type removing the unused
(and incorrect) fourth field which is supposed to have nullability information.

## Patch testing

precheckin -Pstore

## Is precheckin with -Pstore clean?

yes

## Other PRs 

See snappydata PR for SNAP-3332