### PR TITLE
Fix for some putInto/update test failures

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/cache/TransactionFlag.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/cache/TransactionFlag.java
@@ -24,6 +24,9 @@ import java.util.EnumSet;
  * Flags that can be combined and passed as an {@link EnumSet} to
  * {@link CacheTransactionManager} to define additional properties for the
  * transaction.
+ *
+ * Properties marked as [Transient] will be sent across messages and set on the
+ * remote node transaction.
  * 
  * @author swale
  * @since 7.0
@@ -55,5 +58,24 @@ public enum TransactionFlag {
    * not see committed data for sometime (the thread that initializes the commit
    * will always see committed data)
    */
-  SYNC_COMMITS
+  SYNC_COMMITS,
+
+  /**
+   * [Transient] disable column table delta rollover for the current operation
+   */
+  DISABLE_DELTA_ROLLOVER {
+    @Override
+    public int bitmask() {
+      return 0x1;
+    }
+  },
+
+  ;
+
+  /**
+   * The bitmask to use for transient transaction flags.
+   */
+  public int bitmask() {
+    return 0x0;
+  }
 }

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/BucketRegion.java
@@ -84,6 +84,7 @@ import com.gemstone.gemfire.internal.cache.wan.parallel.ConcurrentParallelGatewa
 import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
 import com.gemstone.gemfire.internal.offheap.StoredObject;
 import com.gemstone.gemfire.internal.offheap.annotations.Unretained;
+import com.gemstone.gemfire.internal.shared.SystemProperties;
 import com.gemstone.gemfire.internal.shared.Version;
 import com.gemstone.gemfire.internal.snappy.CallbackFactoryProvider;
 import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
@@ -101,6 +102,10 @@ import com.gemstone.gemfire.internal.snappy.StoreCallbacks;
  *
  */
 public class BucketRegion extends DistributedRegion implements Bucket {
+
+  public static final boolean ALLOW_COLUMN_STORE_UUID_OVERWRITE_ON_OVERFLOW =
+      SystemProperties.getServerInstance().getBoolean(
+          "columnstore.allow-uuid-overwrite-on-overflow", false);
 
   /**
    * A special value for the bucket size indicating that this bucket
@@ -812,7 +817,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
         txStarted = true;
       }
       try {
-        long batchId =  partitionedRegion.newUUID(false);
+        long batchId =  partitionedRegion.newUUID(!ALLOW_COLUMN_STORE_UUID_OVERWRITE_ON_OVERFLOW);
         if (getCache().getLoggerI18n().fineEnabled()) {
           getCache().getLoggerI18n().info(LocalizedStrings.DEBUG, "createAndInsertCachedBatch: " +
               "The snapshot after creating cached batch is " + getTXState().getLocalTXState().getCurrentSnapshot() +

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXManagerImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXManagerImpl.java
@@ -446,6 +446,8 @@ public final class TXManagerImpl implements CacheTransactionManager,
       .of(TransactionFlag.DISABLE_BATCHING);
   public static final EnumSet<TransactionFlag> SYNC_COMMITS = EnumSet
       .of(TransactionFlag.SYNC_COMMITS);
+  public static final EnumSet<TransactionFlag> DISABLE_DELTA_ROLLOVER = EnumSet
+      .of(TransactionFlag.DISABLE_DELTA_ROLLOVER);
 
   /**
    * A flag to allow persistent transactions. public for testing.
@@ -1630,6 +1632,7 @@ public final class TXManagerImpl implements CacheTransactionManager,
       proxy = this.hostedTXStates.get(txId, txStateCreator);
     }
     if (proxy != null) {
+      proxy.setTransientTransactionFlags(msg.getTransientTXFlags());
       msg.startTXProxyRead();
       if (!useTXProxy) {
         // for write operations create a new local TXState if not present

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateProxy.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/TXStateProxy.java
@@ -587,7 +587,9 @@ public class TXStateProxy extends NonReentrantReadWriteLock implements
       else {
         this.enableBatching = (this.lockPolicy != LockingPolicy.SNAPSHOT) && ENABLE_BATCHING;
       }
-      this.syncCommits = (this.lockPolicy == LockingPolicy.SNAPSHOT) || flags.contains(TransactionFlag.SYNC_COMMITS);
+      this.syncCommits = (this.lockPolicy == LockingPolicy.SNAPSHOT) ||
+          flags.contains(TransactionFlag.SYNC_COMMITS);
+      setTransientTransactionFlags(flags);
     }
     this.inconsistentThr = null;
 
@@ -640,6 +642,12 @@ public class TXStateProxy extends NonReentrantReadWriteLock implements
 
   public static final TXStateProxyFactory getFactory() {
     return factory;
+  }
+
+  public void setTransientTransactionFlags(EnumSet<TransactionFlag> flags) {
+    if (flags != null) {
+      this.columnRolloverDisabled = flags.contains(TransactionFlag.DISABLE_DELTA_ROLLOVER);
+    }
   }
 
   private long getViewId(DM dm) {

--- a/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
+++ b/gemfire-shared/src/main/java/com/gemstone/gemfire/internal/shared/unsafe/UnsafeHolder.java
@@ -174,8 +174,8 @@ public abstract class UnsafeHolder {
     try {
       Wrapper.init();
       v = true;
-    } catch (LinkageError le) {
-      System.out.println(le.getMessage());
+    } catch (Throwable t) {
+      System.out.println(t.getMessage());
       v = false;
     }
     hasUnsafe = v;

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/SnappyUpdateDeletePutResultSet.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/sql/execute/SnappyUpdateDeletePutResultSet.java
@@ -48,7 +48,7 @@ public final class SnappyUpdateDeletePutResultSet extends SnappySelectResultSet 
         throw GemFireXDRuntimeException.newRuntimeException("Update or Delete or Put on Snappy", ex);
       }
     }
-    Misc.getCacheLogWriter().info("SnappyUpdateDeleteResultSet:::modifiedRowCount" + rowCount);
+    Misc.getCacheLogWriter().fine("SnappyUpdateDeleteResultSet::modifiedRowCount = " + rowCount);
     return rowCount;
   }
 }

--- a/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
+++ b/gemfirexd/core/src/main/java/com/pivotal/gemfirexd/internal/engine/store/GemFireContainer.java
@@ -1370,6 +1370,7 @@ public final class GemFireContainer extends AbstractGfxdLockable implements
     if (isByteArrayStore()) {
       this.tableInfo.initRowFormatter(this);
     }
+    invalidateHiveMetaData();
   }
 
   /**

--- a/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/ExpirationDUnit.java
+++ b/gemfirexd/tools/src/dunit/java/com/pivotal/gemfirexd/ddl/ExpirationDUnit.java
@@ -356,18 +356,28 @@ public class ExpirationDUnit extends DistributedSQLTestBase {
     expected.add(2);
 
     // some slow systems may already have exceeded the time in restart
+    boolean canBeEmpty = false;
     long elapsed = System.currentTimeMillis() - start;
     if (elapsed < 2000) {
       Thread.sleep(2000 - elapsed);
     } else if (elapsed > 3000) {
       expected = null;
+    } else if (elapsed > 2000) {
+      canBeEmpty = true;
     }
 
-    validateResults("EMP.TESTTABLE_ONE", expected);
+    validateResults("EMP.TESTTABLE_ONE", expected, canBeEmpty);
+    canBeEmpty = false;
+    elapsed = System.currentTimeMillis() - start;
+    if (elapsed >= 3000) {
+      expected = null;
+    } else if (elapsed > 2000) {
+      canBeEmpty = true;
+    }
     if (expected != null) {
       expected.add(3);
     }
-    validateResults("EMP.TESTTABLE_TWO", expected);
+    validateResults("EMP.TESTTABLE_TWO", expected, canBeEmpty);
     Thread.sleep(1500);
     validateResults("EMP.TESTTABLE_ONE", null);
     validateResults("EMP.TESTTABLE_TWO", null);


### PR DESCRIPTION
## Changes proposed in this pull request

- pass through columnRolloverDisabled using TransactionFlag
  - added generic handling for passing transient TransactionFlags as part of base
    AbstractOperationMessage; this fixes issues where remote iterators fail to set the flag
- added global property to disable throwing exception when column batch UUID overflows
-  removing unnecessary log on every update/delete/insert 
-  minor adjustment for occasional failures in ExpirationDUnit under load 

## Patch testing

precheckin -Pstore

## Is precheckin with -Pstore clean?

Yes

## ReleaseNotes changes

NA

## Other PRs 

https://github.com/TIBCOSoftware/snappydata/pull/1563